### PR TITLE
ApiHal: fixes and improvements

### DIFF
--- a/bootloader/targets/f6/target.c
+++ b/bootloader/targets/f6/target.c
@@ -88,7 +88,7 @@ void rtc_init() {
         // Start LSI1 needed for CSS
         LL_RCC_LSI1_Enable();
         // Try to start LSE normal way
-        LL_RCC_LSE_SetDriveCapability(LL_RCC_LSEDRIVE_MEDIUMLOW);
+        LL_RCC_LSE_SetDriveCapability(LL_RCC_LSEDRIVE_HIGH);
         LL_RCC_LSE_Enable();
         uint32_t c = 0;
         while(!RTC_CLOCK_IS_READY() && c < 200) {

--- a/firmware/targets/f6/Inc/stm32wbxx_it.h
+++ b/firmware/targets/f6/Inc/stm32wbxx_it.h
@@ -47,15 +47,7 @@
 /* USER CODE END EM */
 
 /* Exported functions prototypes ---------------------------------------------*/
-void NMI_Handler(void);
-void HardFault_Handler(void);
-void MemManage_Handler(void);
-void BusFault_Handler(void);
-void UsageFault_Handler(void);
-void DebugMon_Handler(void);
 void SysTick_Handler(void);
-void TAMP_STAMP_LSECSS_IRQHandler(void);
-void RCC_IRQHandler(void);
 void ADC1_IRQHandler(void);
 void USB_LP_IRQHandler(void);
 void COMP_IRQHandler(void);

--- a/firmware/targets/f6/Src/stm32wbxx_it.c
+++ b/firmware/targets/f6/Src/stm32wbxx_it.c
@@ -16,55 +16,8 @@ extern void HW_TS_RTC_Wakeup_Handler();
 extern void HW_IPCC_Tx_Handler();
 extern void HW_IPCC_Rx_Handler();
 
-void NMI_Handler(void) {
-    if (LL_RCC_IsActiveFlag_HSECSS()) {
-        LL_RCC_ClearFlag_HSECSS();
-        NVIC_SystemReset();
-    }
-}
-
-void HardFault_Handler(void) {
-    if ((*(volatile uint32_t *)CoreDebug_BASE) & (1 << 0)) {
-        __asm("bkpt 1");
-    }
-    while (1) {}
-}
-
-void MemManage_Handler(void) {
-    __asm("bkpt 1");
-    while (1) {}
-}
-
-void BusFault_Handler(void) {
-    __asm("bkpt 1");
-    while (1) {}
-}
-
-void UsageFault_Handler(void) {
-    __asm("bkpt 1");
-    while (1) {}
-}
-
-void DebugMon_Handler(void) {
-}
-
 void SysTick_Handler(void) {
     HAL_IncTick();
-}
-
-void TAMP_STAMP_LSECSS_IRQHandler(void) {
-    if (LL_RCC_IsActiveFlag_LSECSS()) {
-        LL_RCC_ClearFlag_LSECSS();
-        if (!LL_RCC_LSE_IsReady()) {
-            // TODO: notify user about issue with LSE
-            LL_RCC_ForceBackupDomainReset();
-            LL_RCC_ReleaseBackupDomainReset();
-            NVIC_SystemReset();
-        }
-    }
-}
-
-void RCC_IRQHandler(void) {
 }
 
 void ADC1_IRQHandler(void) {


### PR DESCRIPTION
# What's new

- ApiHal: initialize clock in parallel.
- ApiHal: switch LSE driving to high(still 20 times smaller than Typ. and 100 times smaller than Max.).
- ApiHal: enable EXTI line 18 to fix LSECSS.
- ApiHal: move some interrupts service routines to api-hal-interrupts.

# Verification 

- Compile and upload
- Power off and on not causing LSE to stop anymore.
- LSECSS is back again: device will reboot on failure

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
