### PR TITLE
Loader: forget menu position on main menu reentry, proper NULL arg passing. Gui: set current item for menu gui module.

### DIFF
--- a/applications/applications.mk
+++ b/applications/applications.mk
@@ -204,7 +204,7 @@ CFLAGS		+= -DSRV_LOADER
 SRV_GUI		= 1
 # Loader autostart hook
 LOADER_AUTOSTART ?= ""
-ifneq ($(strip $(LOADER_AUTOSTART)),)
+ifneq ($(strip $(LOADER_AUTOSTART)), "")
 CFLAGS		+= -DLOADER_AUTOSTART="\"$(LOADER_AUTOSTART)\""
 endif
 # Loader autostart hook END

--- a/applications/gui/modules/menu.c
+++ b/applications/gui/modules/menu.c
@@ -160,6 +160,18 @@ void menu_clean(Menu* menu) {
         });
 }
 
+void menu_set_selected_item(Menu* menu, uint32_t index) {
+    with_view_model(
+        menu->view, (MenuModel * model) {
+            if(index >= MenuItemArray_size(model->items)) {
+                return false;
+            }
+
+            model->position = index;
+            return true;
+        });
+}
+
 static void menu_process_up(Menu* menu) {
     with_view_model(
         menu->view, (MenuModel * model) {

--- a/applications/gui/modules/menu.h
+++ b/applications/gui/modules/menu.h
@@ -47,6 +47,12 @@ void menu_add_item(
  */
 void menu_clean(Menu* menu);
 
+/** Set current menu item
+ * @param submenu
+ * @param index
+ */
+void menu_set_selected_item(Menu* menu, uint32_t index);
+
 #ifdef __cplusplus
 }
 #endif

--- a/applications/loader/loader.c
+++ b/applications/loader/loader.c
@@ -90,9 +90,11 @@ bool loader_start(Loader* instance, const char* name, const char* args) {
     }
 
     instance->current_app = flipper_app;
+    void* thread_args = NULL;
     if(args) {
         string_set_str(instance->args, args);
         string_strim(instance->args);
+        thread_args = (void*)string_get_cstr(instance->args);
         FURI_LOG_I(LOADER_LOG_TAG, "Start %s app with args: %s", name, args);
     } else {
         string_clean(instance->args);
@@ -101,7 +103,7 @@ bool loader_start(Loader* instance, const char* name, const char* args) {
 
     furi_thread_set_name(instance->thread, flipper_app->name);
     furi_thread_set_stack_size(instance->thread, flipper_app->stack_size);
-    furi_thread_set_context(instance->thread, (void*)string_get_cstr(instance->args));
+    furi_thread_set_context(instance->thread, thread_args);
     furi_thread_set_callback(instance->thread, flipper_app->app);
 
     return furi_thread_start(instance->thread);
@@ -352,6 +354,7 @@ int32_t loader_srv(void* p) {
     while(1) {
         uint32_t flags = osThreadFlagsWait(LOADER_THREAD_FLAG_ALL, osFlagsWaitAny, osWaitForever);
         if(flags & LOADER_THREAD_FLAG_SHOW_MENU) {
+            menu_set_selected_item(loader_instance->primary_menu, 0);
             view_dispatcher_switch_to_view(
                 loader_instance->view_dispatcher, LoaderMenuViewPrimary);
             view_dispatcher_run(loader_instance->view_dispatcher);


### PR DESCRIPTION
# What's new

- Loader: forget menu position on main menu reentry, proper NULL arg passing. 
- Gui: set current item for menu gui module.

# Verification 

- Compile and upload 
- Reentering main menu now resets position
- Starting application throw loader with NULL arg is fixed

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
