### PR TITLE
[FL-1188] cli_print_version: fix garbage dereference and function signature

### DIFF
--- a/applications/cli/cli.c
+++ b/applications/cli/cli.c
@@ -71,16 +71,13 @@ void cli_print_version(const Version* version) {
 }
 
 void cli_motd() {
-    const Version* version;
     printf("Flipper cli.\r\n");
 
-    version = (const Version*)api_hal_version_get_boot_version();
     printf("Bootloader\r\n");
-    cli_print_version(version);
+    cli_print_version(api_hal_version_get_boot_version());
 
-    version = (const Version*)api_hal_version_get_fw_version();
     printf("Firmware\r\n");
-    cli_print_version(version);
+    cli_print_version(api_hal_version_get_fw_version());
 }
 
 void cli_nl() {

--- a/applications/cli/cli_commands.c
+++ b/applications/cli/cli_commands.c
@@ -29,7 +29,11 @@ void cli_command_help(string_t args, void* context) {
 void cli_command_version(string_t args, void* context) {
     (void)args;
     (void)context;
-    cli_print_version();
+    printf("Bootloader\r\n");
+    cli_print_version(api_hal_version_get_boot_version());
+
+    printf("Firmware\r\n");
+    cli_print_version(api_hal_version_get_fw_version());
 }
 
 void cli_command_uuid(string_t args, void* context) {

--- a/applications/cli/cli_i.h
+++ b/applications/cli/cli_i.h
@@ -39,6 +39,6 @@ struct Cli {
 Cli* cli_alloc();
 void cli_free(Cli* cli);
 void cli_reset_state(Cli* cli);
-void cli_print_version();
+void cli_print_version(const Version* version);
 void cli_putc(char c);
 void cli_stdout_callback(void* _cookie, const char* data, size_t size);


### PR DESCRIPTION
# What's new

- Fix crash caused by garbage dereference in cli_print_version

# Verification

- Compile and upload
- Open cli and run `version` command

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
