### PR TITLE
FL-810 fix emulating init state

### DIFF
--- a/applications/lf-rfid/lf-rfid.c
+++ b/applications/lf-rfid/lf-rfid.c
@@ -327,7 +327,8 @@ void lf_rfid_workaround(void* p) {
 
                 if(state->on) {
                     gpio_write(pull_pin_record, false);
-                    api_interrupt_add(comparator_trigger_callback, InterruptTypeComparatorTrigger, comp_ctx);
+                    api_interrupt_add(
+                        comparator_trigger_callback, InterruptTypeComparatorTrigger, comp_ctx);
                 } else {
                     api_interrupt_remove(comparator_trigger_callback);
                 }


### PR DESCRIPTION
Enabling emulating mode after application start.

# How to check:

* Open LF RFID app
* Do not touch any buttons
* Read flipper by another reader or flipper
* Switch to reading by pressing OK, read tag
* Switch to emulating by pressing OK, check emulating again

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
