### PR TITLE
FIX: coordinate switch to deep sleep and clock configuration with core2

### DIFF
--- a/firmware/targets/api-hal-include/api-hal-power.h
+++ b/firmware/targets/api-hal-include/api-hal-power.h
@@ -16,6 +16,9 @@ typedef enum {
 /* Initialize drivers */
 void api_hal_power_init();
 
+/* Go to deep sleep */
+void api_hal_power_deep_sleep();
+
 /* Get predicted remaining battery capacity in percents */
 uint8_t api_hal_power_get_pct();
 

--- a/firmware/targets/f4/api-hal/api-hal-clock.c
+++ b/firmware/targets/f4/api-hal/api-hal-clock.c
@@ -1,0 +1,27 @@
+#include <api-hal-clock.h>
+
+#include <stm32wbxx_ll_rcc.h>
+
+void api_hal_clock_switch_to_hsi() {
+    LL_RCC_HSI_Enable( );
+
+    while(!LL_RCC_HSI_IsReady());
+
+    LL_RCC_SetSysClkSource(LL_RCC_SYS_CLKSOURCE_HSI);
+    LL_RCC_SetSMPSClockSource(LL_RCC_SMPS_CLKSOURCE_HSI);
+
+    while (LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_HSI);
+}
+
+void api_hal_clock_switch_to_pll() {
+    LL_RCC_HSE_Enable();
+    LL_RCC_PLL_Enable();
+
+    while(!LL_RCC_HSE_IsReady());
+    while(!LL_RCC_PLL_IsReady());
+
+    LL_RCC_SetSysClkSource(LL_RCC_SYS_CLKSOURCE_PLL);
+    LL_RCC_SetSMPSClockSource(LL_RCC_SMPS_CLKSOURCE_HSE);
+
+    while (LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_PLL);
+}

--- a/firmware/targets/f4/api-hal/api-hal-clock.h
+++ b/firmware/targets/f4/api-hal/api-hal-clock.h
@@ -1,0 +1,7 @@
+#pragma once
+
+/* Switch to HSI clock */
+void api_hal_clock_switch_to_hsi();
+
+/* Switch to PLL clock */
+void api_hal_clock_switch_to_pll();


### PR DESCRIPTION
# What's new

- HAL API Clock: switch between HSI and HSE+PLL
- HAL Power: deep sleep coordinated with core2
- HAL Timebase: use our own deep sleep, coordinated with core2

# Verification

- Compile and upload
- Check any application that uses timers on sysclock bus: rfid, irda, etc...

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
