### PR TITLE
[FL-1881] iButton cli: enable "OTG" when performing "onewire search"

### DIFF
--- a/applications/ibutton/ibutton-cli.cpp
+++ b/applications/ibutton/ibutton-cli.cpp
@@ -248,6 +248,8 @@ void onewire_cli_search(Cli* cli) {
     printf("Search started\r\n");
 
     onewire.start();
+    furi_hal_power_enable_otg();
+
     while(!done) {
         if(onewire.search(address, true) != 1) {
             printf("Search finished\r\n");
@@ -263,6 +265,8 @@ void onewire_cli_search(Cli* cli) {
         }
         delay(100);
     }
+
+    furi_hal_power_disable_otg();
     onewire.stop();
 }
 


### PR DESCRIPTION
# What's new

- Enable "OTG" power when performing "onewire search".

# Verification 

- CLI command "onewire search" now searches correctly even when no USB power is available.

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
