### PR TITLE
Use NFC device format when NFC app runs with args

### DIFF
--- a/applications/nfc/nfc.c
+++ b/applications/nfc/nfc.c
@@ -155,7 +155,11 @@ int32_t nfc_app(void* p) {
 
     // Check argument and run corresponding scene
     if((*args != '\0') && nfc_device_load(&nfc->dev, p)) {
-        scene_manager_next_scene(nfc->scene_manager, NfcSceneEmulateUid);
+        if(nfc->dev.format == NfcDeviceSaveFormatMifareUl) {
+            scene_manager_next_scene(nfc->scene_manager, NfcSceneEmulateMifareUl);
+        } else {
+            scene_manager_next_scene(nfc->scene_manager, NfcSceneEmulateUid);
+        }
     } else {
         scene_manager_next_scene(nfc->scene_manager, NfcSceneStart);
     }


### PR DESCRIPTION
# What's new

If I try to run Mf Ul key from favorites, NFC app runs UID emulating instead of Mf Ul emulating.

# Verification 

* Save any Mifare ultralight key
* Go to archive -> NFC -> select this key -> Run in app
* Or pin key, go to archive -> Favorites -> select this key
* Check "Emulating Mf Ultralight" is happening

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
