### PR TITLE
[FL-938] Keyboard widget changes

### DIFF
--- a/applications/gui/modules/byte_input.c
+++ b/applications/gui/modules/byte_input.c
@@ -608,7 +608,7 @@ static bool byte_input_view_input_callback(InputEvent* event, void* context) {
     furi_assert(byte_input);
     bool consumed = false;
 
-    if(event->type == InputTypeShort || event->type == InputTypeRepeate) {
+    if(event->type == InputTypeShort || event->type == InputTypeRepeat) {
         switch(event->key) {
         case InputKeyLeft:
             with_view_model(

--- a/applications/gui/modules/text_input.c
+++ b/applications/gui/modules/text_input.c
@@ -292,7 +292,7 @@ static bool text_input_view_input_callback(InputEvent* event, void* context) {
     furi_assert(text_input);
     bool consumed = false;
 
-    if(event->type == InputTypeShort || event->type == InputTypeRepeate) {
+    if(event->type == InputTypeShort || event->type == InputTypeRepeat) {
         switch(event->key) {
         case InputKeyUp:
             text_input_handle_up(text_input);

--- a/applications/input/input.c
+++ b/applications/input/input.c
@@ -11,12 +11,12 @@ void input_press_timer_callback(void* arg) {
     InputPinState* input_pin = arg;
     InputEvent event;
     event.key = input_pin->pin->key;
-    if(!input_pin->repeate_event) {
+    if(!input_pin->repeat_event) {
         event.type = InputTypeLong;
         notify_pubsub(&input->event_pubsub, &event);
-        input_pin->repeate_event = true;
+        input_pin->repeat_event = true;
     } else {
-        event.type = InputTypeRepeate;
+        event.type = InputTypeRepeat;
         notify_pubsub(&input->event_pubsub, &event);
     }
     osTimerStart(input_pin->press_timer, INPUT_REPEATE_PRESS_TICKS);
@@ -97,7 +97,7 @@ int32_t input_task() {
     for(size_t i = 0; i < pin_count; i++) {
         input->pin_states[i].pin = &input_pins[i];
         input->pin_states[i].state = GPIO_Read(input->pin_states[i]);
-        input->pin_states[i].repeate_event = false;
+        input->pin_states[i].repeat_event = false;
         input->pin_states[i].debounce = INPUT_DEBOUNCE_TICKS_HALF;
         input->pin_states[i].press_timer =
             osTimerNew(input_press_timer_callback, osTimerOnce, &input->pin_states[i], NULL);
@@ -122,9 +122,9 @@ int32_t input_task() {
                 // Short/Long press logic
                 if(state) {
                     osTimerStart(input->pin_states[i].press_timer, INPUT_LONG_PRESS_TICKS);
-                } else if(input->pin_states[i].repeate_event) {
+                } else if(input->pin_states[i].repeat_event) {
                     osTimerStop(input->pin_states[i].press_timer);
-                    input->pin_states[i].repeate_event = false;
+                    input->pin_states[i].repeat_event = false;
                 } else if(osTimerStop(input->pin_states[i].press_timer) == osOK) {
                     event.type = InputTypeShort;
                     notify_pubsub(&input->event_pubsub, &event);

--- a/applications/input/input.h
+++ b/applications/input/input.h
@@ -10,7 +10,7 @@ typedef enum {
     InputTypeRelease, /* Release event, emitted after debounce */
     InputTypeShort, /* Short event, emitted after InputTypeRelease done withing INPUT_LONG_PRESS interval */
     InputTypeLong, /* Long event, emmited after INPUT_LONG_PRESS interval, asynchronouse to InputTypeRelease  */
-    InputTypeRepeate, /* Repeate event, emmited with INPUT_REPEATE_PRESS period after InputTypeLong event */
+    InputTypeRepeat, /* Repeat event, emmited with INPUT_REPEATE_PRESS period after InputTypeLong event */
 } InputType;
 
 /* Input Event, dispatches with PubSub */

--- a/applications/input/input_i.h
+++ b/applications/input/input_i.h
@@ -18,7 +18,7 @@ typedef struct {
     const InputPin* pin;
     // State
     volatile bool state;
-    volatile bool repeate_event;
+    volatile bool repeat_event;
     volatile uint8_t debounce;
     volatile osTimerId_t press_timer;
 } InputPinState;


### PR DESCRIPTION
# What's new

- Add InputTypeRepeate event emitting after InputTypeLong event with 256 ticks period
- Change byte_input draw

# Verification

- Build for f4 and f5 targets
- Verify changes in byte_input draw
- Press long buttons, verify repeat event behavior

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
