### PR TITLE
[FL-1214] nfc_worker fix emulation

### DIFF
--- a/applications/nfc/nfc_worker.c
+++ b/applications/nfc/nfc_worker.c
@@ -185,6 +185,7 @@ void nfc_worker_emulate(NfcWorker* nfc_worker) {
     params.lmConfigPA.SENS_RES[0] = 0x44;
     params.lmConfigPA.SENS_RES[1] = 0x00;
     params.lmConfigPA.SEL_RES = 0x00;
+    api_hal_nfc_exit_sleep();
 
     ReturnCode ret;
     ret = rfalNfcDiscover(&params);
@@ -204,6 +205,7 @@ void nfc_worker_emulate(NfcWorker* nfc_worker) {
     }
 
     rfalNfcDeactivate(false);
+    api_hal_nfc_start_sleep();
 }
 
 void nfc_worker_field(NfcWorker* nfc_worker) {


### PR DESCRIPTION
# What's new

- Exit nfc sleep mode before starting emulation

# Verification 

- Build and upload f5 target
- Verify correct emulation

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
