### PR TITLE
FL-633: sleep mode for CC1101 at subghz app exit

### DIFF
--- a/applications/cc1101-workaround/cc1101-workaround.cpp
+++ b/applications/cc1101-workaround/cc1101-workaround.cpp
@@ -429,6 +429,12 @@ extern "C" void cc1101_workaround(void* p) {
             if(event.type == EventTypeKey) {
                 if(event.value.input.state && event.value.input.input == InputBack) {
                     printf("[cc1101] bye!\n");
+                    cli_print("[cc1101] bye!\n");
+
+                    cc1101.SpiStrobe(CC1101_SIDLE);
+                    cc1101.SpiStrobe(CC1101_SPWD);
+                    cli_print("[cc1101] go to power down\n");
+
                     // TODO remove all widgets create by app
                     widget_enabled_set(widget, false);
                     furiac_exit(NULL);


### PR DESCRIPTION
Set CC1101 to sleep mode at Sub-GHz app exit.

# How to check:

1. Reboot device, check overall consumption by Power-Info
2. Go to Sub-GHz app and check RSSI is continuously changing
2. Exit app
3. Check overall consumption by Power-info, check consumption decrease by 1-2 mA
4. Go to Sub-GHz app again and check RSSI is continuously changing (CC1101 wake up)

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
