### PR TITLE
NFC: Fix typo in the struct name

### DIFF
--- a/applications/nfc/nfc_cli.c
+++ b/applications/nfc/nfc_cli.c
@@ -54,7 +54,7 @@ void nfc_cli_emulate(Cli* cli, string_t args, void* context) {
     printf("Emulating NFC-A Type: T2T UID: CF72D440 SAK: 20 ATQA: 00/04\r\n");
     printf("Press Ctrl+C to abort\r\n");
 
-    NfcDeviceCommomData params = {
+    NfcDeviceCommonData params = {
         .uid = {0x36, 0x9C, 0xe7, 0xb1, 0x0A, 0xC1, 0x34},
         .uid_len = 7,
         .atqa = {0x44, 0x00},

--- a/applications/nfc/nfc_device.c
+++ b/applications/nfc/nfc_device.c
@@ -60,7 +60,7 @@ bool nfc_device_parse_format_string(NfcDevice* dev, string_t format_string) {
 }
 
 uint16_t nfc_device_prepare_uid_string(NfcDevice* dev, string_t uid_string) {
-    NfcDeviceCommomData* uid_data = &dev->dev_data.nfc_data;
+    NfcDeviceCommonData* uid_data = &dev->dev_data.nfc_data;
     string_printf(uid_string, "UID len: %02X UID: ", dev->dev_data.nfc_data.uid_len);
     for(uint8_t i = 0; i < uid_data->uid_len; i++) {
         string_cat_printf(uid_string, "%02X ", uid_data->uid[i]);
@@ -75,7 +75,7 @@ uint16_t nfc_device_prepare_uid_string(NfcDevice* dev, string_t uid_string) {
 }
 
 bool nfc_device_parse_uid_string(NfcDevice* dev, string_t uid_string) {
-    NfcDeviceCommomData* uid_data = &dev->dev_data.nfc_data;
+    NfcDeviceCommonData* uid_data = &dev->dev_data.nfc_data;
     bool parsed = false;
 
     do {

--- a/applications/nfc/nfc_device.h
+++ b/applications/nfc/nfc_device.h
@@ -34,7 +34,7 @@ typedef struct {
     uint8_t sak;
     NfcDeviceType device;
     NfcProtocol protocol;
-} NfcDeviceCommomData;
+} NfcDeviceCommonData;
 
 typedef struct {
     char name[32];
@@ -48,7 +48,7 @@ typedef struct {
 } NfcEmvData;
 
 typedef struct {
-    NfcDeviceCommomData nfc_data;
+    NfcDeviceCommonData nfc_data;
     union {
         NfcEmvData emv_data;
         MifareUlData mf_ul_data;

--- a/applications/nfc/nfc_worker.c
+++ b/applications/nfc/nfc_worker.c
@@ -100,7 +100,7 @@ void nfc_worker_detect(NfcWorker* nfc_worker) {
     rfalNfcDevice* dev_list;
     rfalNfcDevice* dev;
     uint8_t dev_cnt;
-    NfcDeviceCommomData* result = &nfc_worker->dev_data->nfc_data;
+    NfcDeviceCommonData* result = &nfc_worker->dev_data->nfc_data;
 
     while(nfc_worker->state == NfcWorkerStateDetect) {
         if(furi_hal_nfc_detect(&dev_list, &dev_cnt, 1000, true)) {
@@ -141,7 +141,7 @@ void nfc_worker_detect(NfcWorker* nfc_worker) {
 }
 
 void nfc_worker_emulate(NfcWorker* nfc_worker) {
-    NfcDeviceCommomData* data = &nfc_worker->dev_data->nfc_data;
+    NfcDeviceCommonData* data = &nfc_worker->dev_data->nfc_data;
     while(nfc_worker->state == NfcWorkerStateEmulate) {
         if(furi_hal_nfc_listen(data->uid, data->uid_len, data->atqa, data->sak, false, 100)) {
             FURI_LOG_I(NFC_WORKER_TAG, "Reader detected");
@@ -364,7 +364,7 @@ void nfc_worker_emulate_apdu(NfcWorker* nfc_worker) {
     uint16_t tx_len = 0;
     uint8_t* rx_buff;
     uint16_t* rx_len;
-    NfcDeviceCommomData params = {
+    NfcDeviceCommonData params = {
         .uid = {0xCF, 0x72, 0xd4, 0x40},
         .uid_len = 4,
         .atqa = {0x00, 0x04},

--- a/applications/nfc/scenes/nfc_scene_delete.c
+++ b/applications/nfc/scenes/nfc_scene_delete.c
@@ -18,7 +18,7 @@ void nfc_scene_delete_on_enter(void* context) {
     widget_add_button_element(
         nfc->widget, GuiButtonTypeRight, "Delete", nfc_scene_delete_widget_callback, nfc);
     char uid_str[32];
-    NfcDeviceCommomData* data = &nfc->dev.dev_data.nfc_data;
+    NfcDeviceCommonData* data = &nfc->dev.dev_data.nfc_data;
     if(data->uid_len == 4) {
         snprintf(
             uid_str,

--- a/applications/nfc/scenes/nfc_scene_device_info.c
+++ b/applications/nfc/scenes/nfc_scene_device_info.c
@@ -38,7 +38,7 @@ void nfc_scene_device_info_on_enter(void* context) {
     widget_add_button_element(
         nfc->widget, GuiButtonTypeRight, "Data", nfc_scene_device_info_widget_callback, nfc);
     char uid_str[32];
-    NfcDeviceCommomData* data = &nfc->dev.dev_data.nfc_data;
+    NfcDeviceCommonData* data = &nfc->dev.dev_data.nfc_data;
     if(data->uid_len == 4) {
         snprintf(
             uid_str,

--- a/applications/nfc/scenes/nfc_scene_emulate_uid.c
+++ b/applications/nfc/scenes/nfc_scene_emulate_uid.c
@@ -5,7 +5,7 @@ const void nfc_scene_emulate_uid_on_enter(void* context) {
 
     // Setup view
     Popup* popup = nfc->popup;
-    NfcDeviceCommomData* data = &nfc->dev.dev_data.nfc_data;
+    NfcDeviceCommonData* data = &nfc->dev.dev_data.nfc_data;
 
     if(strcmp(nfc->dev.dev_name, "")) {
         nfc_text_store_set(nfc, "%s", nfc->dev.dev_name);

--- a/applications/nfc/scenes/nfc_scene_read_card_success.c
+++ b/applications/nfc/scenes/nfc_scene_read_card_success.c
@@ -18,7 +18,7 @@ void nfc_scene_read_card_success_on_enter(void* context) {
     notification_message(nfc->notifications, &sequence_success);
 
     // Setup view
-    NfcDeviceCommomData* data = (NfcDeviceCommomData*)&nfc->dev.dev_data.nfc_data;
+    NfcDeviceCommonData* data = (NfcDeviceCommonData*)&nfc->dev.dev_data.nfc_data;
     DialogEx* dialog_ex = nfc->dialog_ex;
     dialog_ex_set_left_button_text(dialog_ex, "Retry");
     dialog_ex_set_right_button_text(dialog_ex, "More");

--- a/applications/nfc/scenes/nfc_scene_read_emv_app_success.c
+++ b/applications/nfc/scenes/nfc_scene_read_emv_app_success.c
@@ -13,7 +13,7 @@ void nfc_scene_read_emv_app_success_on_enter(void* context) {
     Nfc* nfc = (Nfc*)context;
 
     // Setup view
-    NfcDeviceCommomData* nfc_data = &nfc->dev.dev_data.nfc_data;
+    NfcDeviceCommonData* nfc_data = &nfc->dev.dev_data.nfc_data;
     NfcEmvData* emv_data = &nfc->dev.dev_data.emv_data;
     DialogEx* dialog_ex = nfc->dialog_ex;
     dialog_ex_set_left_button_text(dialog_ex, "Retry");

--- a/applications/nfc/scenes/nfc_scene_read_emv_data_success.c
+++ b/applications/nfc/scenes/nfc_scene_read_emv_data_success.c
@@ -10,7 +10,7 @@ void nfc_scene_read_emv_data_success_widget_callback(GuiButtonType result, void*
 void nfc_scene_read_emv_data_success_on_enter(void* context) {
     Nfc* nfc = (Nfc*)context;
     NfcEmvData* emv_data = &nfc->dev.dev_data.emv_data;
-    NfcDeviceCommomData* nfc_data = &nfc->dev.dev_data.nfc_data;
+    NfcDeviceCommonData* nfc_data = &nfc->dev.dev_data.nfc_data;
 
     // Clear device name
     nfc_device_set_name(&nfc->dev, "");

--- a/applications/nfc/scenes/nfc_scene_read_mifare_ul_success.c
+++ b/applications/nfc/scenes/nfc_scene_read_mifare_ul_success.c
@@ -30,7 +30,7 @@ const void nfc_scene_read_mifare_ul_success_on_enter(void* context) {
     notification_message(nfc->notifications, &sequence_success);
 
     // Setup dialog view
-    NfcDeviceCommomData* data = (NfcDeviceCommomData*)&nfc->dev.dev_data.nfc_data;
+    NfcDeviceCommonData* data = (NfcDeviceCommonData*)&nfc->dev.dev_data.nfc_data;
     DialogEx* dialog_ex = nfc->dialog_ex;
     dialog_ex_set_left_button_text(dialog_ex, "Retry");
     dialog_ex_set_right_button_text(dialog_ex, "More");


### PR DESCRIPTION
# What's new

- Renamed `NfcDeviceCommomData` to `NfcDeviceCommonData`

# Verification 

- The project builds successfully

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
