### PR TITLE
GUI: view enter, exit callbacks.

### DIFF
--- a/applications/gui/view.c
+++ b/applications/gui/view.c
@@ -40,6 +40,16 @@ void view_set_next_callback(View* view, ViewNavigationCallback callback) {
     view->next_callback = callback;
 }
 
+void view_set_enter_callback(View* view, ViewCallback callback) {
+    furi_assert(view);
+    view->enter_callback = callback;
+}
+
+void view_set_exit_callback(View* view, ViewCallback callback) {
+    furi_assert(view);
+    view->exit_callback = callback;
+}
+
 void view_set_context(View* view, void* context) {
     furi_assert(view);
     furi_assert(context);
@@ -142,4 +152,14 @@ uint32_t view_next(View* view) {
     } else {
         return VIEW_IGNORE;
     }
+}
+
+void view_enter(View* view) {
+    furi_assert(view);
+    if(view->enter_callback) view->enter_callback(view->context);
+}
+
+void view_exit(View* view) {
+    furi_assert(view);
+    if(view->exit_callback) view->exit_callback(view->context);
 }

--- a/applications/gui/view.h
+++ b/applications/gui/view.h
@@ -42,6 +42,12 @@ typedef bool (*ViewInputCallback)(InputEvent* event, void* context);
  */
 typedef uint32_t (*ViewNavigationCallback)(void* context);
 
+/* View callback
+ * @param context, pointer to context
+ * @warning called from GUI thread
+ */
+typedef void (*ViewCallback)(void* context);
+
 /* View model types */
 typedef enum {
     /* Model is not allocated */
@@ -91,6 +97,18 @@ void view_set_previous_callback(View* view, ViewNavigationCallback callback);
  * @param callback, input callback
  */
 void view_set_next_callback(View* view, ViewNavigationCallback callback);
+
+/* Set Enter callback
+ * @param view, pointer to View
+ * @param callback, callback
+ */
+void view_set_enter_callback(View* view, ViewCallback callback);
+
+/* Set Exit callback
+ * @param view, pointer to View
+ * @param callback, callback
+ */
+void view_set_exit_callback(View* view, ViewCallback callback);
 
 /* Set View Draw callback
  * @param view, pointer to View

--- a/applications/gui/view_dispatcher_i.h
+++ b/applications/gui/view_dispatcher_i.h
@@ -20,5 +20,8 @@ void view_dispatcher_draw_callback(Canvas* canvas, void* context);
 /* ViewPort Input Callback */
 void view_dispatcher_input_callback(InputEvent* event, void* context);
 
+/* Set current view, dispatches view enter and exit */
+void view_dispatcher_set_current_view(ViewDispatcher* view_dispatcher, View* view);
+
 /* View to ViewDispatcher update event */
 void view_dispatcher_update(ViewDispatcher* view_dispatcher, View* view);

--- a/applications/gui/view_i.h
+++ b/applications/gui/view_i.h
@@ -16,6 +16,8 @@ struct View {
     ViewModelType model_type;
     ViewNavigationCallback previous_callback;
     ViewNavigationCallback next_callback;
+    ViewCallback enter_callback;
+    ViewCallback exit_callback;
     void* model;
     void* context;
 };
@@ -37,3 +39,9 @@ uint32_t view_previous(View* view);
 
 /* Next Callback for View dispatcher */
 uint32_t view_next(View* view);
+
+/* Enter Callback for View dispatcher */
+void view_enter(View* view);
+
+/* Exit Callback for View dispatcher */
+void view_exit(View* view);

--- a/applications/gui/view_port.h
+++ b/applications/gui/view_port.h
@@ -51,7 +51,9 @@ uint8_t view_port_get_height(ViewPort* view_port);
 
 /*
  * Enable or disable view_port rendering.
- * @param enabled.
+ * @param view_port - ViewPort instance
+ * @param enabled
+ * @warning automatically dispatches update event
  */
 void view_port_enabled_set(ViewPort* view_port, bool enabled);
 bool view_port_is_enabled(ViewPort* view_port);


### PR DESCRIPTION
# What's new

- GUI View: enter and exit callbacks. Called upon view change.

# Verification

- Add View enter/exit callbacks where you need them most: animation timers and etc.
- Keep in mind that they are dispatched from GUI thread.

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
