### PR TITLE
All strange time constants are now frequency multipliers

### DIFF
--- a/applications/bt/bt_debug_app/views/bt_carrier_test.c
+++ b/applications/bt/bt_debug_app/views/bt_carrier_test.c
@@ -35,10 +35,10 @@ static void bt_carrier_test_start(BtCarrierTest* bt_carrier_test) {
     furi_assert(bt_carrier_test);
     if(bt_carrier_test->mode == BtTestModeRx) {
         furi_hal_bt_start_packet_rx(bt_carrier_test->channel, 1);
-        osTimerStart(bt_carrier_test->timer, 1024 / 4);
+        osTimerStart(bt_carrier_test->timer, osKernelGetTickFreq() / 4);
     } else if(bt_carrier_test->mode == BtTestModeTxHopping) {
         furi_hal_bt_start_tone_tx(bt_carrier_test->channel, bt_carrier_test->power);
-        osTimerStart(bt_carrier_test->timer, 2048);
+        osTimerStart(bt_carrier_test->timer, osKernelGetTickFreq() * 2);
     } else if(bt_carrier_test->mode == BtTestModeTx) {
         furi_hal_bt_start_tone_tx(bt_carrier_test->channel, bt_carrier_test->power);
     }

--- a/applications/bt/bt_debug_app/views/bt_packet_test.c
+++ b/applications/bt/bt_debug_app/views/bt_packet_test.c
@@ -31,7 +31,7 @@ static void bt_packet_test_start(BtPacketTest* bt_packet_test) {
     furi_assert(bt_packet_test);
     if(bt_packet_test->mode == BtTestModeRx) {
         furi_hal_bt_start_packet_rx(bt_packet_test->channel, bt_packet_test->data_rate);
-        osTimerStart(bt_packet_test->timer, 1024 / 4);
+        osTimerStart(bt_packet_test->timer, osKernelGetTickFreq() / 4);
     } else if(bt_packet_test->mode == BtTestModeTx) {
         furi_hal_bt_start_packet_tx(bt_packet_test->channel, 1, bt_packet_test->data_rate);
     }

--- a/applications/debug_tools/blink_test.c
+++ b/applications/debug_tools/blink_test.c
@@ -49,7 +49,7 @@ int32_t blink_test_app(void* p) {
     view_port_draw_callback_set(view_port, blink_test_draw_callback, NULL);
     view_port_input_callback_set(view_port, blink_test_input_callback, event_queue);
     osTimerId_t timer = osTimerNew(blink_test_update, osTimerPeriodic, event_queue, NULL);
-    osTimerStart(timer, 1000);
+    osTimerStart(timer, osKernelGetTickFreq());
 
     // Register view port in GUI
     Gui* gui = furi_record_open("gui");

--- a/applications/desktop/scenes/desktop_scene_locked.c
+++ b/applications/desktop/scenes/desktop_scene_locked.c
@@ -21,7 +21,7 @@ void desktop_scene_locked_on_enter(void* context) {
     desktop_locked_with_pin(desktop->locked_view, state == DesktopLockedWithPin);
 
     view_port_enabled_set(desktop->lock_viewport, true);
-    osTimerStart(locked_view->timer, 63);
+    osTimerStart(locked_view->timer, osKernelGetTickFreq() / 16);
 
     view_dispatcher_switch_to_view(desktop->view_dispatcher, DesktopViewLocked);
 }

--- a/applications/subghz/views/subghz_test_carrier.c
+++ b/applications/subghz/views/subghz_test_carrier.c
@@ -152,7 +152,7 @@ void subghz_test_carrier_enter(void* context) {
 
     furi_hal_subghz_rx();
 
-    osTimerStart(subghz_test_carrier->timer, 1024 / 4);
+    osTimerStart(subghz_test_carrier->timer, osKernelGetTickFreq() / 4);
 }
 
 void subghz_test_carrier_exit(void* context) {

--- a/applications/subghz/views/subghz_test_packet.c
+++ b/applications/subghz/views/subghz_test_packet.c
@@ -198,7 +198,7 @@ void subghz_test_packet_enter(void* context) {
 
     furi_hal_subghz_start_async_rx(subghz_test_packet_rx_callback, instance);
 
-    osTimerStart(instance->timer, 1024 / 4);
+    osTimerStart(instance->timer, osKernelGetTickFreq() / 4);
 }
 
 void subghz_test_packet_exit(void* context) {


### PR DESCRIPTION
# What's new

Time constants everywhere were just numbers. It's hard to read, now constants are the product of frequency and number of seconds. Just walking by and wanting to improve.

# Verification 

Perhaps we should open all these applications and check that they work?

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
