### PR TITLE
Added openocd freertos debug support

### DIFF
--- a/firmware/targets/f2/Src/freertos-openocd.c
+++ b/firmware/targets/f2/Src/freertos-openocd.c
@@ -1,0 +1,21 @@
+
+/*
+ * Since at least FreeRTOS V7.5.3 uxTopUsedPriority is no longer
+ * present in the kernel, so it has to be supplied by other means for
+ * OpenOCD's threads awareness.
+ *
+ * Add this file to your project, and, if you're using --gc-sections,
+ * ``--undefined=uxTopUsedPriority'' (or
+ * ``-Wl,--undefined=uxTopUsedPriority'' when using gcc for final
+ * linking) to your LDFLAGS; same with all the other symbols you need.
+ */
+
+#include "FreeRTOS.h"
+
+#ifdef __GNUC__
+#define USED __attribute__((used))
+#else
+#define USED
+#endif
+
+const int USED uxTopUsedPriority = configMAX_PRIORITIES - 1;

--- a/make/toolchain.mk
+++ b/make/toolchain.mk
@@ -23,4 +23,4 @@ endif
 
 CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)"
 CPPFLAGS = -fno-threadsafe-statics
-LDFLAGS	+= -Wl,-Map=$(OBJ_DIR)/$(PROJECT).map,--cref -Wl,--gc-sections
+LDFLAGS	+= -Wl,-Map=$(OBJ_DIR)/$(PROJECT).map,--cref -Wl,--gc-sections -Wl,--undefined=uxTopUsedPriority


### PR DESCRIPTION
Openocd needs a visible uxTopUsedPriority symbol for freertos, but freertos is discarding it in v7, so I add the helper file manually.