### PR TITLE
Fix incorrect RPC session termination on BLE disconnect

### DIFF
--- a/applications/bt/bt_service/bt_i.h
+++ b/applications/bt/bt_service/bt_i.h
@@ -51,5 +51,5 @@ struct Bt {
     Power* power;
     Rpc* rpc;
     RpcSession* rpc_session;
-    osSemaphoreId_t rpc_sem;
+    osEventFlagsId_t rpc_event;
 };

--- a/applications/rpc/rpc.c
+++ b/applications/rpc/rpc.c
@@ -354,6 +354,7 @@ void rpc_session_close(RpcSession* session) {
 
     rpc_session_set_send_bytes_callback(session, NULL);
     rpc_session_set_close_callback(session, NULL);
+    rpc_session_set_buffer_is_empty_callback(session, NULL);
     osEventFlagsSet(session->rpc->events, RPC_EVENT_DISCONNECT);
 }
 
@@ -409,7 +410,6 @@ void rpc_session_set_buffer_is_empty_callback(
     RpcSession* session,
     RpcBufferIsEmptyCallback callback) {
     furi_assert(session);
-    furi_assert(callback);
     furi_assert(session->rpc->busy);
 
     osMutexAcquire(session->callbacks_mutex, osWaitForever);


### PR DESCRIPTION
# What's new

- Add explicit disconnect event aborting ble tx
- Sett callbacks to NULL after session is closed

# Verification 

- Open screen streaming on mobile apps, then close application. Repeat several times. Verify nothing is crushed.

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
