### PR TITLE
[FL-1993] Scripts: remove padding from cli output detection

### DIFF
--- a/scripts/flipper/storage.py
+++ b/scripts/flipper/storage.py
@@ -65,7 +65,7 @@ class FlipperStorage:
         self.port.reset_input_buffer()
         # Send a command with a known syntax to make sure the buffer is flushed
         self.send("device_info\r")
-        self.read.until("hardware_model      :")
+        self.read.until("hardware_model")
         # And read buffer until we get prompt
         self.read.until(self.CLI_PROMPT)
 


### PR DESCRIPTION
# What's new

- Scripts: remove padding from cli output detection

# Verification 

- Compile and upload
- storage.py now should work as expected

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
