### PR TITLE
Add single makefile to perform build ops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+bl:
+	docker-compose exec dev make -j$(nproc) -C bootloader
+
+fw:
+	docker-compose exec dev make -j$(nproc) -C firmware
+
+hex: bootloader/.obj/f7/bootloader.hex firmware/.obj/f7/firmware.hex
+	docker-compose exec dev srec_cat bootloader/.obj/f7/bootloader.hex -Intel firmware/.obj/f7/firmware.hex -Intel -o firmware/.obj/f7/full.hex -Intel
+
+dfu: firmware/.obj/f7/full.hex
+	docker-compose exec dev hex2dfu -i firmware/.obj/f7/full.hex -o firmware/.obj/f7/full.dfu -l "Flipper Zero F7"
+
+all: bl fw hex dfu
+
+flash: firmware/.obj/f7/full.dfu
+	dfu-util -D firmware/.obj/f7/full.dfu -a 0
+
+clean-bl:
+	sudo rm -rf bootloader/.obj
+
+clean-fw:
+	sudo rm -rf firmware/.obj
+
+clean: clean-bl clean-fw
+	


### PR DESCRIPTION
# What's new

Created basic Makefile in root that lets you:

1. build each of steps separately:
    - `make bl` for bootloader
    - `make fw` for firmware
    - `make hex` to merge fbootloader and firmware hex files
    - `make dfu` to convert hex to dfu
2. run them one after another with `make all`
3. flash with `make flash`
4. clean-up build artifacts with `make clean`

All according to readme in the root of repository. 
I needed `sudo` for cleanup operations because of some permissions stuff on files created by docker. 

Created PR for you to look at it, as I spoke with Anna on Discord :)

# Verification 

- Probably run those and check the results :)

# Checklist (do not modify)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
