### PR TITLE
Storage: fixed internal info when otp is not programmed.

### DIFF
--- a/applications/storage-settings/scenes/storage-settings-scene-internal-info.c
+++ b/applications/storage-settings/scenes/storage-settings-scene-internal-info.c
@@ -28,7 +28,7 @@ void storage_settings_scene_internal_info_on_enter(void* context) {
         string_printf(
             app->text_string,
             "Label: %s\nType: LittleFS\n%lu KB total\n%lu KB free",
-            furi_hal_version_get_name_ptr(),
+            furi_hal_version_get_name_ptr() ? furi_hal_version_get_name_ptr() : "Unknown",
             (uint32_t)(total_space / 1024),
             (uint32_t)(free_space / 1024));
         dialog_ex_set_text(

--- a/applications/storage/storage-cli.c
+++ b/applications/storage/storage-cli.c
@@ -64,7 +64,7 @@ void storage_cli_info(Cli* cli, string_t path) {
         } else {
             printf(
                 "Label: %s\r\nType: LittleFS\r\n%lu KB total\r\n%lu KB free\r\n",
-                furi_hal_version_get_name_ptr(),
+                furi_hal_version_get_name_ptr() ? furi_hal_version_get_name_ptr() : "Unknown",
                 (uint32_t)(total_space / 1024),
                 (uint32_t)(free_space / 1024));
         }


### PR DESCRIPTION
# What's new

- Fixed internal info when otp is not programmed.

# Verification 

- Run "storage info /int" in Cli, or "Settings -> Storage -> About internal storage", when otp is not programmed.

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
