### PR TITLE
[FL-1478] Fix setting PA0 high confirmation dialog

### DIFF
--- a/applications/cli/cli_commands.c
+++ b/applications/cli/cli_commands.c
@@ -256,7 +256,7 @@ void cli_command_gpio_set(Cli* cli, string_t args, void* context) {
             printf(
                 "Setting PA0 pin HIGH with TSOP connected can damage IR receiver. Are you sure you want to continue? (y/n)?\r\n");
             char c = cli_getc(cli);
-            if(c != 'y' || c != 'Y') {
+            if(c != 'y' && c != 'Y') {
                 printf("Cancelled.\r\n");
                 return;
             }


### PR DESCRIPTION
# What's new

- Fix setting PA0 high confirmation dialog

# Verification 

!!! DISCONNECT iButton flex cable before test !!!

- Compile and upload
- Use cli command: `gpio_set PA0 1`
- DISCONNECT iButton flex cable
- Press `y` or `Y`.

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
