### PR TITLE
docker-compose linting and a good practice fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 version: '3'
 services:
   dev:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:focal
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y \
         ca-certificates \
         build-essential \
         python3 \


### PR DESCRIPTION
# What's new

I just fixed linting issues for docker-compose.yml and made sure there is `apt upgrade` before any `adb install` commands, to make sure there is no version mismatch for new packages and dependencies.

# Verification 

- Run `docker-compose up`

- Build Dockerfile

# Checklist (do not modify)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
