### PR TITLE
[FL-1904] LFRFID: dedicated reading modes

### DIFF
--- a/applications/lfrfid/helpers/rfid-reader.cpp
+++ b/applications/lfrfid/helpers/rfid-reader.cpp
@@ -102,7 +102,7 @@ void RfidReader::stop() {
     stop_comparator();
 }
 
-bool RfidReader::read(LfrfidKeyType* _type, uint8_t* data, uint8_t data_size) {
+bool RfidReader::read(LfrfidKeyType* _type, uint8_t* data, uint8_t data_size, bool switch_enable) {
     bool result = false;
     bool something_readed = false;
 
@@ -140,7 +140,7 @@ bool RfidReader::read(LfrfidKeyType* _type, uint8_t* data, uint8_t data_size) {
     }
 
     // mode switching
-    if(switch_timer_elapsed()) {
+    if(switch_enable && switch_timer_elapsed()) {
         switch_mode();
         last_readed_count = 0;
     }

--- a/applications/lfrfid/helpers/rfid-reader.h
+++ b/applications/lfrfid/helpers/rfid-reader.h
@@ -19,7 +19,7 @@ public:
     void start();
     void start_forced(RfidReader::Type type);
     void stop();
-    bool read(LfrfidKeyType* type, uint8_t* data, uint8_t data_size);
+    bool read(LfrfidKeyType* type, uint8_t* data, uint8_t data_size, bool switch_enable = true);
 
     bool detect();
     bool any_read();

--- a/applications/lfrfid/lfrfid-cli.cpp
+++ b/applications/lfrfid/lfrfid-cli.cpp
@@ -18,7 +18,7 @@ extern "C" void lfrfid_cli_init() {
 
 void lfrfid_cli_print_usage() {
     printf("Usage:\r\n");
-    printf("rfid read\r\n");
+    printf("rfid read <optional key_type>\r\n");
     printf("rfid <write | emulate> <key_type> <key_data>\r\n");
     printf("\t<key_type> choose from:\r\n");
     printf("\tEM4100, EM-Marin (5 bytes key_data)\r\n");
@@ -44,17 +44,42 @@ bool lfrfid_cli_get_key_type(string_t data, LfrfidKeyType* type) {
     return result;
 }
 
-void lfrfid_cli_read(Cli* cli) {
+void lfrfid_cli_read(Cli* cli, string_t args) {
     RfidReader reader;
-    reader.start();
+    string_t type_string;
+    string_init(type_string);
+    bool simple_mode = true;
+    LfrfidKeyType type;
+
+    if(args_read_string_and_trim(args, type_string)) {
+        simple_mode = false;
+        if(!lfrfid_cli_get_key_type(type_string, &type)) {
+            lfrfid_cli_print_usage();
+            string_clear(type_string);
+            return;
+        }
+    }
+
+    if(simple_mode) {
+        reader.start();
+    } else {
+        switch(type) {
+        case LfrfidKeyType::KeyEM4100:
+        case LfrfidKeyType::KeyH10301:
+            reader.start_forced(RfidReader::Type::Normal);
+            break;
+        case LfrfidKeyType::KeyI40134:
+            reader.start_forced(RfidReader::Type::Indala);
+            break;
+        }
+    }
 
     static const uint8_t data_size = LFRFID_KEY_SIZE;
     uint8_t data[data_size] = {0};
-    LfrfidKeyType type;
 
     printf("Reading RFID...\r\nPress Ctrl+C to abort\r\n");
     while(!cli_cmd_interrupt_received(cli)) {
-        if(reader.read(&type, data, data_size)) {
+        if(reader.read(&type, data, data_size, simple_mode)) {
             printf("%s", lfrfid_key_get_type_string(type));
             printf(" ");
 
@@ -69,6 +94,8 @@ void lfrfid_cli_read(Cli* cli) {
 
     printf("Reading stopped\r\n");
     reader.stop();
+
+    string_clear(type_string);
 }
 
 void lfrfid_cli_write(Cli* cli, string_t args) {
@@ -129,7 +156,7 @@ void lfrfid_cli(Cli* cli, string_t args, void* context) {
     }
 
     if(string_cmp_str(cmd, "read") == 0) {
-        lfrfid_cli_read(cli);
+        lfrfid_cli_read(cli, args);
     } else if(string_cmp_str(cmd, "write") == 0) {
         lfrfid_cli_write(cli, args);
     } else if(string_cmp_str(cmd, "emulate") == 0) {


### PR DESCRIPTION
# What's new

- Dedicated RFID reading modes in the CLI.

# Verification 

- CLI: `rfid read`, `rfid read normal`, `rfid read indala`

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
