### PR TITLE
Rewrite images path to absolute in wiki repo

### DIFF
--- a/.github/deploy_wiki.sh
+++ b/.github/deploy_wiki.sh
@@ -63,6 +63,12 @@ if [ ! -r "$tmp_dir/Home.md" ]; then
     rsync -q -a "$GITHUB_WORKSPACE/README.md" "$tmp_dir/Home.md"
 fi
 
+debug "Rewriting images path to absolute"
+(
+    cd "$tmp_dir" || exit 1
+    find . -type f -exec sed -Ei 's@([ (])([^( ]+)(\/wiki_static\/.+?\.(png|jpe?g|svg)[ \)])@\1https://github.com/Flipper-Zero/flipperzero-firmware-community/raw/master\3@' {} \;
+)
+
 debug "Committing and pushing changes"
 (
     cd "$tmp_dir" || exit 1

--- a/.github/workflows/publish_wiki.yml
+++ b/.github/workflows/publish_wiki.yml
@@ -4,6 +4,8 @@ name: Publish the wiki
 on:
   push:
     branches: [ master ]
+    paths:
+    - "wiki"
 
 
 jobs:


### PR DESCRIPTION
I'm using IDE for wiki page editing and I want to see images inline while editing, so I need relative paths for images. But relative paths break images in the wiki. 

This simple regex rewrites images paths to absolute only for wiki repo. This means paths in sources are always relative and work everywhere. 

Also, I think we should run wiki deploy only when files in `/wiki` are changed, so maybe this condition is better:

```
on:
  push:
    branches: [ master ]
    paths:
    - "wiki"
```