### PR TITLE
[FL-1190] Enable OTG pullup for reading and writing keys

### DIFF
--- a/applications/ibutton/helpers/key-reader.cpp
+++ b/applications/ibutton/helpers/key-reader.cpp
@@ -178,10 +178,12 @@ void KeyReader::switch_mode_if_needed() {
 }
 
 void KeyReader::start() {
+    api_hal_power_enable_otg();
     switch_to(ReadMode::CYFRAL_METAKOM);
 }
 
 void KeyReader::stop() {
+    api_hal_power_disable_otg();
     onewire_master->stop();
     stop_comaparator();
 }

--- a/applications/ibutton/helpers/key-writer.cpp
+++ b/applications/ibutton/helpers/key-writer.cpp
@@ -10,10 +10,12 @@ KeyWriter::Error KeyWriter::write(iButtonKey* key) {
 }
 
 void KeyWriter::start() {
+    api_hal_power_enable_otg();
     onewire_master->start();
 }
 
 void KeyWriter::stop() {
+    api_hal_power_disable_otg();
     onewire_master->stop();
 }
 

--- a/lib/onewire/one_wire_master.cpp
+++ b/lib/onewire/one_wire_master.cpp
@@ -12,12 +12,10 @@ OneWireMaster::~OneWireMaster() {
 
 void OneWireMaster::start(void) {
     gpio_init(gpio, GpioModeOutputOpenDrain);
-    api_hal_power_enable_otg();
 }
 
 void OneWireMaster::stop(void) {
     gpio_init(gpio, GpioModeAnalog);
-    api_hal_power_disable_otg();
 }
 
 void OneWireMaster::reset_search() {


### PR DESCRIPTION
# What's new
Enable OTG pullup for reading and writing keys

# Verification

- Build for f4 and f5 targets
- Read Dallas, Cyfral and Metakom keys with placed R69 pullup resister

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
