### PR TITLE
[FL-1850] Archive: limit name length in text input view

### DIFF
--- a/applications/applications.c
+++ b/applications/applications.c
@@ -259,7 +259,7 @@ const FlipperApplication FLIPPER_SETTINGS_APPS[] = {
     {.app = power_settings_app, .name = "Power", .stack_size = 1024, .icon = NULL},
 #endif
 
-#ifdef APP_DESKTOP
+#ifdef SRV_DESKTOP
     {.app = desktop_settings_app, .name = "Desktop", .stack_size = 1024, .icon = NULL},
 #endif
 

--- a/applications/archive/scenes/archive_scene_rename.c
+++ b/applications/archive/scenes/archive_scene_rename.c
@@ -4,6 +4,7 @@
 #include "../helpers/archive_browser.h"
 
 #define SCENE_RENAME_CUSTOM_EVENT (0UL)
+#define MAX_TEXT_INPUT_LEN 22
 
 void archive_scene_rename_text_input_callback(void* context) {
     ArchiveApp* archive = (ArchiveApp*)context;
@@ -26,7 +27,7 @@ void archive_scene_rename_on_enter(void* context) {
         archive_scene_rename_text_input_callback,
         archive,
         archive->text_store,
-        MAX_NAME_LEN,
+        MAX_TEXT_INPUT_LEN,
         false);
 
     view_dispatcher_switch_to_view(archive->view_dispatcher, ArchiveViewTextInput);


### PR DESCRIPTION
# What's new

- Fix max name length in text input view
- Fix desktop settings autostart

# Verification 

- Flash
- Try to rename key in archive

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
