### PR TITLE
Dolphin: fix archive double start crash

### DIFF
--- a/applications/dolphin/dolphin.c
+++ b/applications/dolphin/dolphin.c
@@ -10,9 +10,15 @@ static void dolphin_switch_to_app(Dolphin* dolphin, const FlipperApplication* fl
     furi_assert(flipper_app->app);
     furi_assert(flipper_app->name);
 
+    if(furi_thread_get_state(dolphin->scene_thread) != FuriThreadStateStopped) {
+        FURI_LOG_E("Dolphin", "Thread is already running");
+        return;
+    }
+
     furi_thread_set_name(dolphin->scene_thread, flipper_app->name);
     furi_thread_set_stack_size(dolphin->scene_thread, flipper_app->stack_size);
     furi_thread_set_callback(dolphin->scene_thread, flipper_app->app);
+
     furi_thread_start(dolphin->scene_thread);
 }
 


### PR DESCRIPTION
# What's new

- Dolphin: fix archive double start crash

# Verification 

- Compile and upload
- Fast double short press of archive button doesn't crash flipper anymore.

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
