### PR TITLE
[FL-1917] Archive: fix duplicates in favorites

### DIFF
--- a/applications/archive/helpers/archive_browser.c
+++ b/applications/archive/helpers/archive_browser.c
@@ -10,7 +10,7 @@ void archive_update_offset(ArchiveBrowserView* browser) {
 
             if(array_size > 3 && model->idx >= array_size - 1) {
                 model->list_offset = model->idx - 3;
-            } else if(model->last_offset && model->last_offset != model->list_offset) {
+            } else if(model->last_offset != model->list_offset && model->tab_idx == model->last_tab) {
                 model->list_offset = model->last_offset;
                 model->last_offset = !model->last_offset;
             } else if(model->list_offset < model->idx - bounds) {
@@ -18,7 +18,6 @@ void archive_update_offset(ArchiveBrowserView* browser) {
             } else if(model->list_offset > model->idx - bounds) {
                 model->list_offset = CLAMP(model->idx - 1, array_size - bounds, 0);
             }
-
             return true;
         });
 }

--- a/applications/archive/helpers/archive_browser.c
+++ b/applications/archive/helpers/archive_browser.c
@@ -10,7 +10,9 @@ void archive_update_offset(ArchiveBrowserView* browser) {
 
             if(array_size > 3 && model->idx >= array_size - 1) {
                 model->list_offset = model->idx - 3;
-            } else if(model->last_offset != model->list_offset && model->tab_idx == model->last_tab) {
+            } else if(
+                model->last_offset && model->last_offset != model->list_offset &&
+                model->tab_idx == model->last_tab) {
                 model->list_offset = model->last_offset;
                 model->last_offset = !model->last_offset;
             } else if(model->list_offset < model->idx - bounds) {


### PR DESCRIPTION
# What's new

- Fix wrong last_offset usage when switching to new tab in archive

# Verification 

- Build, Flash
- Switching to favorites from browser sub-folders should work correctly

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
