### PR TITLE
[FL-1961] Cli: device_info format versioning. Detach target from firmware name.

### DIFF
--- a/applications/about/about.c
+++ b/applications/about/about.c
@@ -110,7 +110,7 @@ static DialogMessageButton fw_version_screen(DialogsApp* dialogs, DialogMessage*
     } else {
         string_cat_printf(
             buffer,
-            "%s [%s]\n%s [%s]\n[%s] %s",
+            "%s [%s]\n%s [%s]\n[%d] %s",
             version_get_version(ver),
             version_get_builddate(ver),
             version_get_githash(ver),
@@ -140,7 +140,7 @@ static DialogMessageButton boot_version_screen(DialogsApp* dialogs, DialogMessag
     } else {
         string_cat_printf(
             buffer,
-            "%s [%s]\n%s [%s]\n[%s] %s",
+            "%s [%s]\n%s [%s]\n[%d] %s",
             version_get_version(ver),
             version_get_builddate(ver),
             version_get_githash(ver),

--- a/applications/cli/cli_commands.c
+++ b/applications/cli/cli_commands.c
@@ -55,6 +55,9 @@ static const uint8_t enclave_signature_expected[ENCLAVE_SIGNATURE_KEY_SLOTS][ENC
  * Keys and values format MUST NOT BE changed
  */
 void cli_command_device_info(Cli* cli, string_t args, void* context) {
+    // Device Info version
+    printf("device_info_major   : %d\r\n", 1);
+    printf("device_info_minor   : %d\r\n", 0);
     // Model name
     printf("hardware_model      : %s\r\n", furi_hal_version_get_model_name());
 
@@ -88,21 +91,23 @@ void cli_command_device_info(Cli* cli, string_t args, void* context) {
     // Bootloader Version
     const Version* boot_version = furi_hal_version_get_boot_version();
     if(boot_version) {
-        printf("boot_version        : %s\r\n", version_get_version(boot_version));
-        printf("boot_target         : %s\r\n", version_get_target(boot_version));
         printf("boot_commit         : %s\r\n", version_get_githash(boot_version));
         printf("boot_branch         : %s\r\n", version_get_gitbranch(boot_version));
+        printf("boot_branch_num     : %s\r\n", version_get_gitbranchnum(boot_version));
+        printf("boot_version        : %s\r\n", version_get_version(boot_version));
         printf("boot_build_date     : %s\r\n", version_get_builddate(boot_version));
+        printf("boot_target         : %d\r\n", version_get_target(boot_version));
     }
 
     // Firmware version
     const Version* firmware_version = furi_hal_version_get_firmware_version();
     if(firmware_version) {
-        printf("firmware_version    : %s\r\n", version_get_version(firmware_version));
-        printf("firmware_target     : %s\r\n", version_get_target(firmware_version));
         printf("firmware_commit     : %s\r\n", version_get_githash(firmware_version));
         printf("firmware_branch     : %s\r\n", version_get_gitbranch(firmware_version));
+        printf("firmware_branch_num : %s\r\n", version_get_gitbranchnum(firmware_version));
+        printf("firmware_version    : %s\r\n", version_get_version(firmware_version));
         printf("firmware_build_date : %s\r\n", version_get_builddate(firmware_version));
+        printf("firmware_target     : %d\r\n", version_get_target(firmware_version));
     }
 
     WirelessFwInfo_t pWirelessInfo;

--- a/applications/desktop/scenes/desktop_scene_hw_mismatch.c
+++ b/applications/desktop/scenes/desktop_scene_hw_mismatch.c
@@ -15,8 +15,9 @@ void desktop_scene_hw_mismatch_on_enter(void* context) {
     snprintf(
         buffer,
         sizeof(buffer),
-        "HW target: F%d\nFW target: " TARGET,
-        furi_hal_version_get_hw_target());
+        "HW target: %d\nFW target: %d",
+        furi_hal_version_get_hw_target(),
+        version_get_target(NULL));
     popup_set_context(popup, desktop);
     popup_set_header(popup, "!!!! HW Mismatch !!!!", 60, 14, AlignCenter, AlignCenter);
     popup_set_text(popup, buffer, 60, 37, AlignCenter, AlignCenter);

--- a/applications/desktop/views/desktop_debug.c
+++ b/applications/desktop/views/desktop_debug.c
@@ -67,7 +67,7 @@ void desktop_debug_render(Canvas* canvas, void* model) {
         canvas_draw_str(canvas, 5, 43, buffer);
 
         snprintf(
-            buffer, sizeof(buffer), "[%s] %s", version_get_target(ver), version_get_gitbranch(ver));
+            buffer, sizeof(buffer), "[%d] %s", version_get_target(ver), version_get_gitbranch(ver));
         canvas_draw_str(canvas, 5, 54, buffer);
 
     } else {

--- a/bootloader/targets/f6/target.mk
+++ b/bootloader/targets/f6/target.mk
@@ -12,6 +12,8 @@ MCU_FLAGS		= -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=hard
 CFLAGS			+= $(MCU_FLAGS) $(BOOT_CFLAGS) -DSTM32WB55xx -Wall -fdata-sections -ffunction-sections
 LDFLAGS			+= $(MCU_FLAGS) -specs=nosys.specs -specs=nano.specs 
 
+HARDWARE_TARGET = 6
+
 CUBE_DIR		= $(PROJECT_ROOT)/lib/STM32CubeWB
 
 # ST HAL

--- a/bootloader/targets/f7/target.mk
+++ b/bootloader/targets/f7/target.mk
@@ -12,6 +12,8 @@ MCU_FLAGS		= -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=hard
 CFLAGS			+= $(MCU_FLAGS) $(BOOT_CFLAGS) -DSTM32WB55xx -Wall -fdata-sections -ffunction-sections
 LDFLAGS			+= $(MCU_FLAGS) -specs=nosys.specs -specs=nano.specs 
 
+HARDWARE_TARGET = 7
+
 CUBE_DIR		= $(PROJECT_ROOT)/lib/STM32CubeWB
 
 # ST HAL

--- a/core/furi/common_defines.h
+++ b/core/furi/common_defines.h
@@ -57,3 +57,11 @@
 #ifndef ALIGN
 #define ALIGN(n) __attribute__((aligned(n)))
 #endif
+
+#ifndef STRINGIFY
+#define STRINGIFY(x) #x
+#endif
+
+#ifndef TOSTRING
+#define TOSTRING(x) STRINGIFY(x)
+#endif

--- a/firmware/targets/f6/ble-glue/dev_info_service.c
+++ b/firmware/targets/f6/ble-glue/dev_info_service.c
@@ -18,7 +18,7 @@ static DevInfoSvc* dev_info_svc = NULL;
 
 static const char dev_info_man_name[] = "Flipper Devices Inc.";
 static const char dev_info_serial_num[] = "1.0";
-static const char dev_info_firmware_rev_num[] = TARGET;
+static const char dev_info_firmware_rev_num[] = TOSTRING(TARGET);
 static const char dev_info_software_rev_num[] = GIT_COMMIT " " GIT_BRANCH " " GIT_BRANCH_NUM " " BUILD_DATE;
 
 void dev_info_svc_start() {

--- a/firmware/targets/f6/target.mk
+++ b/firmware/targets/f6/target.mk
@@ -24,6 +24,8 @@ LDFLAGS			+= $(MCU_FLAGS) -specs=nosys.specs -specs=nano.specs
 CPPFLAGS		+= -fno-rtti -fno-use-cxa-atexit -fno-exceptions 
 LDFLAGS			+= -Wl,--start-group -lstdc++ -lsupc++ -Wl,--end-group
 
+HARDWARE_TARGET = 6
+
 MXPROJECT_DIR = $(TARGET_DIR)
 
 # Entry Point

--- a/firmware/targets/f7/ble-glue/dev_info_service.c
+++ b/firmware/targets/f7/ble-glue/dev_info_service.c
@@ -18,7 +18,7 @@ static DevInfoSvc* dev_info_svc = NULL;
 
 static const char dev_info_man_name[] = "Flipper Devices Inc.";
 static const char dev_info_serial_num[] = "1.0";
-static const char dev_info_firmware_rev_num[] = TARGET;
+static const char dev_info_firmware_rev_num[] = TOSTRING(TARGET);
 static const char dev_info_software_rev_num[] = GIT_COMMIT " " GIT_BRANCH " " GIT_BRANCH_NUM " " BUILD_DATE;
 
 void dev_info_svc_start() {

--- a/firmware/targets/f7/target.mk
+++ b/firmware/targets/f7/target.mk
@@ -24,6 +24,8 @@ LDFLAGS			+= $(MCU_FLAGS) -specs=nosys.specs -specs=nano.specs
 CPPFLAGS		+= -fno-rtti -fno-use-cxa-atexit -fno-exceptions 
 LDFLAGS			+= -Wl,--start-group -lstdc++ -lsupc++ -Wl,--end-group
 
+HARDWARE_TARGET = 7
+
 MXPROJECT_DIR = $(TARGET_DIR)
 
 # Entry Point

--- a/lib/toolbox/version.c
+++ b/lib/toolbox/version.c
@@ -6,7 +6,7 @@ struct Version {
     const char*  git_branch_num;
     const char*  build_date;
     const char*  version;
-    const char*  target;
+    const uint8_t target;
 };
 
 /* version of current running firmware (bootloader/flipper) */
@@ -44,7 +44,7 @@ const char* version_get_version(const Version* v) {
     return v ? v->version : version.version;
 }
 
-const char* version_get_target(const Version* v) {
+const uint8_t version_get_target(const Version* v) {
     return v ? v->target : version.target;
 }
 

--- a/lib/toolbox/version.h
+++ b/lib/toolbox/version.h
@@ -1,71 +1,76 @@
 #pragma once
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct Version Version;
 
-/**
- * Gets current running firmware version handle.
- * You can store it somewhere. But if you want to retrieve data,
- * you have to use 'version_*_get()' set of functions.
- * Also, 'version_*_get()' imply to use this
+/** Get current running firmware version handle.
+ *
+ * You can store it somewhere. But if you want to retrieve data, you have to use
+ * 'version_*_get()' set of functions. Also, 'version_*_get()' imply to use this
  * handle if no handle (NULL_PTR) provided.
  *
- * @return Handle to version data.
+ * @return     pointer to Version data.
  */
 const Version* version_get(void);
 
-/**
- * Gets git hash of build commit.
+/** Get git commit hash.
  *
- * @param   v - ptr to version handle. If zero - gets current running fw info.
- * @return  git hash
+ * @param      v     pointer to Version data. NULL for currently running
+ *                   software.
+ *
+ * @return     git hash
  */
 const char* version_get_githash(const Version* v);
 
-/**
- * Gets git branch of build commit.
+/** Get git branch.
  *
- * @param   v - ptr to version handle. If zero - gets current running fw info.
- * @return  git branch
+ * @param      v     pointer to Version data. NULL for currently running
+ *                   software.
+ *
+ * @return     git branch
  */
 const char* version_get_gitbranch(const Version* v);
 
-/**
- * Gets git number of build commit.
+/** Get number of commit in git branch.
  *
- * @param   v - ptr to version handle. If zero - gets current running fw info.
- * @return  number of commit
+ * @param      v     pointer to Version data. NULL for currently running
+ *                   software.
+ *
+ * @return     number of commit
  */
 const char* version_get_gitbranchnum(const Version* v);
 
-/**
- * Gets build date.
+/** Get build date.
  *
- * @param   v - ptr to version handle. If zero - gets current running fw info.
- * @return  build date
+ * @param      v     pointer to Version data. NULL for currently running
+ *                   software.
+ *
+ * @return     build date
  */
 const char* version_get_builddate(const Version* v);
 
-/**
- * Gets build version.
- * Build version is last tag in git history.
+/** Get build version. Build version is last tag in git history.
  *
- * @param   v - ptr to version handle. If zero - gets current running fw info.
- * @return  build date
+ * @param      v     pointer to Version data. NULL for currently running
+ *                   software.
+ *
+ * @return     build date
  */
 const char* version_get_version(const Version* v);
 
-/**
- * Gets firmware target.
- * Build version is last tag for build commit.
+/** Get hardware target this firmware was built for
  *
- * @param   v - ptr to version handle. If zero - gets current running fw info.
- * @return  build date
+ * @param      v     pointer to Version data. NULL for currently running
+ *                   software.
+ *
+ * @return     build date
  */
-const char* version_get_target(const Version* v);
+const uint8_t version_get_target(const Version* v);
 
 #ifdef __cplusplus
 }

--- a/make/git.mk
+++ b/make/git.mk
@@ -5,9 +5,9 @@ BUILD_DATE		:= $(shell date '+%d-%m-%Y' || echo 'unknown')
 VERSION			:= $(shell git describe --tags --abbrev=0 --exact-match || echo 'unknown')
 
 CFLAGS += \
-	-DGIT_COMMIT="\"$(GIT_COMMIT)\"" \
-	-DGIT_BRANCH="\"$(GIT_BRANCH)\"" \
-	-DGIT_BRANCH_NUM="\"$(GIT_BRANCH_NUM)\"" \
-	-DBUILD_DATE="\"$(BUILD_DATE)\"" \
-	-DTARGET="\"$(TARGET)\"" \
-	-DVERSION="\"$(VERSION)\""
+	-DGIT_COMMIT=\"$(GIT_COMMIT)\" \
+	-DGIT_BRANCH=\"$(GIT_BRANCH)\" \
+	-DGIT_BRANCH_NUM=\"$(GIT_BRANCH_NUM)\" \
+	-DBUILD_DATE=\"$(BUILD_DATE)\" \
+	-DVERSION=\"$(VERSION)\" \
+	-DTARGET=$(HARDWARE_TARGET)


### PR DESCRIPTION
# What's new

- Cli: device_info format versioning.
- Detach target from firmware name.

# Verification 

- Compile and upload
- Use `device_info` cli command

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
