### PR TITLE
ApiHalNfc: exit sleep mode before activating field and vice versa

### DIFF
--- a/firmware/targets/f5/api-hal/api-hal-nfc.c
+++ b/firmware/targets/f5/api-hal/api-hal-nfc.c
@@ -16,11 +16,13 @@ bool api_hal_nfc_is_busy() {
 }
 
 void api_hal_nfc_field_on() {
+    api_hal_nfc_exit_sleep();
     st25r3916TxRxOn();
 }
 
 void api_hal_nfc_field_off() {
-    rfalFieldOff();
+    st25r3916TxRxOff();
+    api_hal_nfc_start_sleep();
 }
 
 void api_hal_nfc_start_sleep() {


### PR DESCRIPTION
# What's new

- ApiHalNfc: exit sleep mode before activating field and vice versa

# Verification 

- Compile and upload
- Nfc Field should work now (was broken)

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
