### PR TITLE
[FL-1430] ApiHal: add regions and colors enums

### DIFF
--- a/firmware/targets/api-hal-include/api-hal-version.h
+++ b/firmware/targets/api-hal-include/api-hal-version.h
@@ -9,6 +9,21 @@
 extern "C" {
 #endif
 
+/** Device Colors */
+typedef enum {
+    ApiHalVersionColorUnknown=0x00,
+    ApiHalVersionColorBlack=0x01,
+    ApiHalVersionColorWhite=0x02,
+} ApiHalVersionColor;
+
+/** Device Regions */
+typedef enum {
+    ApiHalVersionRegionUnknown=0x00,
+    ApiHalVersionRegionEuRu=0x01,
+    ApiHalVersionRegionUsCaAu=0x02,
+    ApiHalVersionRegionJp=0x03,
+} ApiHalVersionRegion;
+
 /** Init flipper version */
 void api_hal_version_init();
 
@@ -28,13 +43,13 @@ const uint8_t api_hal_version_get_hw_target();
 const uint8_t api_hal_version_get_hw_body();
 
 /** Get hardware body color */
-const uint8_t api_hal_version_get_hw_color();
+const ApiHalVersionColor api_hal_version_get_hw_color();
 
 /** Get hardware connect */
 const uint8_t api_hal_version_get_hw_connect();
 
 /** Get hardware region */
-const uint8_t api_hal_version_get_hw_region();
+const ApiHalVersionRegion api_hal_version_get_hw_region();
 
 /** Get hardware timestamp */
 const uint32_t api_hal_version_get_hw_timestamp();

--- a/firmware/targets/f6/api-hal/api-hal-version.c
+++ b/firmware/targets/f6/api-hal/api-hal-version.c
@@ -187,7 +187,7 @@ const uint8_t api_hal_version_get_hw_body() {
     return api_hal_version.board_body;
 }
 
-const uint8_t api_hal_version_get_hw_color() {
+const ApiHalVersionColor api_hal_version_get_hw_color() {
     return api_hal_version.board_color;
 }
 
@@ -195,7 +195,7 @@ const uint8_t api_hal_version_get_hw_connect() {
     return api_hal_version.board_connect;
 }
 
-const uint8_t api_hal_version_get_hw_region() {
+const ApiHalVersionRegion api_hal_version_get_hw_region() {
     return api_hal_version.board_region;
 }
 

--- a/scripts/otp.py
+++ b/scripts/otp.py
@@ -20,8 +20,9 @@ OTP_COLORS = {
 }
 OTP_REGIONS = {
     "unknown": 0x00,
-    "europe": 0x01,
-    "usa": 0x02,
+    "eu_ru": 0x01,
+    "us_ca_au": 0x02,
+    "jp": 0x03,
 }
 
 BOARD_RESERVED = 0x0000


### PR DESCRIPTION
# What's new

- ApiHal: add regions and colors enums

# Verification 

- otp.py now supports exact names for regions
- ApiHal version now provides you with enums for device color and region

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
