### PR TITLE
Bump default target to f7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   TARGETS: f6 f7
-  DEFAULT_TARGET: f6
+  DEFAULT_TARGET: f7
 
 jobs:
   build:

--- a/bootloader/Makefile
+++ b/bootloader/Makefile
@@ -8,7 +8,7 @@ ASM_SOURCES		+= $(wildcard src/*.s)
 C_SOURCES		+= $(wildcard src/*.c)
 CPP_SOURCES		+= $(wildcard src/*.cpp)
 
-TARGET			?= f6
+TARGET			?= f7
 TARGET_DIR		= targets/$(TARGET)
 include			$(TARGET_DIR)/target.mk
 

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -12,7 +12,7 @@ CFLAGS			+= -I$(PROJECT_ROOT) -Itargets/furi-hal-include
 CFLAGS			+= -Werror -Wno-address-of-packed-member
 CPPFLAGS		+= -Werror
 
-TARGET			?= f6
+TARGET			?= f7
 TARGET_DIR		= targets/$(TARGET)
 include			$(TARGET_DIR)/target.mk
 


### PR DESCRIPTION
# What's new

- f7 is now the default target. やった！

# Verification 

- The link in the comment below points to the f7 binary

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
