### PR TITLE
[FL-1557] Cli: give input command CliCommandFlagParallelSafe flag

### DIFF
--- a/applications/input/input.c
+++ b/applications/input/input.c
@@ -99,7 +99,8 @@ int32_t input_task() {
 
     input->cli = furi_record_open("cli");
     if(input->cli) {
-        cli_add_command(input->cli, "input_send", CliCommandFlagParallelSafe, input_cli_send, input);
+        cli_add_command(
+            input->cli, "input_send", CliCommandFlagParallelSafe, input_cli_send, input);
     }
 
     const size_t pin_count = input_pins_count;


### PR DESCRIPTION
# What's new

- Cli: give input command CliCommandFlagParallelSafe flag

# Verification 

- Compile and upload
- Fixes issue with inability to inject input when any app is running

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
