### PR TITLE
Furi: proper thread id in heap tracking

### DIFF
--- a/core/furi/thread.c
+++ b/core/furi/thread.c
@@ -16,7 +16,7 @@ struct FuriThread {
     void* state_context;
 
     osThreadAttr_t attr;
-    osThreadId_t id;
+    volatile osThreadId_t id;
 
     bool heap_trace_enabled;
     size_t heap_size;
@@ -37,15 +37,16 @@ void furi_thread_body(void* context) {
     furi_assert(thread->state == FuriThreadStateStarting);
     furi_thread_set_state(thread, FuriThreadStateRunning);
 
+    osThreadId_t thread_id = osThreadGetId();
     if(thread->heap_trace_enabled == true) {
-        memmgr_heap_enable_thread_trace(thread->id);
+        memmgr_heap_enable_thread_trace(thread_id);
     }
 
     thread->ret = thread->callback(thread->context);
 
     if(thread->heap_trace_enabled == true) {
-        thread->heap_size = memmgr_heap_get_thread_memory(thread->id);
-        memmgr_heap_disable_thread_trace(thread->id);
+        thread->heap_size = memmgr_heap_get_thread_memory(thread_id);
+        memmgr_heap_disable_thread_trace(thread_id);
     }
 
     furi_assert(thread->state == FuriThreadStateRunning);


### PR DESCRIPTION
# What's new

- Furi: proper thread id in heap tracking

# Verification 

- Compile release version and upload
- Periodic crash should be gone now 

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
