### PR TITLE
Applications: add stack_size to keypad_test and assert in furi thread

### DIFF
--- a/applications/applications.c
+++ b/applications/applications.c
@@ -144,7 +144,7 @@ const FlipperApplication FLIPPER_SERVICES[] = {
 #endif
 
 #ifdef SRV_KEYPAD_TEST
-    {.app = keypad_test, .name = "keypad_test", .icon = &A_Plugins_14},
+    {.app = keypad_test, .name = "keypad_test", .stack_size = 1024, .icon = &A_Plugins_14},
 #endif
 
 #ifdef SRV_ACCESSOR
@@ -273,7 +273,7 @@ const FlipperApplication FLIPPER_DEBUG_APPS[] = {
 #endif
 
 #ifdef APP_KEYPAD_TEST
-    {.app = keypad_test, .name = "keypad_test", .icon = &A_Plugins_14},
+    {.app = keypad_test, .name = "keypad_test", .stack_size = 1024, .icon = &A_Plugins_14},
 #endif
 
 #ifdef APP_ACCESSOR

--- a/core/furi/thread.c
+++ b/core/furi/thread.c
@@ -115,6 +115,7 @@ bool furi_thread_start(FuriThread* thread) {
     furi_assert(thread);
     furi_assert(thread->callback);
     furi_assert(thread->state == FuriThreadStateStopped);
+    furi_assert(thread->attr.stack_size > 0);
     furi_thread_set_state(thread, FuriThreadStateStarting);
     thread->id = osThreadNew(furi_thread_body, thread, &thread->attr);
     if(thread->id) {


### PR DESCRIPTION
# What's new

- Applications: add stack_size to keypad_test and assert in furi thread

# Verification 

- Compile and run
- Keypad test stack overflow should be gone

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
