### PR TITLE
[FL-1437] Replace stringstream with sscanf

### DIFF
--- a/applications/irda/cli/irda-cli.cpp
+++ b/applications/irda/cli/irda-cli.cpp
@@ -54,7 +54,7 @@ static void irda_cli_start_ir_rx(Cli* cli, string_t args, void* context) {
 }
 
 static void irda_cli_print_usage(void) {
-    printf("Usage:\r\n\tir_tx <protocol> <command> <address>\r\n");
+    printf("Usage:\r\n\tir_tx <protocol> <address> <command>\r\n");
     printf("\t<command> and <address> are hex-formatted\r\n");
     printf("\tAvailable protocols:");
     for(int i = 0; irda_is_protocol_valid((IrdaProtocol)i); ++i) {
@@ -68,18 +68,19 @@ static void irda_cli_start_ir_tx(Cli* cli, string_t args, void* context) {
         printf("IRDA is busy. Exit.");
         return;
     }
-    auto ss = std::istringstream(string_get_cstr(args));
+
     uint32_t command = 0;
     uint32_t address = 0;
-    std::string protocol_name;
+    char protocol_name[32];
+    int parsed = sscanf(string_get_cstr(args), "%31s %lX %lX", protocol_name, &address, &command);
 
-    if(!(ss >> protocol_name) || !(ss >> std::hex >> address) || !(ss >> std::hex >> command)) {
+    if(parsed != 3) {
         printf("Wrong arguments.\r\n");
         irda_cli_print_usage();
         return;
     }
 
-    IrdaProtocol protocol = irda_get_protocol_by_name(protocol_name.c_str());
+    IrdaProtocol protocol = irda_get_protocol_by_name(protocol_name);
 
     if(!irda_is_protocol_valid(protocol)) {
         printf("Unknown protocol.\r\n");


### PR DESCRIPTION
Do this to save space. Stringstream is very heavy.

# What's new

- Remove stringstream to save space

# Verification 

- Build new FW and notice that it's lighter for 135 KB

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
