### PR TITLE
[FL-948] iButton Dallas timings tuning

### DIFF
--- a/lib/onewire/one_wire_timings.h
+++ b/lib/onewire/one_wire_timings.h
@@ -37,7 +37,7 @@ typedef uint32_t OneWiteTimeType;
 
 class OneWireEmulateTiming {
 public:
-    constexpr static const OneWiteTimeType RESET_MIN = 430;
+    constexpr static const OneWiteTimeType RESET_MIN = 270;
     constexpr static const OneWiteTimeType RESET_MAX = 960;
 
     constexpr static const OneWiteTimeType PRESENCE_TIMEOUT = 20;


### PR DESCRIPTION
# What's new
Decrease allowed RESET impulse time from 430 to 270 us, as in reference Dallas key

# Verification

- Build for f4 and f5 targets
- Verify correct Dallas keys emulation for each door phones

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
