### PR TITLE
Support for external SPI modules with custom configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf

--- a/bootloader/targets/f7/furi-hal/furi-hal-resources.c
+++ b/bootloader/targets/f7/furi-hal/furi-hal-resources.c
@@ -13,6 +13,7 @@ const GpioPin gpio_display_rst = {.port = DISPLAY_RST_GPIO_Port, .pin = DISPLAY_
 const GpioPin gpio_display_di = {.port = DISPLAY_DI_GPIO_Port, .pin = DISPLAY_DI_Pin};
 const GpioPin gpio_sdcard_cs = {.port = SD_CS_GPIO_Port, .pin = SD_CS_Pin};
 const GpioPin gpio_nfc_cs = {.port = NFC_CS_GPIO_Port, .pin = NFC_CS_Pin};
+const GpioPin gpio_spi_ext_cs = {.port = SPI_EXT_CS_GPIO_Port, .pin = SPI_EXT_CS_Pin};
 
 const GpioPin gpio_spi_d_miso = {.port = SPI_D_MISO_GPIO_Port, .pin = SPI_D_MISO_Pin};
 const GpioPin gpio_spi_d_mosi = {.port = SPI_D_MOSI_GPIO_Port, .pin = SPI_D_MOSI_Pin};
@@ -20,6 +21,9 @@ const GpioPin gpio_spi_d_sck = {.port = SPI_D_SCK_GPIO_Port, .pin = SPI_D_SCK_Pi
 const GpioPin gpio_spi_r_miso = {.port = SPI_R_MISO_GPIO_Port, .pin = SPI_R_MISO_Pin};
 const GpioPin gpio_spi_r_mosi = {.port = SPI_R_MOSI_GPIO_Port, .pin = SPI_R_MOSI_Pin};
 const GpioPin gpio_spi_r_sck = {.port = SPI_R_SCK_GPIO_Port, .pin = SPI_R_SCK_Pin};
+const GpioPin gpio_spi_ext_miso = {.port = SPI_EXT_MISO_GPIO_Port, .pin = SPI_EXT_MISO_Pin};
+const GpioPin gpio_spi_ext_mosi = {.port = SPI_EXT_MOSI_GPIO_Port, .pin = SPI_EXT_MOSI_Pin};
+const GpioPin gpio_spi_ext_sck = {.port = SPI_EXT_SCK_GPIO_Port, .pin = SPI_EXT_SCK_Pin};
 
 const GpioPin gpio_ext_pc0 = {.port = GPIOC, .pin = LL_GPIO_PIN_0};
 const GpioPin gpio_ext_pc1 = {.port = GPIOC, .pin = LL_GPIO_PIN_1};

--- a/bootloader/targets/f7/furi-hal/furi-hal-resources.h
+++ b/bootloader/targets/f7/furi-hal/furi-hal-resources.h
@@ -50,6 +50,7 @@ extern const GpioPin gpio_display_rst;
 extern const GpioPin gpio_display_di;
 extern const GpioPin gpio_sdcard_cs;
 extern const GpioPin gpio_nfc_cs;
+extern const GpioPin gpio_spi_ext_cs;
 
 extern const GpioPin gpio_spi_d_miso;
 extern const GpioPin gpio_spi_d_mosi;
@@ -57,6 +58,9 @@ extern const GpioPin gpio_spi_d_sck;
 extern const GpioPin gpio_spi_r_miso;
 extern const GpioPin gpio_spi_r_mosi;
 extern const GpioPin gpio_spi_r_sck;
+extern const GpioPin gpio_spi_ext_miso;
+extern const GpioPin gpio_spi_ext_mosi;
+extern const GpioPin gpio_spi_ext_sck;
 
 extern const GpioPin gpio_ext_pc0;
 extern const GpioPin gpio_ext_pc1;

--- a/bootloader/targets/f7/furi-hal/furi-hal-spi-config.c
+++ b/bootloader/targets/f7/furi-hal/furi-hal-spi-config.c
@@ -75,6 +75,19 @@ const LL_SPI_InitTypeDef furi_hal_spi_config_sd_slow = {
     .CRCPoly = 7,
 };
 
+const LL_SPI_InitTypeDef furi_hal_spi_config_ext_spi = {
+    .Mode = LL_SPI_MODE_MASTER,
+    .TransferDirection = LL_SPI_FULL_DUPLEX,
+    .DataWidth = LL_SPI_DATAWIDTH_8BIT,
+    .ClockPolarity = LL_SPI_POLARITY_LOW,
+    .ClockPhase = LL_SPI_PHASE_1EDGE,
+    .NSS = LL_SPI_NSS_SOFT,
+    .BaudRate = LL_SPI_BAUDRATEPRESCALER_DIV16,
+    .BitOrder = LL_SPI_MSB_FIRST,
+    .CRCCalculation = LL_SPI_CRCCALCULATION_DISABLE,
+    .CRCPoly = 7,
+};
+
 const FuriHalSpiBus spi_r = {
     .spi = SPI_R,
     .miso = &gpio_spi_r_miso,
@@ -87,6 +100,13 @@ const FuriHalSpiBus spi_d = {
     .miso = &gpio_spi_d_miso,
     .mosi = &gpio_spi_d_mosi,
     .clk = &gpio_spi_d_sck,
+};
+
+const FuriHalSpiBus spi_ext = {
+    .spi = SPI_R,
+    .miso = &gpio_spi_ext_miso,
+    .mosi = &gpio_spi_ext_mosi,
+    .clk = &gpio_spi_ext_sck,
 };
 
 const FuriHalSpiDevice furi_hal_spi_devices[FuriHalSpiDeviceIdMax] = {
@@ -110,5 +130,14 @@ const FuriHalSpiDevice furi_hal_spi_devices[FuriHalSpiDeviceIdMax] = {
         .config = &furi_hal_spi_config_sd_slow,
         .chip_select = &gpio_sdcard_cs,
     },
-    {.bus = &spi_r, .config = &furi_hal_spi_config_nfc, .chip_select = &gpio_nfc_cs},
+    {
+        .bus = &spi_r, 
+        .config = &furi_hal_spi_config_nfc, 
+        .chip_select = &gpio_nfc_cs
+    },
+    {
+        .bus = &spi_ext, 
+        .config = &furi_hal_spi_config_ext_spi, 
+        .chip_select = &gpio_spi_ext_cs
+    },
 };

--- a/bootloader/targets/f7/furi-hal/furi-hal-spi-config.c
+++ b/bootloader/targets/f7/furi-hal/furi-hal-spi-config.c
@@ -131,13 +131,13 @@ const FuriHalSpiDevice furi_hal_spi_devices[FuriHalSpiDeviceIdMax] = {
         .chip_select = &gpio_sdcard_cs,
     },
     {
-        .bus = &spi_r, 
-        .config = &furi_hal_spi_config_nfc, 
+        .bus = &spi_r,
+        .config = &furi_hal_spi_config_nfc,
         .chip_select = &gpio_nfc_cs
     },
     {
-        .bus = &spi_ext, 
-        .config = &furi_hal_spi_config_ext_spi, 
+        .bus = &spi_ext,
+        .config = &furi_hal_spi_config_ext_spi,
         .chip_select = &gpio_spi_ext_cs
     },
 };

--- a/bootloader/targets/f7/furi-hal/furi-hal-spi-config.c
+++ b/bootloader/targets/f7/furi-hal/furi-hal-spi-config.c
@@ -130,14 +130,6 @@ const FuriHalSpiDevice furi_hal_spi_devices[FuriHalSpiDeviceIdMax] = {
         .config = &furi_hal_spi_config_sd_slow,
         .chip_select = &gpio_sdcard_cs,
     },
-    {
-        .bus = &spi_r,
-        .config = &furi_hal_spi_config_nfc,
-        .chip_select = &gpio_nfc_cs
-    },
-    {
-        .bus = &spi_ext,
-        .config = &furi_hal_spi_config_ext_spi,
-        .chip_select = &gpio_spi_ext_cs
-    },
+    {.bus = &spi_r, .config = &furi_hal_spi_config_nfc, .chip_select = &gpio_nfc_cs},
+    {.bus = &spi_ext, .config = &furi_hal_spi_config_ext_spi, .chip_select = &gpio_spi_ext_cs},
 };

--- a/bootloader/targets/f7/furi-hal/furi-hal-spi-config.h
+++ b/bootloader/targets/f7/furi-hal/furi-hal-spi-config.h
@@ -39,6 +39,7 @@ typedef enum {
     FuriHalSpiDeviceIdSdCardFast, /** SDCARD: fast mode, after initialization */
     FuriHalSpiDeviceIdSdCardSlow, /** SDCARD: slow mode, before initialization */
     FuriHalSpiDeviceIdNfc, /** NFC: ST25R3916, pretty standard, but RFAL makes it complex */
+    FuriHalSpiDeviceIdExtSpi, /** External SPI interface */
 
     FuriHalSpiDeviceIdMax, /** Service Value, do not use */
 } FuriHalSpiDeviceId;

--- a/bootloader/targets/f7/furi-hal/main.h
+++ b/bootloader/targets/f7/furi-hal/main.h
@@ -37,6 +37,9 @@
 #define NFC_CS_GPIO_Port GPIOE
 #define NFC_CS_Pin LL_GPIO_PIN_4
 
+#define SPI_EXT_CS_GPIO_Port GPIOA
+#define SPI_EXT_CS_Pin LL_GPIO_PIN_4
+
 #define PA4_GPIO_Port GPIOA
 #define PA4_Pin LL_GPIO_PIN_4
 #define PA6_GPIO_Port GPIOA
@@ -106,3 +109,10 @@
 #define SPI_R_MOSI_Pin LL_GPIO_PIN_5
 #define SPI_R_SCK_GPIO_Port GPIOA
 #define SPI_R_SCK_Pin LL_GPIO_PIN_5
+
+#define SPI_EXT_MISO_GPIO_Port GPIOA
+#define SPI_EXT_MISO_Pin LL_GPIO_PIN_6
+#define SPI_EXT_MOSI_GPIO_Port GPIOA
+#define SPI_EXT_MOSI_Pin LL_GPIO_PIN_7
+#define SPI_EXT_SCK_GPIO_Port GPIOB
+#define SPI_EXT_SCK_Pin LL_GPIO_PIN_3

--- a/firmware/targets/f7/Inc/main.h
+++ b/firmware/targets/f7/Inc/main.h
@@ -47,6 +47,9 @@ void Error_Handler(void);
 #define NFC_CS_GPIO_Port GPIOE
 #define NFC_CS_Pin GPIO_PIN_4
 
+#define SPI_EXT_CS_GPIO_Port GPIOA
+#define SPI_EXT_CS_Pin GPIO_PIN_4
+
 #define PA4_GPIO_Port GPIOA
 #define PA4_Pin GPIO_PIN_4
 #define PA6_GPIO_Port GPIOA
@@ -116,6 +119,13 @@ void Error_Handler(void);
 #define SPI_R_MOSI_Pin GPIO_PIN_5
 #define SPI_R_SCK_GPIO_Port GPIOA
 #define SPI_R_SCK_Pin GPIO_PIN_5
+
+#define SPI_EXT_MISO_GPIO_Port GPIOA
+#define SPI_EXT_MISO_Pin GPIO_PIN_6
+#define SPI_EXT_MOSI_GPIO_Port GPIOA
+#define SPI_EXT_MOSI_Pin GPIO_PIN_7
+#define SPI_EXT_SCK_GPIO_Port GPIOB
+#define SPI_EXT_SCK_Pin GPIO_PIN_3
 
 extern TIM_HandleTypeDef htim1;
 extern TIM_HandleTypeDef htim2;

--- a/firmware/targets/f7/furi-hal/furi-hal-resources.c
+++ b/firmware/targets/f7/furi-hal/furi-hal-resources.c
@@ -28,6 +28,7 @@ const GpioPin gpio_display_rst = {.port = DISPLAY_RST_GPIO_Port, .pin = DISPLAY_
 const GpioPin gpio_display_di = {.port = DISPLAY_DI_GPIO_Port, .pin = DISPLAY_DI_Pin};
 const GpioPin gpio_sdcard_cs = {.port = SD_CS_GPIO_Port, .pin = SD_CS_Pin};
 const GpioPin gpio_nfc_cs = {.port = NFC_CS_GPIO_Port, .pin = NFC_CS_Pin};
+const GpioPin gpio_spi_ext_cs = {.port = SPI_EXT_CS_GPIO_Port, .pin = SPI_EXT_CS_Pin};
 
 const GpioPin gpio_spi_d_miso = {.port = SPI_D_MISO_GPIO_Port, .pin = SPI_D_MISO_Pin};
 const GpioPin gpio_spi_d_mosi = {.port = SPI_D_MOSI_GPIO_Port, .pin = SPI_D_MOSI_Pin};
@@ -35,6 +36,9 @@ const GpioPin gpio_spi_d_sck = {.port = SPI_D_SCK_GPIO_Port, .pin = SPI_D_SCK_Pi
 const GpioPin gpio_spi_r_miso = {.port = SPI_R_MISO_GPIO_Port, .pin = SPI_R_MISO_Pin};
 const GpioPin gpio_spi_r_mosi = {.port = SPI_R_MOSI_GPIO_Port, .pin = SPI_R_MOSI_Pin};
 const GpioPin gpio_spi_r_sck = {.port = SPI_R_SCK_GPIO_Port, .pin = SPI_R_SCK_Pin};
+const GpioPin gpio_spi_ext_miso = {.port = SPI_EXT_MISO_GPIO_Port, .pin = SPI_EXT_MISO_Pin};
+const GpioPin gpio_spi_ext_mosi = {.port = SPI_EXT_MOSI_GPIO_Port, .pin = SPI_EXT_MOSI_Pin};
+const GpioPin gpio_spi_ext_sck = {.port = SPI_EXT_SCK_GPIO_Port, .pin = SPI_EXT_SCK_Pin};
 
 const GpioPin gpio_ext_pc0 = {.port = GPIOC, .pin = GPIO_PIN_0};
 const GpioPin gpio_ext_pc1 = {.port = GPIOC, .pin = GPIO_PIN_1};

--- a/firmware/targets/f7/furi-hal/furi-hal-resources.h
+++ b/firmware/targets/f7/furi-hal/furi-hal-resources.h
@@ -72,6 +72,7 @@ extern const GpioPin gpio_display_rst;
 extern const GpioPin gpio_display_di;
 extern const GpioPin gpio_sdcard_cs;
 extern const GpioPin gpio_nfc_cs;
+extern const GpioPin gpio_spi_ext_cs;
 
 extern const GpioPin gpio_spi_d_miso;
 extern const GpioPin gpio_spi_d_mosi;
@@ -79,6 +80,9 @@ extern const GpioPin gpio_spi_d_sck;
 extern const GpioPin gpio_spi_r_miso;
 extern const GpioPin gpio_spi_r_mosi;
 extern const GpioPin gpio_spi_r_sck;
+extern const GpioPin gpio_spi_ext_miso;
+extern const GpioPin gpio_spi_ext_mosi;
+extern const GpioPin gpio_spi_ext_sck;
 
 extern const GpioPin gpio_ext_pc0;
 extern const GpioPin gpio_ext_pc1;

--- a/firmware/targets/f7/furi-hal/furi-hal-spi-config.c
+++ b/firmware/targets/f7/furi-hal/furi-hal-spi-config.c
@@ -99,6 +99,7 @@ const FuriHalSpiBus spi_r = {
     .miso=&gpio_spi_r_miso,
     .mosi=&gpio_spi_r_mosi,
     .clk=&gpio_spi_r_sck,
+    .alt_fn=GpioAltFn5SPI1,
 };
 
 const FuriHalSpiBus spi_d = {
@@ -107,6 +108,7 @@ const FuriHalSpiBus spi_d = {
     .miso=&gpio_spi_d_miso,
     .mosi=&gpio_spi_d_mosi,
     .clk=&gpio_spi_d_sck,
+    .alt_fn=GpioAltFn5SPI2,
 };
 
 const FuriHalSpiBus spi_ext = {
@@ -115,13 +117,14 @@ const FuriHalSpiBus spi_ext = {
     .miso=&gpio_spi_ext_miso,
     .mosi=&gpio_spi_ext_mosi,
     .clk=&gpio_spi_ext_sck,
+    .alt_fn=GpioAltFn5SPI1,
 };
 
 const FuriHalSpiDevice furi_hal_spi_devices[FuriHalSpiDeviceIdMax] = {
-    { .bus=&spi_r, .config=&furi_hal_spi_config_subghz, .chip_select=&gpio_subghz_cs, },
-    { .bus=&spi_d, .config=&furi_hal_spi_config_display, .chip_select=&gpio_display_cs, },
-    { .bus=&spi_d, .config=&furi_hal_spi_config_sd_fast, .chip_select=&gpio_sdcard_cs, },
-    { .bus=&spi_d, .config=&furi_hal_spi_config_sd_slow, .chip_select=&gpio_sdcard_cs, },
-    { .bus=&spi_r, .config=&furi_hal_spi_config_nfc, .chip_select=&gpio_nfc_cs },
-    { .bus=&spi_ext, .config=&furi_hal_spi_config_ext_spi, .chip_select=&gpio_spi_ext_cs },
+    { .bus=&spi_r,   .config=&furi_hal_spi_config_subghz,  .chip_select=&gpio_subghz_cs,  .auto_init = true, },
+    { .bus=&spi_d,   .config=&furi_hal_spi_config_display, .chip_select=&gpio_display_cs, .auto_init = true, },
+    { .bus=&spi_d,   .config=&furi_hal_spi_config_sd_fast, .chip_select=&gpio_sdcard_cs,  .auto_init = true, },
+    { .bus=&spi_d,   .config=&furi_hal_spi_config_sd_slow, .chip_select=&gpio_sdcard_cs,  .auto_init = true, },
+    { .bus=&spi_r,   .config=&furi_hal_spi_config_nfc,     .chip_select=&gpio_nfc_cs,     .auto_init = true, },
+    { .bus=&spi_ext, .config=&furi_hal_spi_config_ext_spi, .chip_select=&gpio_spi_ext_cs, .auto_init = false, },
 };

--- a/firmware/targets/f7/furi-hal/furi-hal-spi-config.c
+++ b/firmware/targets/f7/furi-hal/furi-hal-spi-config.c
@@ -75,6 +75,21 @@ const LL_SPI_InitTypeDef furi_hal_spi_config_sd_slow = {
     .CRCPoly = 7,
 };
 
+
+
+const LL_SPI_InitTypeDef furi_hal_spi_config_ext_spi = {
+    .Mode = LL_SPI_MODE_MASTER,
+    .TransferDirection = LL_SPI_FULL_DUPLEX,
+    .DataWidth = LL_SPI_DATAWIDTH_8BIT,
+    .ClockPolarity = LL_SPI_POLARITY_LOW,
+    .ClockPhase = LL_SPI_PHASE_1EDGE,
+    .NSS = LL_SPI_NSS_SOFT,
+    .BaudRate = LL_SPI_BAUDRATEPRESCALER_DIV16,
+    .BitOrder = LL_SPI_MSB_FIRST,
+    .CRCCalculation = LL_SPI_CRCCALCULATION_DISABLE,
+    .CRCPoly = 7,
+};
+
 osMutexId_t spi_mutex_d = NULL;
 osMutexId_t spi_mutex_r = NULL;
 
@@ -94,10 +109,19 @@ const FuriHalSpiBus spi_d = {
     .clk=&gpio_spi_d_sck,
 };
 
+const FuriHalSpiBus spi_ext = {
+    .spi=SPI_R,
+    .mutex=&spi_mutex_r,
+    .miso=&gpio_spi_ext_miso,
+    .mosi=&gpio_spi_ext_mosi,
+    .clk=&gpio_spi_ext_sck,
+};
+
 const FuriHalSpiDevice furi_hal_spi_devices[FuriHalSpiDeviceIdMax] = {
     { .bus=&spi_r, .config=&furi_hal_spi_config_subghz, .chip_select=&gpio_subghz_cs, },
     { .bus=&spi_d, .config=&furi_hal_spi_config_display, .chip_select=&gpio_display_cs, },
     { .bus=&spi_d, .config=&furi_hal_spi_config_sd_fast, .chip_select=&gpio_sdcard_cs, },
     { .bus=&spi_d, .config=&furi_hal_spi_config_sd_slow, .chip_select=&gpio_sdcard_cs, },
     { .bus=&spi_r, .config=&furi_hal_spi_config_nfc, .chip_select=&gpio_nfc_cs },
+    { .bus=&spi_ext, .config=&furi_hal_spi_config_ext_spi, .chip_select=&gpio_spi_ext_cs },
 };

--- a/firmware/targets/f7/furi-hal/furi-hal-spi-config.c
+++ b/firmware/targets/f7/furi-hal/furi-hal-spi-config.c
@@ -90,9 +90,12 @@ const LL_SPI_InitTypeDef furi_hal_spi_config_ext_spi = {
     .CRCPoly = 7,
 };
 
+osMutexId_t* spi_mutex_d = NULL;
+osMutexId_t* spi_mutex_r = NULL;
+
 const FuriHalSpiBus spi_r = {
     .spi=SPI_R,
-    .mutex=NULL,
+    .mutex=&spi_mutex_r,
     .miso=&gpio_spi_r_miso,
     .mosi=&gpio_spi_r_mosi,
     .clk=&gpio_spi_r_sck,
@@ -101,7 +104,7 @@ const FuriHalSpiBus spi_r = {
 
 const FuriHalSpiBus spi_d = {
     .spi=SPI_D,
-    .mutex=NULL,
+    .mutex=&spi_mutex_d,
     .miso=&gpio_spi_d_miso,
     .mosi=&gpio_spi_d_mosi,
     .clk=&gpio_spi_d_sck,
@@ -110,7 +113,7 @@ const FuriHalSpiBus spi_d = {
 
 const FuriHalSpiBus spi_ext = {
     .spi=SPI_R,
-    .mutex=NULL, // FIXME -- must use spi_r mutex
+    .mutex=&spi_mutex_r,
     .miso=&gpio_spi_ext_miso,
     .mosi=&gpio_spi_ext_mosi,
     .clk=&gpio_spi_ext_sck,

--- a/firmware/targets/f7/furi-hal/furi-hal-spi-config.c
+++ b/firmware/targets/f7/furi-hal/furi-hal-spi-config.c
@@ -90,12 +90,9 @@ const LL_SPI_InitTypeDef furi_hal_spi_config_ext_spi = {
     .CRCPoly = 7,
 };
 
-osMutexId_t spi_mutex_d = NULL;
-osMutexId_t spi_mutex_r = NULL;
-
 const FuriHalSpiBus spi_r = {
     .spi=SPI_R,
-    .mutex=&spi_mutex_r,
+    .mutex=NULL,
     .miso=&gpio_spi_r_miso,
     .mosi=&gpio_spi_r_mosi,
     .clk=&gpio_spi_r_sck,
@@ -104,7 +101,7 @@ const FuriHalSpiBus spi_r = {
 
 const FuriHalSpiBus spi_d = {
     .spi=SPI_D,
-    .mutex=&spi_mutex_d,
+    .mutex=NULL,
     .miso=&gpio_spi_d_miso,
     .mosi=&gpio_spi_d_mosi,
     .clk=&gpio_spi_d_sck,
@@ -113,7 +110,7 @@ const FuriHalSpiBus spi_d = {
 
 const FuriHalSpiBus spi_ext = {
     .spi=SPI_R,
-    .mutex=&spi_mutex_r,
+    .mutex=NULL, // FIXME -- must use spi_r mutex
     .miso=&gpio_spi_ext_miso,
     .mosi=&gpio_spi_ext_mosi,
     .clk=&gpio_spi_ext_sck,

--- a/firmware/targets/f7/furi-hal/furi-hal-spi-config.c
+++ b/firmware/targets/f7/furi-hal/furi-hal-spi-config.c
@@ -120,11 +120,12 @@ const FuriHalSpiBus spi_ext = {
     .alt_fn=GpioAltFn5SPI1,
 };
 
-const FuriHalSpiDevice furi_hal_spi_devices[FuriHalSpiDeviceIdMax] = {
-    { .bus=&spi_r,   .config=&furi_hal_spi_config_subghz,  .chip_select=&gpio_subghz_cs,  .auto_init = true, },
-    { .bus=&spi_d,   .config=&furi_hal_spi_config_display, .chip_select=&gpio_display_cs, .auto_init = true, },
-    { .bus=&spi_d,   .config=&furi_hal_spi_config_sd_fast, .chip_select=&gpio_sdcard_cs,  .auto_init = true, },
-    { .bus=&spi_d,   .config=&furi_hal_spi_config_sd_slow, .chip_select=&gpio_sdcard_cs,  .auto_init = true, },
-    { .bus=&spi_r,   .config=&furi_hal_spi_config_nfc,     .chip_select=&gpio_nfc_cs,     .auto_init = true, },
-    { .bus=&spi_ext, .config=&furi_hal_spi_config_ext_spi, .chip_select=&gpio_spi_ext_cs, .auto_init = false, },
+const FuriHalSpiDevice furi_hal_spi_devices[FuriHalSpiDeviceIdMax + 1] = {
+    { .bus=&spi_r,   .config=&furi_hal_spi_config_subghz,  .chip_select=&gpio_subghz_cs,  .main_bus_config = NULL, },
+    { .bus=&spi_d,   .config=&furi_hal_spi_config_display, .chip_select=&gpio_display_cs, .main_bus_config = NULL, },
+    { .bus=&spi_d,   .config=&furi_hal_spi_config_sd_fast, .chip_select=&gpio_sdcard_cs,  .main_bus_config = NULL, },
+    { .bus=&spi_d,   .config=&furi_hal_spi_config_sd_slow, .chip_select=&gpio_sdcard_cs,  .main_bus_config = NULL, },
+    { .bus=&spi_r,   .config=&furi_hal_spi_config_nfc,     .chip_select=&gpio_nfc_cs,     .main_bus_config = NULL, },
+    { .bus=&spi_ext, .config=&furi_hal_spi_config_ext_spi, .chip_select=&gpio_spi_ext_cs, .main_bus_config = &spi_r, },
+    { NULL }
 };

--- a/firmware/targets/f7/furi-hal/furi-hal-spi-config.c
+++ b/firmware/targets/f7/furi-hal/furi-hal-spi-config.c
@@ -121,40 +121,40 @@ const FuriHalSpiBus spi_ext = {
 };
 
 const FuriHalSpiDevice furi_hal_spi_devices[FuriHalSpiDeviceIdMax] = {
-    { 
-        .bus=&spi_r,   
-        .config=&furi_hal_spi_config_subghz,          
-        .chip_select=&gpio_subghz_cs,  
+    {
+        .bus=&spi_r,
+        .config=&furi_hal_spi_config_subghz,
+        .chip_select=&gpio_subghz_cs,
         .main_bus_config = NULL,
     },
-    { 
-        .bus=&spi_d,   
-        .config=&furi_hal_spi_config_display,         
-        .chip_select=&gpio_display_cs, 
+    {
+        .bus=&spi_d,
+        .config=&furi_hal_spi_config_display,
+        .chip_select=&gpio_display_cs,
         .main_bus_config = NULL,
     },
-    { 
-        .bus=&spi_d,   
-        .config=&furi_hal_spi_config_sd_fast,         
-        .chip_select=&gpio_sdcard_cs,  
+    {
+        .bus=&spi_d,
+        .config=&furi_hal_spi_config_sd_fast,
+        .chip_select=&gpio_sdcard_cs,
         .main_bus_config = NULL,
     },
-    { 
-        .bus=&spi_d,   
-        .config=&furi_hal_spi_config_sd_slow,         
-        .chip_select=&gpio_sdcard_cs,  
+    {
+        .bus=&spi_d,
+        .config=&furi_hal_spi_config_sd_slow,
+        .chip_select=&gpio_sdcard_cs,
         .main_bus_config = NULL,
     },
-    { 
-        .bus=&spi_r,   
-        .config=&furi_hal_spi_config_nfc,             
-        .chip_select=&gpio_nfc_cs,     
+    {
+        .bus=&spi_r,
+        .config=&furi_hal_spi_config_nfc,
+        .chip_select=&gpio_nfc_cs,
         .main_bus_config = NULL,
     },
-    { 
-        .bus=&spi_ext, 
-        .config=&furi_hal_spi_config_ext_spi_default, 
-        .chip_select=&gpio_spi_ext_cs, 
+    {
+        .bus=&spi_ext,
+        .config=&furi_hal_spi_config_ext_spi_default,
+        .chip_select=&gpio_spi_ext_cs,
         .main_bus_config = &spi_r,
     },
 };

--- a/firmware/targets/f7/furi-hal/furi-hal-spi-config.c
+++ b/firmware/targets/f7/furi-hal/furi-hal-spi-config.c
@@ -77,7 +77,7 @@ const LL_SPI_InitTypeDef furi_hal_spi_config_sd_slow = {
 
 
 
-const LL_SPI_InitTypeDef furi_hal_spi_config_ext_spi = {
+const LL_SPI_InitTypeDef furi_hal_spi_config_ext_spi_default = {
     .Mode = LL_SPI_MODE_MASTER,
     .TransferDirection = LL_SPI_FULL_DUPLEX,
     .DataWidth = LL_SPI_DATAWIDTH_8BIT,
@@ -120,12 +120,41 @@ const FuriHalSpiBus spi_ext = {
     .alt_fn=GpioAltFn5SPI1,
 };
 
-const FuriHalSpiDevice furi_hal_spi_devices[FuriHalSpiDeviceIdMax + 1] = {
-    { .bus=&spi_r,   .config=&furi_hal_spi_config_subghz,  .chip_select=&gpio_subghz_cs,  .main_bus_config = NULL, },
-    { .bus=&spi_d,   .config=&furi_hal_spi_config_display, .chip_select=&gpio_display_cs, .main_bus_config = NULL, },
-    { .bus=&spi_d,   .config=&furi_hal_spi_config_sd_fast, .chip_select=&gpio_sdcard_cs,  .main_bus_config = NULL, },
-    { .bus=&spi_d,   .config=&furi_hal_spi_config_sd_slow, .chip_select=&gpio_sdcard_cs,  .main_bus_config = NULL, },
-    { .bus=&spi_r,   .config=&furi_hal_spi_config_nfc,     .chip_select=&gpio_nfc_cs,     .main_bus_config = NULL, },
-    { .bus=&spi_ext, .config=&furi_hal_spi_config_ext_spi, .chip_select=&gpio_spi_ext_cs, .main_bus_config = &spi_r, },
-    { NULL }
+const FuriHalSpiDevice furi_hal_spi_devices[FuriHalSpiDeviceIdMax] = {
+    { 
+        .bus=&spi_r,   
+        .config=&furi_hal_spi_config_subghz,          
+        .chip_select=&gpio_subghz_cs,  
+        .main_bus_config = NULL,
+    },
+    { 
+        .bus=&spi_d,   
+        .config=&furi_hal_spi_config_display,         
+        .chip_select=&gpio_display_cs, 
+        .main_bus_config = NULL,
+    },
+    { 
+        .bus=&spi_d,   
+        .config=&furi_hal_spi_config_sd_fast,         
+        .chip_select=&gpio_sdcard_cs,  
+        .main_bus_config = NULL,
+    },
+    { 
+        .bus=&spi_d,   
+        .config=&furi_hal_spi_config_sd_slow,         
+        .chip_select=&gpio_sdcard_cs,  
+        .main_bus_config = NULL,
+    },
+    { 
+        .bus=&spi_r,   
+        .config=&furi_hal_spi_config_nfc,             
+        .chip_select=&gpio_nfc_cs,     
+        .main_bus_config = NULL,
+    },
+    { 
+        .bus=&spi_ext, 
+        .config=&furi_hal_spi_config_ext_spi_default, 
+        .chip_select=&gpio_spi_ext_cs, 
+        .main_bus_config = &spi_r,
+    },
 };

--- a/firmware/targets/f7/furi-hal/furi-hal-spi-config.h
+++ b/firmware/targets/f7/furi-hal/furi-hal-spi-config.h
@@ -19,7 +19,7 @@ extern const LL_SPI_InitTypeDef furi_hal_spi_config_sd_slow;
  */
 typedef struct {
     const SPI_TypeDef* spi;
-    const osMutexId_t* mutex;
+    osMutexId_t **const mutex;
     const GpioPin* miso;
     const GpioPin* mosi;
     const GpioPin* clk;

--- a/firmware/targets/f7/furi-hal/furi-hal-spi-config.h
+++ b/firmware/targets/f7/furi-hal/furi-hal-spi-config.h
@@ -23,6 +23,7 @@ typedef struct {
     const GpioPin* miso;
     const GpioPin* mosi;
     const GpioPin* clk;
+    const GpioAltFn alt_fn;
 } FuriHalSpiBus;
 
 /** FURI HAL SPI Device handler
@@ -32,6 +33,7 @@ typedef struct {
     const FuriHalSpiBus* bus;
     const LL_SPI_InitTypeDef* config;
     const GpioPin* chip_select;
+    const bool auto_init;
 } FuriHalSpiDevice;
 
 /** FURI HAL SPI Standard Device IDs */

--- a/firmware/targets/f7/furi-hal/furi-hal-spi-config.h
+++ b/firmware/targets/f7/furi-hal/furi-hal-spi-config.h
@@ -13,6 +13,7 @@ extern const LL_SPI_InitTypeDef furi_hal_spi_config_subghz;
 extern const LL_SPI_InitTypeDef furi_hal_spi_config_display;
 extern const LL_SPI_InitTypeDef furi_hal_spi_config_sd_fast;
 extern const LL_SPI_InitTypeDef furi_hal_spi_config_sd_slow;
+extern const LL_SPI_InitTypeDef furi_hal_spi_config_ext_spi_default;
 
 /** FURI HAL SPI BUS handler
  * Structure content may change at some point
@@ -59,7 +60,7 @@ extern const FuriHalSpiBus spi_r;
 extern const FuriHalSpiBus spi_d;
 
 /** Furi Hal Spi devices */
-extern const FuriHalSpiDevice furi_hal_spi_devices[FuriHalSpiDeviceIdMax+1];
+extern const FuriHalSpiDevice furi_hal_spi_devices[FuriHalSpiDeviceIdMax];
 
 #ifdef __cplusplus
 }

--- a/firmware/targets/f7/furi-hal/furi-hal-spi-config.h
+++ b/firmware/targets/f7/furi-hal/furi-hal-spi-config.h
@@ -33,7 +33,7 @@ typedef struct {
     const FuriHalSpiBus* bus;
     const LL_SPI_InitTypeDef* config;
     const GpioPin* chip_select;
-    const bool auto_init;
+    const FuriHalSpiBus* main_bus_config; // bus configuration to restore after releasing device
 } FuriHalSpiDevice;
 
 /** FURI HAL SPI Standard Device IDs */
@@ -59,7 +59,7 @@ extern const FuriHalSpiBus spi_r;
 extern const FuriHalSpiBus spi_d;
 
 /** Furi Hal Spi devices */
-extern const FuriHalSpiDevice furi_hal_spi_devices[FuriHalSpiDeviceIdMax];
+extern const FuriHalSpiDevice furi_hal_spi_devices[FuriHalSpiDeviceIdMax+1];
 
 #ifdef __cplusplus
 }

--- a/firmware/targets/f7/furi-hal/furi-hal-spi-config.h
+++ b/firmware/targets/f7/furi-hal/furi-hal-spi-config.h
@@ -41,6 +41,7 @@ typedef enum {
     FuriHalSpiDeviceIdSdCardFast,    /** SDCARD: fast mode, after initialization */
     FuriHalSpiDeviceIdSdCardSlow,    /** SDCARD: slow mode, before initialization */
     FuriHalSpiDeviceIdNfc,           /** NFC: ST25R3916, pretty standard, but RFAL makes it complex */
+    FuriHalSpiDeviceIdExtSpi,        /** External SPI interface */
 
     FuriHalSpiDeviceIdMax,           /** Service Value, do not use */
 } FuriHalSpiDeviceId;

--- a/firmware/targets/f7/furi-hal/furi-hal-spi.c
+++ b/firmware/targets/f7/furi-hal/furi-hal-spi.c
@@ -12,18 +12,21 @@
 #define TAG "FuriHalSpi"
 
 void furi_hal_spi_bus_init(const FuriHalSpiBus* bus) {
-    // Spi structure is const, but mutex is not
-    // Need some hell-ish casting to make it work
-    // 
-    if (bus->mutex == NULL) {
-        *(osMutexId_t*)(bus->mutex) = osMutexNew(NULL);
+    furi_assert(bus);
+    furi_assert(bus->mutex);
+
+    if (*bus->mutex == NULL) {
+        *bus->mutex = osMutexNew(NULL);
     }
+
     hal_gpio_init_ex(bus->miso, GpioModeAltFunctionPushPull, GpioPullNo, GpioSpeedVeryHigh, bus->alt_fn);
     hal_gpio_init_ex(bus->mosi, GpioModeAltFunctionPushPull, GpioPullNo, GpioSpeedVeryHigh, bus->alt_fn);
     hal_gpio_init_ex(bus->clk, GpioModeAltFunctionPushPull, GpioPullNo, GpioSpeedVeryHigh, bus->alt_fn);
 }
 
 void furi_hal_spi_device_cs_init(const FuriHalSpiDevice* device) {
+    furi_assert(device);
+
     hal_gpio_init(
         device->chip_select,
         GpioModeOutputPushPull,
@@ -49,12 +52,14 @@ void furi_hal_spi_init() {
 
 void furi_hal_spi_bus_lock(const FuriHalSpiBus* bus) {
     furi_assert(bus);
-    furi_check(osMutexAcquire(*bus->mutex, osWaitForever) == osOK);
+    furi_assert(bus->mutex);
+    furi_check(osMutexAcquire(*(bus->mutex), osWaitForever) == osOK);
 }
 
 void furi_hal_spi_bus_unlock(const FuriHalSpiBus* bus) {
     furi_assert(bus);
-    furi_check(osMutexRelease(*bus->mutex) == osOK);
+    furi_assert(bus->mutex);
+    furi_check(osMutexRelease(*(bus->mutex)) == osOK);
 }
 
 void furi_hal_spi_bus_configure(const FuriHalSpiBus* bus, const LL_SPI_InitTypeDef* config) {

--- a/firmware/targets/f7/furi-hal/furi-hal-spi.c
+++ b/firmware/targets/f7/furi-hal/furi-hal-spi.c
@@ -124,7 +124,7 @@ bool furi_hal_spi_bus_trx(const FuriHalSpiBus* bus, uint8_t* tx_buffer, uint8_t*
             tx_size--;
             tx_allowed = false;
         }
-        
+
         if(LL_SPI_IsActiveFlag_RXNE((SPI_TypeDef *)bus->spi)) {
             *rx_buffer = LL_SPI_ReceiveData8((SPI_TypeDef *)bus->spi);
             rx_buffer++;

--- a/firmware/targets/f7/furi-hal/furi-hal-spi.h
+++ b/firmware/targets/f7/furi-hal/furi-hal-spi.h
@@ -60,16 +60,26 @@ bool furi_hal_spi_bus_trx(const FuriHalSpiBus* bus, uint8_t* tx_buffer, uint8_t*
 /* Device Level API */
 
 /** Reconfigure SPI bus for device
- * @param device - device description
+ * @param device - device description. 
  */
 void furi_hal_spi_device_configure(const FuriHalSpiDevice* device);
 
 /** Get Device handle
  * And lock access to the corresponding SPI BUS
  * @param device_id - device identifier
+ *   For FuriHalSpiDeviceIdExtSpi, uses default config. 
+ *   For custom SPI config, use furi_hal_spi_custom_device_get
  * @return device handle
  */
 const FuriHalSpiDevice* furi_hal_spi_device_get(FuriHalSpiDeviceId device_id);
+
+/** Get Custom Device handle
+ * And lock access to the corresponding SPI BUS
+ * @param device_config - device configuration descriptor
+ *   If NULL, default configuration is used.
+ * @return device handle
+ */
+const FuriHalSpiDevice* furi_hal_spi_custom_device_get(const LL_SPI_InitTypeDef* device_config);
 
 /** Return Device handle
  * And unlock access to the corresponding SPI BUS


### PR DESCRIPTION
# What's new

- Added `FuriHalSpiDeviceId::FuriHalSpiDeviceIdExtSpi` and automatic reconfiguration of SPI1 interface to external pins
- Added `furi_hal_spi_custom_device_get` to SPI API for usage with customized SPI configuration of external modules

# Verification 

- Build and run basic checks for radio & NFC module. 
- To check `FuriHalSpiDeviceIdExtSpi` and `furi_hal_spi_custom_device_get`, there must be a new application utilizing that API

# Checklist (do not modify)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
