### PR TITLE
[FL-1816] Fix ble radio stack is alive check. Fix random crashes on storage use.

### DIFF
--- a/applications/bt/bt_service/bt.c
+++ b/applications/bt/bt_service/bt.c
@@ -67,17 +67,17 @@ int32_t bt_srv() {
         }
     }
     // Update statusbar
-    view_port_enabled_set(bt->statusbar_view_port, furi_hal_bt_is_alive());
+    view_port_enabled_set(bt->statusbar_view_port, furi_hal_bt_is_active());
 
     BtMessage message;
     while(1) {
         furi_check(osMessageQueueGet(bt->message_queue, &message, NULL, osWaitForever) == osOK);
         if(message.type == BtMessageTypeUpdateStatusbar) {
             // Update statusbar
-            view_port_enabled_set(bt->statusbar_view_port, furi_hal_bt_is_alive());
+            view_port_enabled_set(bt->statusbar_view_port, furi_hal_bt_is_active());
         } else if(message.type == BtMessageTypeUpdateBatteryLevel) {
             // Update battery level
-            if(furi_hal_bt_is_alive()) {
+            if(furi_hal_bt_is_active()) {
                 battery_svc_update_level(message.data.battery_level);
             }
         } else if(message.type == BtMessageTypePinCodeShow) {

--- a/applications/cli/cli_commands.c
+++ b/applications/cli/cli_commands.c
@@ -385,17 +385,18 @@ void cli_command_ps(Cli* cli, string_t args, void* context) {
     const uint8_t threads_num_max = 32;
     osThreadId_t threads_id[threads_num_max];
     uint8_t thread_num = osThreadEnumerate(threads_id, threads_num_max);
-    printf("%d threads in total:\r\n", thread_num);
-    printf("%-20s %-14s %-14s %s\r\n", "Name", "Stack start", "Stack alloc", "Stack watermark");
+    printf("%-20s %-14s %-8s %-8s %s\r\n", "Name", "Stack start", "Heap", "Stack", "Stack min free");
     for(uint8_t i = 0; i < thread_num; i++) {
         TaskControlBlock* tcb = (TaskControlBlock*)threads_id[i];
         printf(
-            "%-20s 0x%-12lx %-14ld %ld\r\n",
+            "%-20s 0x%-12lx %-8d %-8ld %-8ld\r\n",
             osThreadGetName(threads_id[i]),
             (uint32_t)tcb->pxStack,
-            (uint32_t)(tcb->pxEndOfStack - tcb->pxStack + 1) * sizeof(uint32_t),
-            osThreadGetStackSpace(threads_id[i]) * sizeof(uint32_t));
+            memmgr_heap_get_thread_memory(threads_id[i]),
+            (uint32_t)(tcb->pxEndOfStack - tcb->pxStack + 1) * sizeof(StackType_t),
+            osThreadGetStackSpace(threads_id[i]));
     }
+    printf("\r\nTotal: %d", thread_num);
 }
 
 void cli_command_free(Cli* cli, string_t args, void* context) {

--- a/applications/cli/cli_commands.c
+++ b/applications/cli/cli_commands.c
@@ -385,7 +385,8 @@ void cli_command_ps(Cli* cli, string_t args, void* context) {
     const uint8_t threads_num_max = 32;
     osThreadId_t threads_id[threads_num_max];
     uint8_t thread_num = osThreadEnumerate(threads_id, threads_num_max);
-    printf("%-20s %-14s %-8s %-8s %s\r\n", "Name", "Stack start", "Heap", "Stack", "Stack min free");
+    printf(
+        "%-20s %-14s %-8s %-8s %s\r\n", "Name", "Stack start", "Heap", "Stack", "Stack min free");
     for(uint8_t i = 0; i < thread_num; i++) {
         TaskControlBlock* tcb = (TaskControlBlock*)threads_id[i];
         printf(

--- a/core/furi/memmgr_heap.c
+++ b/core/furi/memmgr_heap.c
@@ -155,19 +155,20 @@ void memmgr_heap_disable_thread_trace(osThreadId_t thread_id) {
 }
 
 size_t memmgr_heap_get_thread_memory(osThreadId_t thread_id) {
-    size_t leftovers = 0;
+    size_t leftovers = MEMMGR_HEAP_UNKNOWN;
     vTaskSuspendAll();
     {
         memmgr_heap_thread_trace_depth++;
         MemmgrHeapAllocDict_t* alloc_dict =
             MemmgrHeapThreadDict_get(memmgr_heap_thread_dict, (uint32_t)thread_id);
-        furi_check(alloc_dict);
-        MemmgrHeapAllocDict_it_t alloc_dict_it;
-        for(MemmgrHeapAllocDict_it(alloc_dict_it, *alloc_dict);
-            !MemmgrHeapAllocDict_end_p(alloc_dict_it);
-            MemmgrHeapAllocDict_next(alloc_dict_it)) {
-            MemmgrHeapAllocDict_itref_t* data = MemmgrHeapAllocDict_ref(alloc_dict_it);
-            leftovers += data->value;
+        if(alloc_dict) {
+            MemmgrHeapAllocDict_it_t alloc_dict_it;
+            for(MemmgrHeapAllocDict_it(alloc_dict_it, *alloc_dict);
+                !MemmgrHeapAllocDict_end_p(alloc_dict_it);
+                MemmgrHeapAllocDict_next(alloc_dict_it)) {
+                MemmgrHeapAllocDict_itref_t* data = MemmgrHeapAllocDict_ref(alloc_dict_it);
+                leftovers += data->value;
+            }
         }
         memmgr_heap_thread_trace_depth--;
     }

--- a/core/furi/memmgr_heap.c
+++ b/core/furi/memmgr_heap.c
@@ -162,6 +162,7 @@ size_t memmgr_heap_get_thread_memory(osThreadId_t thread_id) {
         MemmgrHeapAllocDict_t* alloc_dict =
             MemmgrHeapThreadDict_get(memmgr_heap_thread_dict, (uint32_t)thread_id);
         if(alloc_dict) {
+            leftovers = 0;
             MemmgrHeapAllocDict_it_t alloc_dict_it;
             for(MemmgrHeapAllocDict_it(alloc_dict_it, *alloc_dict);
                 !MemmgrHeapAllocDict_end_p(alloc_dict_it);

--- a/core/furi/memmgr_heap.h
+++ b/core/furi/memmgr_heap.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+#define MEMMGR_HEAP_UNKNOWN 0xFFFFFFFF
+
 /** Memmgr heap enable thread allocation tracking
  * @param thread_id - thread id to track
  */

--- a/firmware/targets/f6/furi-hal/furi-hal-bt.c
+++ b/firmware/targets/f6/furi-hal/furi-hal-bt.c
@@ -52,7 +52,8 @@ void furi_hal_bt_dump_state(string_t buffer) {
 }
 
 bool furi_hal_bt_is_alive() {
-    return APPE_Status() == BleGlueStatusStarted;
+    BleGlueStatus status = APPE_Status();
+    return (status == BleGlueStatusBroken) || (status == BleGlueStatusStarted);
 }
 
 bool furi_hal_bt_is_active() {

--- a/firmware/targets/f6/furi-hal/furi-hal-bt.c
+++ b/firmware/targets/f6/furi-hal/furi-hal-bt.c
@@ -24,7 +24,7 @@ void furi_hal_bt_start_advertising() {
 }
 
 void furi_hal_bt_stop_advertising() {
-    if(furi_hal_bt_is_alive()) {
+    if(furi_hal_bt_is_active()) {
         gap_stop_advertising();
     }
 }
@@ -52,6 +52,10 @@ void furi_hal_bt_dump_state(string_t buffer) {
 }
 
 bool furi_hal_bt_is_alive() {
+    return APPE_Status() == BleGlueStatusStarted;
+}
+
+bool furi_hal_bt_is_active() {
     return gap_get_state() > GapStateIdle;
 }
 

--- a/firmware/targets/f6/furi-hal/furi-hal-flash.c
+++ b/firmware/targets/f6/furi-hal/furi-hal-flash.c
@@ -57,7 +57,7 @@ size_t furi_hal_flash_get_free_page_count() {
 }
 
 bool furi_hal_flash_erase(uint8_t page, uint8_t count) {
-    if (!furi_hal_bt_lock_flash()) {
+    if (!furi_hal_bt_lock_flash(true)) {
         return false;
     }
     FLASH_EraseInitTypeDef erase;
@@ -66,24 +66,24 @@ bool furi_hal_flash_erase(uint8_t page, uint8_t count) {
     erase.NbPages = count;
     uint32_t error;
     HAL_StatusTypeDef status = HAL_FLASHEx_Erase(&erase, &error);
-    furi_hal_bt_unlock_flash();
+    furi_hal_bt_unlock_flash(true);
     return status == HAL_OK;
 }
 
 bool furi_hal_flash_write_dword(size_t address, uint64_t data) {
-    if (!furi_hal_bt_lock_flash()) {
+    if (!furi_hal_bt_lock_flash(false)) {
         return false;
     }
     HAL_StatusTypeDef status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, address, data);
-    furi_hal_bt_unlock_flash();
+    furi_hal_bt_unlock_flash(false);
     return status == HAL_OK;
 }
 
 bool furi_hal_flash_write_dword_from(size_t address, size_t source_address) {
-    if (!furi_hal_bt_lock_flash()) {
+    if (!furi_hal_bt_lock_flash(false)) {
         return false;
     }
     HAL_StatusTypeDef status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_FAST, address, source_address);
-    furi_hal_bt_unlock_flash();
+    furi_hal_bt_unlock_flash(false);
     return status == HAL_OK;
 }

--- a/firmware/targets/f7/furi-hal/furi-hal-bt.c
+++ b/firmware/targets/f7/furi-hal/furi-hal-bt.c
@@ -52,7 +52,8 @@ void furi_hal_bt_dump_state(string_t buffer) {
 }
 
 bool furi_hal_bt_is_alive() {
-    return APPE_Status() == BleGlueStatusStarted;
+    BleGlueStatus status = APPE_Status();
+    return (status == BleGlueStatusBroken) || (status == BleGlueStatusStarted);
 }
 
 bool furi_hal_bt_is_active() {

--- a/firmware/targets/f7/furi-hal/furi-hal-bt.c
+++ b/firmware/targets/f7/furi-hal/furi-hal-bt.c
@@ -24,7 +24,7 @@ void furi_hal_bt_start_advertising() {
 }
 
 void furi_hal_bt_stop_advertising() {
-    if(furi_hal_bt_is_alive()) {
+    if(furi_hal_bt_is_active()) {
         gap_stop_advertising();
     }
 }
@@ -52,6 +52,10 @@ void furi_hal_bt_dump_state(string_t buffer) {
 }
 
 bool furi_hal_bt_is_alive() {
+    return APPE_Status() == BleGlueStatusStarted;
+}
+
+bool furi_hal_bt_is_active() {
     return gap_get_state() > GapStateIdle;
 }
 

--- a/firmware/targets/f7/furi-hal/furi-hal-flash.c
+++ b/firmware/targets/f7/furi-hal/furi-hal-flash.c
@@ -57,7 +57,7 @@ size_t furi_hal_flash_get_free_page_count() {
 }
 
 bool furi_hal_flash_erase(uint8_t page, uint8_t count) {
-    if (!furi_hal_bt_lock_flash()) {
+    if (!furi_hal_bt_lock_flash(true)) {
         return false;
     }
     FLASH_EraseInitTypeDef erase;
@@ -66,24 +66,24 @@ bool furi_hal_flash_erase(uint8_t page, uint8_t count) {
     erase.NbPages = count;
     uint32_t error;
     HAL_StatusTypeDef status = HAL_FLASHEx_Erase(&erase, &error);
-    furi_hal_bt_unlock_flash();
+    furi_hal_bt_unlock_flash(true);
     return status == HAL_OK;
 }
 
 bool furi_hal_flash_write_dword(size_t address, uint64_t data) {
-    if (!furi_hal_bt_lock_flash()) {
+    if (!furi_hal_bt_lock_flash(false)) {
         return false;
     }
     HAL_StatusTypeDef status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, address, data);
-    furi_hal_bt_unlock_flash();
+    furi_hal_bt_unlock_flash(false);
     return status == HAL_OK;
 }
 
 bool furi_hal_flash_write_dword_from(size_t address, size_t source_address) {
-    if (!furi_hal_bt_lock_flash()) {
+    if (!furi_hal_bt_lock_flash(false)) {
         return false;
     }
     HAL_StatusTypeDef status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_FAST, address, source_address);
-    furi_hal_bt_unlock_flash();
+    furi_hal_bt_unlock_flash(false);
     return status == HAL_OK;
 }

--- a/firmware/targets/furi-hal-include/furi-hal-bt.h
+++ b/firmware/targets/furi-hal-include/furi-hal-bt.h
@@ -19,6 +19,9 @@ void furi_hal_bt_start_advertising();
 /** Stop advertising */
 void furi_hal_bt_stop_advertising();
 
+/** Returns true if BLE is advertising */
+bool furi_hal_bt_is_active();
+
 /** Get BT/BLE system component state */
 void furi_hal_bt_dump_state(string_t buffer);
 

--- a/firmware/targets/furi-hal-include/furi-hal-bt.h
+++ b/firmware/targets/furi-hal-include/furi-hal-bt.h
@@ -35,10 +35,10 @@ bool furi_hal_bt_wait_startup();
  * Lock shared access to flash controller
  * @return true if lock was successful, false if not
  */
-bool furi_hal_bt_lock_flash();
+bool furi_hal_bt_lock_flash(bool erase_flag);
 
 /** Unlock shared access to flash controller */
-void furi_hal_bt_unlock_flash();
+void furi_hal_bt_unlock_flash(bool erase_flag);
 
 /** Start ble tone tx at given channel and power */
 void furi_hal_bt_start_tone_tx(uint8_t channel, uint8_t power);


### PR DESCRIPTION
# What's new

- Fix ble radio stack is alive return
- Add bt_is_active, indicating if advertising is active or not

# Verification 

- Check device_info with Bluetooth turning off

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
