### PR TITLE
FL-427 Bootloader: delay before boot key sampling.

### DIFF
--- a/bootloader/targets/f4/target.c
+++ b/bootloader/targets/f4/target.c
@@ -93,7 +93,7 @@ int target_is_dfu_requested() {
         LL_RTC_BAK_SetRegister(RTC, LL_RTC_BKP_DR0, BOOT_REQUEST_NONE);
         return 1;
     }
-
+    LL_mDelay(100);
     if(!LL_GPIO_IsInputPinSet(BOOT_DFU_PORT, BOOT_DFU_PIN)) {
         return 1;
     }


### PR DESCRIPTION
https://flipperzero.atlassian.net/browse/FL-427