### PR TITLE
[FL-960] View dispatcher: lock gui when the view tree changes

### DIFF
--- a/applications/gui/view_dispatcher.c
+++ b/applications/gui/view_dispatcher.c
@@ -39,8 +39,19 @@ void view_dispatcher_add_view(ViewDispatcher* view_dispatcher, uint32_t view_id,
     furi_assert(view);
     // Check if view id is not used and resgister view
     furi_check(ViewDict_get(view_dispatcher->views, view_id) == NULL);
+
+    // Lock gui
+    if(view_dispatcher->gui) {
+        gui_lock(view_dispatcher->gui);
+    }
+
     ViewDict_set_at(view_dispatcher->views, view_id, view);
     view_set_dispatcher(view, view_dispatcher);
+
+    // Unlock gui
+    if(view_dispatcher->gui) {
+        gui_unlock(view_dispatcher->gui);
+    }
 }
 
 void view_dispatcher_remove_view(ViewDispatcher* view_dispatcher, uint32_t view_id) {


### PR DESCRIPTION
Lock gui when the view tree changes.

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
