### PR TITLE
[FL-1747] iButton: fix forgotten timer IRQ

### DIFF
--- a/applications/ibutton/helpers/pulse-sequencer.cpp
+++ b/applications/ibutton/helpers/pulse-sequencer.cpp
@@ -54,6 +54,8 @@ void PulseSequencer::init_timer(uint32_t period) {
         Error_Handler();
     }
 
+    HAL_NVIC_EnableIRQ(TIM1_UP_TIM16_IRQn);
+
     hal_gpio_init(&ibutton_gpio, GpioModeOutputOpenDrain, GpioPullNo, GpioSpeedLow);
 }
 


### PR DESCRIPTION
# What's new

- iButton: fix forgotten timer IRQ. Cyfral and Metakom can now be correctly emulated.

# Verification 

- Try to emulate Cyfral and Metakom.

# Checklist (do not modify)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
