### PR TITLE
Prevent device from sleep mode while setuping display

### DIFF
--- a/applications/gui/canvas.c
+++ b/applications/gui/canvas.c
@@ -2,12 +2,15 @@
 #include "icon_i.h"
 
 #include <furi.h>
+#include <api-hal.h>
 
 uint8_t u8g2_gpio_and_delay_stm32(u8x8_t* u8x8, uint8_t msg, uint8_t arg_int, void* arg_ptr);
 uint8_t u8x8_hw_spi_stm32(u8x8_t* u8x8, uint8_t msg, uint8_t arg_int, void* arg_ptr);
 
 Canvas* canvas_init() {
     Canvas* canvas = furi_alloc(sizeof(Canvas));
+
+    api_hal_power_insomnia_enter();
 
     u8g2_Setup_st7565_erc12864_alt_f(
         &canvas->fb, U8G2_R0, u8x8_hw_spi_stm32, u8g2_gpio_and_delay_stm32);
@@ -18,6 +21,8 @@ Canvas* canvas_init() {
     // wake up display
     u8g2_SetPowerSave(&canvas->fb, 0);
     u8g2_SendBuffer(&canvas->fb);
+
+    api_hal_power_insomnia_exit();
 
     return canvas;
 }


### PR DESCRIPTION
# What's new

- Prevent sleep while initializing display

# Verification

- Compile and flash
- Bootup process should be more predictable 

# Checklist (do not modify)

- [X] PR has description of feature/bug or link to Confluence/Jira task
- [X] Description contains actions to verify feature/bugfix
- [X] I've built this code, uploaded it to the device and verified feature/bugfix
