### PR TITLE
Subghz: fix crash on arg free

### DIFF
--- a/applications/subghz/subghz.c
+++ b/applications/subghz/subghz.c
@@ -288,6 +288,8 @@ int32_t subghz_app(void* p) {
     // Check argument and run corresponding scene
     if(p && subghz_key_load(subghz, p)) {
         string_t filename;
+        string_init(filename);
+
         path_extract_filename_no_ext(p, filename);
         strlcpy(
             subghz->file_name, string_get_cstr(filename), strlen(string_get_cstr(filename)) + 1);


### PR DESCRIPTION
# What's new

- Subghz: fix crash on arg free

# Verification 

- Compile and upload
- Use archive to start subghz

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
