### PR TITLE
[FL-942] Change reset logic in CLI commands execution

### DIFF
--- a/applications/power/power.c
+++ b/applications/power/power.c
@@ -144,21 +144,15 @@ void power_free(Power* power) {
 }
 
 void power_cli_poweroff(string_t args, void* context) {
-    printf("Poweroff in 3 seconds");
-    osDelay(3000);
     api_hal_power_off();
 }
 
 void power_cli_reset(string_t args, void* context) {
-    printf("NVIC System Reset in 3 seconds");
-    osDelay(3000);
     NVIC_SystemReset();
 }
 
 void power_cli_dfu(string_t args, void* context) {
-    printf("NVIC System Reset to DFU mode in 3 seconds");
     api_hal_boot_set_mode(ApiHalBootModeDFU);
-    osDelay(3000);
     NVIC_SystemReset();
 }
 


### PR DESCRIPTION
# What's new
Perform "reset", "poweroff" and "dfu" CLI commands immediately instead of 3s delay

# Verification

- Compile and upload to F5
- Compile and upload to F4
- Verify immediate "reset", "poweroff" and "dfu" CLI commands execution

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
