### PR TITLE
CI: Do not upload fork artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,7 @@ jobs:
             done
 
       - name: 'Generate full hex file'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: ./.github/actions/docker
         with:
           run: |
@@ -86,6 +87,7 @@ jobs:
             done
 
       - name: 'Move upload files'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: ./.github/actions/docker
         with:
           run: |
@@ -106,6 +108,7 @@ jobs:
             done
 
       - name: 'Generate full dfu file'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: ./.github/actions/docker
         with:
           run: |
@@ -118,6 +121,7 @@ jobs:
             done
 
       - name: 'Full flash asssembly: bootloader as base'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
           for TARGET in ${TARGETS}
           do
@@ -127,6 +131,7 @@ jobs:
           done
 
       - name: 'Full flash asssembly: bootloader padding'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
           for TARGET in ${TARGETS}
           do
@@ -134,6 +139,7 @@ jobs:
           done
 
       - name: 'Full flash asssembly: append firmware'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
           for TARGET in ${TARGETS}
           do
@@ -143,6 +149,7 @@ jobs:
           done
 
       - name: 'Bundle core2 firmware'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
           test -d core2_firmware && rm -rf core2_firmware || true
           mkdir core2_firmware
@@ -155,14 +162,17 @@ jobs:
           tar czpf artifacts/flipper-z-any-core2_firmware-${SUFFIX}.tgz core2_firmware
 
       - name: 'Bundle scripts'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
           tar czpf artifacts/flipper-z-any-scripts-${SUFFIX}.tgz scripts
 
       - name: 'Bundle resources'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
           tar czpf artifacts/flipper-z-any-resources-${SUFFIX}.tgz -C assets resources
 
       - name: 'Upload artifacts to update server'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: burnett01/rsync-deployments@4.1
         with:
           switches: -avzP --delete
@@ -174,6 +184,7 @@ jobs:
           remote_key: ${{ secrets.RSYNC_DEPLOY_KEY }}
 
       - name: 'Trigger update server reindex'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: wei/curl@master
         with:
           args: -X POST -F 'key=${{ secrets.REINDEX_KEY }}' ${{ secrets.REINDEX_URL }}


### PR DESCRIPTION
# What's new

- Added a condition to skip artifacts upload for external PRs

# Verification 

- PRs get built, but artifacts are not uploaded

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
