### PR TITLE
[FL-1746] Fix IRDA freeze

### DIFF
--- a/lib/irda/encoder_decoder/common/irda_common_decoder.c
+++ b/lib/irda/encoder_decoder/common/irda_common_decoder.c
@@ -257,7 +257,7 @@ void irda_common_decoder_reset_state(IrdaCommonDecoder* common_decoder) {
     common_decoder->databit_cnt = 0;
     common_decoder->switch_detect = false;
     common_decoder->message.protocol = IrdaProtocolUnknown;
-    if (common_decoder->protocol->timings.preamble_mark == 0) {
+    if ((common_decoder->protocol->timings.preamble_mark == 0) && (common_decoder->timings_cnt > 0)) {
         --common_decoder->timings_cnt;
         shift_left_array(common_decoder->timings, common_decoder->timings_cnt, 1);
     }


### PR DESCRIPTION
Reading large RAW signal causes freeze

# What's new

- Fix large RAW signal reading freeze

# Verification 

- Run either Infrared App, or IRDA Monitor and catch signal > 512 samples

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
