### PR TITLE
SubGhz: PTC timings tuning, new static key, new frequency 

### DIFF
--- a/applications/subghz/subghz_i.h
+++ b/applications/subghz/subghz_i.h
@@ -21,22 +21,24 @@ static const uint32_t subghz_frequencies[] = {
     463000000,
     781000000,
     868000000,
+    868350000,
     915000000,
     925000000,
 };
 
 static const ApiHalSubGhzPath subghz_frequencies_paths[] = {
-    ApiHalSubGhzPath2,
-    ApiHalSubGhzPath2,
-    ApiHalSubGhzPath2,
-    ApiHalSubGhzPath2,
-    ApiHalSubGhzPath1,
-    ApiHalSubGhzPath1,
-    ApiHalSubGhzPath1,
-    ApiHalSubGhzPath3,
-    ApiHalSubGhzPath3,
-    ApiHalSubGhzPath3,
-    ApiHalSubGhzPath3,
+    ApiHalSubGhzPath2, /* 301000000 */
+    ApiHalSubGhzPath2, /* 315000000 */
+    ApiHalSubGhzPath2, /* 346000000 */
+    ApiHalSubGhzPath2, /* 385000000 */
+    ApiHalSubGhzPath1, /* 433920000 */
+    ApiHalSubGhzPath1, /* 438900000 */
+    ApiHalSubGhzPath1, /* 463000000 */
+    ApiHalSubGhzPath3, /* 781000000 */
+    ApiHalSubGhzPath3, /* 868000000 */
+    ApiHalSubGhzPath3, /* 868350000 */
+    ApiHalSubGhzPath3, /* 915000000 */
+    ApiHalSubGhzPath3, /* 925000000 */
 };
 
 static const uint32_t subghz_frequencies_count = sizeof(subghz_frequencies) / sizeof(uint32_t);


### PR DESCRIPTION
# What's new

- Better PTC static key timings 
- New frequency 868.35
- New static key

# Verification 

- Compile and upload
- Test subghz with 868.35 receivers 

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
