### PR TITLE
Fix error if dir exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
     steps:
 
       - name: Make empty dir
-        run: mkdir empty
+        run: mkdir -p empty
 
       - name: Clear upload dir
         uses: burnett01/rsync-deployments@4.1


### PR DESCRIPTION
Fix problem with exists empty dir. Example - https://github.com/Flipper-Zero/flipperzero-firmware-community/runs/1905099045?check_suite_focus=true#step:3:4

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
