### PR TITLE
[FL-1581] I2C fast mode

### DIFF
--- a/firmware/targets/f6/api-hal/api-hal-clock.c
+++ b/firmware/targets/f6/api-hal/api-hal-clock.c
@@ -93,6 +93,7 @@ void api_hal_clock_init() {
     // AHB1
     LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_DMAMUX1);
     LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_DMA1);
+    LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_I2C1);
 
     // AHB2
     LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOA);

--- a/firmware/targets/f6/api-hal/api-hal-i2c.c
+++ b/firmware/targets/f6/api-hal/api-hal-i2c.c
@@ -1,4 +1,6 @@
 #include <api-hal-i2c.h>
+#include <api-hal-version.h>
+
 #include <stm32wbxx_ll_i2c.h>
 #include <stm32wbxx_ll_gpio.h>
 #include <stm32wbxx_ll_cortex.h>
@@ -15,7 +17,6 @@ void api_hal_i2c_init() {
 
     LL_RCC_SetI2CClockSource(LL_RCC_I2C1_CLKSOURCE_PCLK1);
 
-    LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOA);
     GPIO_InitStruct.Pin = POWER_I2C_SCL_Pin | POWER_I2C_SDA_Pin;
     GPIO_InitStruct.Mode = LL_GPIO_MODE_ALTERNATE;
     GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
@@ -24,21 +25,23 @@ void api_hal_i2c_init() {
     GPIO_InitStruct.Alternate = LL_GPIO_AF_4;
     LL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
-    LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_I2C1);
-
     I2C_InitStruct.PeripheralMode = LL_I2C_MODE_I2C;
-    I2C_InitStruct.Timing = POWER_I2C_TIMINGS;
     I2C_InitStruct.AnalogFilter = LL_I2C_ANALOGFILTER_ENABLE;
     I2C_InitStruct.DigitalFilter = 0;
     I2C_InitStruct.OwnAddress1 = 0;
     I2C_InitStruct.TypeAcknowledge = LL_I2C_ACK;
     I2C_InitStruct.OwnAddrSize = LL_I2C_OWNADDRESS1_7BIT;
-    LL_I2C_Init(I2C1, &I2C_InitStruct);
-    LL_I2C_EnableAutoEndMode(I2C1);
-    LL_I2C_SetOwnAddress2(I2C1, 0, LL_I2C_OWNADDRESS2_NOMASK);
-    LL_I2C_DisableOwnAddress2(I2C1);
-    LL_I2C_DisableGeneralCall(I2C1);
-    LL_I2C_EnableClockStretching(I2C1);
+    if (api_hal_version_get_hw_version() > 10) {
+        I2C_InitStruct.Timing = POWER_I2C_TIMINGS_400;
+    } else {
+        I2C_InitStruct.Timing = POWER_I2C_TIMINGS_100;
+    }
+    LL_I2C_Init(POWER_I2C, &I2C_InitStruct);
+    LL_I2C_EnableAutoEndMode(POWER_I2C);
+    LL_I2C_SetOwnAddress2(POWER_I2C, 0, LL_I2C_OWNADDRESS2_NOMASK);
+    LL_I2C_DisableOwnAddress2(POWER_I2C);
+    LL_I2C_DisableGeneralCall(POWER_I2C);
+    LL_I2C_EnableClockStretching(POWER_I2C);
 }
 
 bool api_hal_i2c_tx(

--- a/firmware/targets/f6/api-hal/api-hal-resources.h
+++ b/firmware/targets/f6/api-hal/api-hal-resources.h
@@ -17,10 +17,16 @@ extern "C" {
 
 #define POWER_I2C I2C1
 /** Timing register value is computed with the STM32CubeMX Tool,
-  * Fast Mode @100kHz with I2CCLK = 64 MHz,
+  * Standard Mode @100kHz with I2CCLK = 64 MHz,
   * rise time = 0ns, fall time = 0ns
   */
-#define POWER_I2C_TIMINGS 0x10707DBC
+#define POWER_I2C_TIMINGS_100 0x10707DBC
+
+/** Timing register value is computed with the STM32CubeMX Tool,
+  * Fast Mode @400kHz with I2CCLK = 64 MHz,
+  * rise time = 0ns, fall time = 0ns
+  */
+#define POWER_I2C_TIMINGS_400 0x00602173
 
 /* Input Related Constants */
 #define INPUT_DEBOUNCE_TICKS 20


### PR DESCRIPTION
# What's new

- ApiHal: enable fast mode for i2c on 11+ boards

# Verification 

You'll need empty OTP for verification

- Compile and flash
- Flash OTP, set version to 11
- If you using v10 board replace R40/R41 with 1.5k
- I2C now 4 times faster (actually no, but can be in theory)

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
