### PR TITLE
Add github action to publish the wiki

### DIFF
--- a/.github/workflows/publish_wiki.yml
+++ b/.github/workflows/publish_wiki.yml
@@ -1,0 +1,21 @@
+name: Publish the wiki
+
+
+on:
+  push:
+    branches: [ master ]
+
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Upload Documentation to Wiki
+        uses: SwiftDocOrg/github-wiki-publish-action@v1
+        with:
+          path: "wiki"
+        env:
+          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+


### PR DESCRIPTION
#16

This automates the deployment of the wiki pages with github actions. (only on master branch change).
To complete, please also do step 3 and 4 of this document: https://github.com/marketplace/actions/publish-to-github-wiki (create personal access token and insert it into the project secrets).
