### PR TITLE
[FL-1945] Firmware, Scripts, Cli: add OTPv2, alternative displays support and 2-step OTP programming.

### DIFF
--- a/applications/cli/cli_commands.c
+++ b/applications/cli/cli_commands.c
@@ -57,10 +57,6 @@ static const uint8_t enclave_signature_expected[ENCLAVE_SIGNATURE_KEY_SLOTS][ENC
 void cli_command_device_info(Cli* cli, string_t args, void* context) {
     // Model name
     printf("hardware_model      : %s\r\n", furi_hal_version_get_model_name());
-    const char* name = furi_hal_version_get_name_ptr();
-    if(name) {
-        printf("hardware_name       : %s\r\n", name);
-    }
 
     // Unique ID
     printf("hardware_uid        : ");
@@ -70,16 +66,24 @@ void cli_command_device_info(Cli* cli, string_t args, void* context) {
     }
     printf("\r\n");
 
+    // OTP Revision
+    printf("hardware_otp_ver    : %d\r\n", furi_hal_version_get_otp_version());
+    printf("hardware_timestamp  : %lu\r\n", furi_hal_version_get_hw_timestamp());
+
     // Board Revision
     printf("hardware_ver        : %d\r\n", furi_hal_version_get_hw_version());
     printf("hardware_target     : %d\r\n", furi_hal_version_get_hw_target());
     printf("hardware_body       : %d\r\n", furi_hal_version_get_hw_body());
     printf("hardware_connect    : %d\r\n", furi_hal_version_get_hw_connect());
-    printf("hardware_timestamp  : %lu\r\n", furi_hal_version_get_hw_timestamp());
+    printf("hardware_display    : %d\r\n", furi_hal_version_get_hw_display());
 
-    // Color and Region
+    // Board Personification
     printf("hardware_color      : %d\r\n", furi_hal_version_get_hw_color());
     printf("hardware_region     : %d\r\n", furi_hal_version_get_hw_region());
+    const char* name = furi_hal_version_get_name_ptr();
+    if(name) {
+        printf("hardware_name       : %s\r\n", name);
+    }
 
     // Bootloader Version
     const Version* boot_version = furi_hal_version_get_boot_version();

--- a/firmware/targets/furi-hal-include/furi-hal-version.h
+++ b/firmware/targets/furi-hal-include/furi-hal-version.h
@@ -19,6 +19,15 @@ extern "C" {
 /** BLE symbol + "Flipper " + name */
 #define FURI_HAL_VERSION_DEVICE_NAME_LENGTH (1 + 8 + FURI_HAL_VERSION_ARRAY_NAME_LENGTH)
 
+/** OTP Versions enum */
+typedef enum {
+    FuriHalVersionOtpVersion0=0x00,
+    FuriHalVersionOtpVersion1=0x01,
+    FuriHalVersionOtpVersion2=0x02,
+    FuriHalVersionOtpVersionEmpty=0xFFFFFFFE,
+    FuriHalVersionOtpVersionUnknown=0xFFFFFFFF,
+} FuriHalVersionOtpVersion;
+
 /** Device Colors */
 typedef enum {
     FuriHalVersionColorUnknown=0x00,
@@ -33,6 +42,13 @@ typedef enum {
     FuriHalVersionRegionUsCaAu=0x02,
     FuriHalVersionRegionJp=0x03,
 } FuriHalVersionRegion;
+
+/** Device Display */
+typedef enum {
+    FuriHalVersionDisplayUnknown=0x00,
+    FuriHalVersionDisplayErc=0x01,
+    FuriHalVersionDisplayMgg=0x02,
+} FuriHalVersionDisplay;
 
 /** Init flipper version
  */
@@ -49,6 +65,12 @@ bool furi_hal_version_do_i_belong_here();
  * @return     model name C-string
  */
 const char* furi_hal_version_get_model_name();
+
+/** Get OTP version
+ *
+ * @return     OTP Version
+ */
+const FuriHalVersionOtpVersion furi_hal_version_get_otp_version();
 
 /** Get hardware version
  *
@@ -85,6 +107,12 @@ const uint8_t furi_hal_version_get_hw_connect();
  * @return     Hardware Region
  */
 const FuriHalVersionRegion furi_hal_version_get_hw_region();
+
+/** Get hardware display id
+ *
+ * @return     Display id
+ */
+const FuriHalVersionDisplay furi_hal_version_get_hw_display();
 
 /** Get hardware timestamp
  *


### PR DESCRIPTION
# What's new

- Firmware, Scripts, Cli: add OTPv2, alternative displays support and 2-step OTP programming.

# Verification 

- Compile and upload
- Use otp.py to flash OTP memory

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
