### PR TITLE
Rollback gui update visibility check, fixes gui thread lockup

### DIFF
--- a/applications/gui/gui.c
+++ b/applications/gui/gui.c
@@ -14,21 +14,9 @@ ViewPort* gui_view_port_find_enabled(ViewPortArray_t array) {
     return NULL;
 }
 
-void gui_update(Gui* gui, ViewPort* view_port) {
+void gui_update(Gui* gui) {
     furi_assert(gui);
-    if(view_port) {
-        // Visibility check
-        gui_lock(gui);
-        for(size_t i = 0; i < GuiLayerMAX; i++) {
-            if(gui_view_port_find_enabled(gui->layers[i]) == view_port) {
-                osThreadFlagsSet(gui->thread, GUI_THREAD_FLAG_DRAW);
-                break;
-            }
-        }
-        gui_unlock(gui);
-    } else {
-        osThreadFlagsSet(gui->thread, GUI_THREAD_FLAG_DRAW);
-    }
+    osThreadFlagsSet(gui->thread, GUI_THREAD_FLAG_DRAW);
 }
 
 void gui_input_events_callback(const void* value, void* ctx) {
@@ -206,7 +194,7 @@ void gui_add_view_port(Gui* gui, ViewPort* view_port, GuiLayer layer) {
     view_port_gui_set(view_port, gui);
     gui_unlock(gui);
 
-    gui_update(gui, NULL);
+    gui_update(gui);
 }
 
 void gui_remove_view_port(Gui* gui, ViewPort* view_port) {
@@ -297,10 +285,8 @@ Gui* gui_alloc() {
     Gui* gui = furi_alloc(sizeof(Gui));
     // Thread ID
     gui->thread = osThreadGetId();
-    gui->mutex_attr.name = "mtx_gui";
-    gui->mutex_attr.attr_bits |= osMutexRecursive;
     // Allocate mutex
-    gui->mutex = osMutexNew(&gui->mutex_attr);
+    gui->mutex = osMutexNew(NULL);
     furi_check(gui->mutex);
     // Layers
     for(size_t i = 0; i < GuiLayerMAX; i++) {

--- a/applications/gui/gui_i.h
+++ b/applications/gui/gui_i.h
@@ -34,7 +34,6 @@ ARRAY_DEF(ViewPortArray, ViewPort*, M_PTR_OPLIST);
 struct Gui {
     // Thread and lock
     osThreadId_t thread;
-    osMutexAttr_t mutex_attr;
     osMutexId_t mutex;
     // Layers and Canvas
     ViewPortArray_t layers[GuiLayerMAX];
@@ -51,12 +50,9 @@ struct Gui {
 ViewPort* gui_view_port_find_enabled(ViewPortArray_t array);
 
 /* Update GUI, request redraw
- * Real redraw event will be issued only if view_port is currently visible
- * Setting view_port to NULL forces redraw, but must be avoided
  * @param gui, Gui instance
- * @param view_port, ViewPort instance or NULL
  */
-void gui_update(Gui* gui, ViewPort* view_port);
+void gui_update(Gui* gui);
 
 void gui_input_events_callback(const void* value, void* ctx);
 

--- a/applications/gui/view_port.c
+++ b/applications/gui/view_port.c
@@ -43,7 +43,7 @@ void view_port_enabled_set(ViewPort* view_port, bool enabled) {
     furi_assert(view_port);
     if(view_port->is_enabled != enabled) {
         view_port->is_enabled = enabled;
-        if(view_port->gui) gui_update(view_port->gui, NULL);
+        if(view_port->gui) gui_update(view_port->gui);
     }
 }
 
@@ -69,7 +69,7 @@ void view_port_input_callback_set(
 
 void view_port_update(ViewPort* view_port) {
     furi_assert(view_port);
-    if(view_port->gui && view_port->is_enabled) gui_update(view_port->gui, view_port);
+    if(view_port->gui && view_port->is_enabled) gui_update(view_port->gui);
 }
 
 void view_port_gui_set(ViewPort* view_port, Gui* gui) {


### PR DESCRIPTION
# What's new

- Rollback view port visibility check in gui_update method

# Verification

- Compile and upload
- Flooper Blooper sudden lockup should be gone

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
