### PR TITLE
Cli: add timestamp to device_info command

### DIFF
--- a/applications/cli/cli_commands.c
+++ b/applications/cli/cli_commands.c
@@ -33,6 +33,7 @@ void cli_command_device_info(Cli* cli, string_t args, void* context) {
     printf("hardware_target     : %d\r\n", api_hal_version_get_hw_target());
     printf("hardware_body       : %d\r\n", api_hal_version_get_hw_body());
     printf("hardware_connect    : %d\r\n", api_hal_version_get_hw_connect());
+    printf("hardware_timestamp  : %lu\r\n", api_hal_version_get_hw_timestamp());
 
     // Color and Region
     printf("hardware_color      : %d\r\n", api_hal_version_get_hw_color());


### PR DESCRIPTION
# What's new

- Cli: add timestamp to device_info command

# Verification 

- Compile and upload
- Use device info cli command and check hardware_timestamp field

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
