### PR TITLE
[FL-1150] RFAL: fix start without NFC board

### DIFF
--- a/lib/ST25RFAL002/platform.h
+++ b/lib/ST25RFAL002/platform.h
@@ -77,7 +77,6 @@ void platformUnprotectST25RComm();
 #define platformGetSysTick()                        osKernelGetTickCount()                              /*!< Get System Tick (1 tick = 1 ms)             */
 
 #define platformAssert( exp )                       assert_param( exp )                                 /*!< Asserts whether the given expression is true*/
-#define platformErrorHandle()                       Error_Handler()                                     /*!< Global error handle\trap                    */
 
 #define platformSpiSelect()                         platformGpioClear( ST25R_SS_PORT, ST25R_SS_PIN )    /*!< SPI SS\CS: Chip|Slave Select                */
 #define platformSpiDeselect()                       platformGpioSet( ST25R_SS_PORT, ST25R_SS_PIN )      /*!< SPI SS\CS: Chip|Slave Deselect              */


### PR DESCRIPTION
# What's new

- RFAL: remove platform error handler that were causing issues with startup without NFC board

# Verification

- Compile and upload
- Disconnect NFC board and confirm firmware startup

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
