### PR TITLE
Project: enum cast fix. Makefile: blackmagic rule in global makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ flash: bootloader_flash firmware_flash
 debug:
 	$(MAKE) -C firmware -j$(NPROCS) debug
 
+.PHONY: blackmagic
+blackmagic:
+	$(MAKE) -C firmware -j$(NPROCS) blackmagic
+
 .PHONY: wipe
 wipe:
 	$(PROJECT_ROOT)/scripts/flash.py wipe

--- a/applications/subghz/subghz_i.c
+++ b/applications/subghz/subghz_i.c
@@ -345,8 +345,7 @@ bool subghz_save_protocol_to_file(SubGhz* subghz, const char* dev_name) {
             break;
         }
 
-        if(!flipper_file_write_uint32(
-               flipper_file, "Frequency", (uint32_t*)&subghz->txrx->frequency, 1)) {
+        if(!flipper_file_write_uint32(flipper_file, "Frequency", &subghz->txrx->frequency, 1)) {
             FURI_LOG_E(SUBGHZ_PARSER_TAG, "Unable to add Frequency");
             break;
         }

--- a/lib/subghz/protocols/subghz_protocol_common.c
+++ b/lib/subghz/protocols/subghz_protocol_common.c
@@ -178,8 +178,9 @@ bool subghz_protocol_common_to_save_file(SubGhzProtocolCommon* instance, Flipper
             FURI_LOG_E(SUBGHZ_PARSER_TAG, "Unable to add Protocol");
             break;
         }
+        uint32_t temp = instance->code_last_count_bit;
         if(!flipper_file_write_uint32(
-               flipper_file, "Bit", (uint32_t*)&instance->code_last_count_bit, 1)) {
+               flipper_file, "Bit", &temp, 1)) {
             FURI_LOG_E(SUBGHZ_PARSER_TAG, "Unable to add Bit");
             break;
         }

--- a/lib/subghz/protocols/subghz_protocol_princeton.c
+++ b/lib/subghz/protocols/subghz_protocol_princeton.c
@@ -298,7 +298,7 @@ bool subghz_decoder_princeton_to_save_file(
     FlipperFile* flipper_file) {
     bool res = subghz_protocol_common_to_save_file((SubGhzProtocolCommon*)instance, flipper_file);
     if(res) {
-        res = flipper_file_write_uint32(flipper_file, "TE", (uint32_t*)&instance->te, 1);
+        res = flipper_file_write_uint32(flipper_file, "TE", &instance->te, 1);
         if(!res) FURI_LOG_E(SUBGHZ_PARSER_TAG, "Unable to add Te");
     }
     return res;

--- a/lib/subghz/protocols/subghz_protocol_raw.c
+++ b/lib/subghz/protocols/subghz_protocol_raw.c
@@ -177,7 +177,7 @@ bool subghz_protocol_raw_save_to_file_init(
             break;
         }
 
-        if(!flipper_file_write_uint32(instance->flipper_file, "Frequency", (uint32_t*)&frequency, 1)) {
+        if(!flipper_file_write_uint32(instance->flipper_file, "Frequency", &frequency, 1)) {
             FURI_LOG_E(TAG, "Unable to add Frequency");
             break;
         }

--- a/lib/subghz/subghz_keystore.c
+++ b/lib/subghz/subghz_keystore.c
@@ -248,8 +248,8 @@ bool subghz_keystore_save(SubGhzKeystore* instance, const char* file_name, uint8
             FURI_LOG_E(TAG, "Unable to add header");
             break;
         }
-        SubGhzKeystoreEncryption encryption = SubGhzKeystoreEncryptionAES256;
-        if(!flipper_file_write_uint32(flipper_file, "Encryption", (uint32_t*)&encryption, 1)) {
+        uint32_t encryption = SubGhzKeystoreEncryptionAES256;
+        if(!flipper_file_write_uint32(flipper_file, "Encryption", &encryption, 1)) {
             FURI_LOG_E(TAG, "Unable to add Encryption");
             break;
         }
@@ -379,9 +379,9 @@ bool subghz_keystore_raw_encrypted_save(
             FURI_LOG_E(TAG, "Unable to add header");
             break;
         }
-        SubGhzKeystoreEncryption tmp_encryption = SubGhzKeystoreEncryptionAES256;
+        uint32_t encryption = SubGhzKeystoreEncryptionAES256;
         if(!flipper_file_write_uint32(
-               output_flipper_file, "Encryption", (uint32_t*)&tmp_encryption, 1)) {
+               output_flipper_file, "Encryption", &encryption, 1)) {
             FURI_LOG_E(TAG, "Unable to add Encryption");
             break;
         }

--- a/make/rules.mk
+++ b/make/rules.mk
@@ -100,7 +100,7 @@ debug_other:
 		-ex "svd_load $(SVD_FILE)" \
 
 
-blackmagic: flash
+blackmagic:
 	arm-none-eabi-gdb-py \
 		-ex 'target extended-remote $(BLACKMAGIC)' \
 		-ex 'monitor swdp_scan' \


### PR DESCRIPTION
# What's new

- Project: enum cast fix. 
- Makefile: blackmagic rule in global makefile

# Verification 

- Compile and run
- Subghz: encoding keeloq files works again
- Subghz: fix TE saving

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
