### PR TITLE
FL-524 Fix subghz freq

### DIFF
--- a/applications/cc1101-workaround/cc1101-workaround.cpp
+++ b/applications/cc1101-workaround/cc1101-workaround.cpp
@@ -196,7 +196,7 @@ void tx_config(CC1101* cc1101) {
     cc1101->SpiWriteReg(CC1101_FSCAL2, 0x2A); //Frequency Synthesizer Calibration
     cc1101->SpiWriteReg(CC1101_FSCAL1, 0x00); //Frequency Synthesizer Calibration
     cc1101->SpiWriteReg(CC1101_FSCAL0, 0x1F); //Frequency Synthesizer Calibration
-    
+
     /*
     cc1101->SpiWriteReg(CC1101_TEST2, 0x81); //Various Test Settings
     cc1101->SpiWriteReg(CC1101_TEST1, 0x35); //Various Test Settings


### PR DESCRIPTION
* Fixes bug with no signal at 300, 387, 779 MHz
* Fix freq selector direction
* Add fine freq tuning

# How to check

* Select all primary freq by press UP and DOWN, for every freq check that no signal at this freq and OOK-modulated signal appear when pressing OK (use SDR receiver)
* For every primary freq transmit signal from another Flipper or signal generator and check that RSSI increases
* For any freq perform fine tuning by press LEFT and RIGHT and check that freq is changing by SDR and signal from another flipper received (RSSI increase)

We have issue with antenna mismatch for upper freq and signal not transmit properly. For RSSI test connect antennas directly by wire or hand.

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
