### PR TITLE
[FL-1318] Fix cyfral and metakom keys reading

### DIFF
--- a/applications/ibutton/helpers/key-reader.cpp
+++ b/applications/ibutton/helpers/key-reader.cpp
@@ -142,8 +142,10 @@ void KeyReader::comparator_trigger_callback(void* hcomp, void* comp_ctx) {
     if(hcomp == &hcomp1) {
         uint32_t current_dwt_value = DWT->CYCCNT;
 
-        _this->cyfral_decoder.process_front(hal_gpio_get_rfid_in_level(), current_dwt_value - last_dwt_value);
-        _this->metakom_decoder.process_front(hal_gpio_get_rfid_in_level(), current_dwt_value - last_dwt_value);
+        _this->cyfral_decoder.process_front(
+            hal_gpio_get_rfid_in_level(), current_dwt_value - last_dwt_value);
+        _this->metakom_decoder.process_front(
+            hal_gpio_get_rfid_in_level(), current_dwt_value - last_dwt_value);
 
         last_dwt_value = DWT->CYCCNT;
     }


### PR DESCRIPTION
# What's new

- Fix cyfral and metakom keys reading

# Verification 

- Build for f5 and f6 targets
- Read cyfral and metakom keys

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
