### PR TITLE
[FL-2061] Scripts: add serial number support to cube programmer api, update usage.

### DIFF
--- a/scripts/flipper/cube.py
+++ b/scripts/flipper/cube.py
@@ -5,23 +5,35 @@ import subprocess
 class CubeProgrammer:
     """STM32 Cube Programmer cli wrapper"""
 
-    def __init__(self, port, params=[]):
-        self.port = port
-        self.params = params
+    def __init__(self, config={}):
+        assert isinstance(config, dict)
+        # Params base
+        self.params = []
+        # Connect params
+        connect = []
+        if "port" in config and config["port"]:
+            connect.append(f"port={config['port']}")
+        else:
+            connect.append(f"port=swd")
+        if "serial" in config and config["serial"]:
+            connect.append(f"sn={config['serial']}")
+        self.params.append("-c " + " ".join(connect))
+        # Other params
+        if "params" in config:
+            self.params += config["params"]
         # logging
         self.logger = logging.getLogger()
 
     def _execute(self, args):
         try:
-            output = subprocess.check_output(
-                [
-                    "STM32_Programmer_CLI",
-                    "-q",
-                    f"-c port={self.port}",
-                    *self.params,
-                    *args,
-                ]
-            )
+            params = [
+                "STM32_Programmer_CLI",
+                "-q",
+                *self.params,
+                *args,
+            ]
+            self.logger.debug(f"_execute: {params}")
+            output = subprocess.check_output(params)
         except subprocess.CalledProcessError as e:
             if e.output:
                 print("Process output:\n", e.output.decode())

--- a/scripts/ob.py
+++ b/scripts/ob.py
@@ -16,18 +16,26 @@ class Main(App):
         self.parser_check = self.subparsers.add_parser(
             "check", help="Check Option Bytes"
         )
-        self.parser_check.add_argument(
-            "--port", type=str, help="Port to connect: swd or usb1", default="swd"
-        )
+        self._addArgsSWD(self.parser_check)
         self.parser_check.set_defaults(func=self.check)
         # Set command
         self.parser_set = self.subparsers.add_parser("set", help="Set Option Bytes")
-        self.parser_set.add_argument(
-            "--port", type=str, help="Port to connect: swd or usb1", default="swd"
-        )
+        self._addArgsSWD(self.parser_set)
         self.parser_set.set_defaults(func=self.set)
         # OB
         self.ob = {}
+
+    def _addArgsSWD(self, parser):
+        parser.add_argument(
+            "--port", type=str, help="Port to connect: swd or usb1", default="swd"
+        )
+        parser.add_argument("--serial", type=str, help="ST-Link Serial Number")
+
+    def _getCubeParams(self):
+        return {
+            "port": self.args.port,
+            "serial": self.args.serial,
+        }
 
     def before(self):
         self.logger.info(f"Loading Option Bytes data")
@@ -39,7 +47,7 @@ class Main(App):
 
     def check(self):
         self.logger.info(f"Checking Option Bytes")
-        cp = CubeProgrammer(self.args.port)
+        cp = CubeProgrammer(self._getCubeParams())
         if cp.checkOptionBytes(self.ob):
             self.logger.info(f"OB Check OK")
             return 0
@@ -49,7 +57,7 @@ class Main(App):
 
     def set(self):
         self.logger.info(f"Setting Option Bytes")
-        cp = CubeProgrammer(self.args.port)
+        cp = CubeProgrammer(self._getCubeParams())
         if cp.setOptionBytes(self.ob):
             self.logger.info(f"OB Set OK")
             return 0


### PR DESCRIPTION
# What's new

- Scripts: add serial number support to cube programmer api, update usage.

# Verification 

- Use `flash.py` `ob.py` `otp.py`

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [X] I've built this code, uploaded it to the device and verified feature/bugfix
