### PR TITLE
[FL-1641] File select fix

### DIFF
--- a/applications/gui/modules/file_select.c
+++ b/applications/gui/modules/file_select.c
@@ -289,7 +289,7 @@ bool file_select_fill_strings(FileSelect* file_select) {
         storage_dir_close(directory);
         storage_file_free(directory);
         free(name);
-        return false;
+        return true;
     }
 
     while(1) {
@@ -350,7 +350,7 @@ bool file_select_fill_count(FileSelect* file_select) {
         storage_dir_close(directory);
         storage_file_free(directory);
         free(name);
-        return false;
+        return true;
     }
 
     while(1) {


### PR DESCRIPTION
# What's new

- Display Empty folder when we can't open directory

# Verification 

- Delete application folder (nfc, subghz ...) on SD card or just format SD card. Verify "Empty folder" message in Saved menu

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
