### PR TITLE
[FL-1493] text input: fix "up" key behaviour

### DIFF
--- a/applications/gui/modules/text_input.c
+++ b/applications/gui/modules/text_input.c
@@ -237,7 +237,7 @@ static void text_input_handle_up(TextInput* text_input) {
         text_input->view, (TextInputModel * model) {
             if(model->selected_row > 0) {
                 model->selected_row--;
-                if(model->selected_column > get_row_size(model->selected_row) - 5) {
+                if(model->selected_column > get_row_size(model->selected_row) - 6) {
                     model->selected_column = model->selected_column + 1;
                 }
             }


### PR DESCRIPTION
# What's new

- Text input: fix "up" key behaviour

# Verification 

- Flash
- Open keyboard, test 'up' key from 'save', 'backspace' keys

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
