### PR TITLE
add force remove artifacts dir for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
     needs: build
     runs-on: [self-hosted]
     steps:
+      - name: Force remove artifacts dir
+        run: rm -rf artifacts
       - name: Create directory for artifacts
         run: mkdir artifacts
       - name: Get bootloader


### PR DESCRIPTION
Fix problem with exists artifacts directory during upload files to update server https://github.com/Flipper-Zero/flipperzero-firmware-community/runs/1888548930?check_suite_focus=true#step:3:4

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
