### PR TITLE
[FL-1811] FuriHal: move core2 startup to hal init stage, prevent working with flash controller till core2 startup finish.

### DIFF
--- a/applications/bt/bt_service/bt.c
+++ b/applications/bt/bt_service/bt.c
@@ -62,7 +62,6 @@ Bt* bt_alloc() {
 int32_t bt_srv() {
     Bt* bt = bt_alloc();
     furi_record_create("bt", bt);
-    furi_hal_bt_init();
 
     if(!furi_hal_bt_wait_startup()) {
         FURI_LOG_E(BT_SERVICE_TAG, "Core2 startup failed");

--- a/firmware/targets/f6/ble-glue/app_entry.c
+++ b/firmware/targets/f6/ble-glue/app_entry.c
@@ -138,8 +138,10 @@ static void APPE_SysUserEvtRx( void * pPayload ) {
   // APPD_EnableCPU2( );
   
   if (APP_BLE_Init()) {
+    FURI_LOG_I("Core2", "BLE stack started");
     ble_glue_status = BleGlueStatusStarted;
   } else {
+    FURI_LOG_E("Core2", "BLE stack startup failed");
     ble_glue_status = BleGlueStatusBroken;
   }
   furi_hal_power_insomnia_exit();

--- a/firmware/targets/f6/furi-hal/furi-hal.c
+++ b/firmware/targets/f6/furi-hal/furi-hal.c
@@ -47,6 +47,7 @@ void furi_hal_init() {
     furi_hal_subghz_init();
     furi_hal_nfc_init();
     furi_hal_rfid_init();
+    furi_hal_bt_init();
 
     // FreeRTOS glue
     furi_hal_os_init();

--- a/firmware/targets/f7/ble-glue/app_entry.c
+++ b/firmware/targets/f7/ble-glue/app_entry.c
@@ -138,8 +138,10 @@ static void APPE_SysUserEvtRx( void * pPayload ) {
   // APPD_EnableCPU2( );
   
   if (APP_BLE_Init()) {
+    FURI_LOG_I("Core2", "BLE stack started");
     ble_glue_status = BleGlueStatusStarted;
   } else {
+    FURI_LOG_E("Core2", "BLE stack startup failed");
     ble_glue_status = BleGlueStatusBroken;
   }
   furi_hal_power_insomnia_exit();

--- a/firmware/targets/f7/furi-hal/furi-hal.c
+++ b/firmware/targets/f7/furi-hal/furi-hal.c
@@ -47,6 +47,7 @@ void furi_hal_init() {
     furi_hal_subghz_init();
     furi_hal_nfc_init();
     furi_hal_rfid_init();
+    furi_hal_bt_init();
 
     // FreeRTOS glue
     furi_hal_os_init();


### PR DESCRIPTION
# What's new

- FuriHal: move core2 startup to hal init stage
- FuriHal: prevent working with flash controller till core2 startup finish.

# Verification 

- Compile and upload
- No more crashes on startup

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
