### PR TITLE
[FL-1226] Upload elf to storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,10 @@ jobs:
           run: |
             mv bootloader/.obj/${TARGET_VERSION}/bootloader.dfu bootloader.dfu
             mv bootloader/.obj/${TARGET_VERSION}/bootloader.bin bootloader.bin
+            mv bootloader/.obj/${TARGET_VERSION}/bootloader.elf bootloader.elf
             mv firmware/.obj/${TARGET_VERSION}/firmware.dfu firmware.dfu
             mv firmware/.obj/${TARGET_VERSION}/firmware.bin firmware.bin
+            mv firmware/.obj/${TARGET_VERSION}/firmware.elf firmware.elf
 
       - name: Generate full dfu file
         uses: ./.github/actions/docker
@@ -120,7 +122,7 @@ jobs:
           remote_key: ${{ secrets.RSYNC_DEPLOY_KEY }}        
 
       - name: Generate files list
-        run: ls bootloader.dfu firmware.dfu full.dfu bootloader.bin firmware.bin full.bin > uploadlist.txt
+        run: ls bootloader.dfu firmware.dfu full.dfu bootloader.bin firmware.bin full.bin bootloader.elf firmware.elf > uploadlist.txt
 
       - name: Upload artifacts
         uses: burnett01/rsync-deployments@4.1


### PR DESCRIPTION
# What's new

- Upload elf files for bootloader and firmware

# Verification 

- Files upload to https://update.flipperzero.one/. 
Example - https://update.flipperzero.one/rd_add-elf-to-upload/

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
