### PR TITLE
SubGhz: faster mess_with_iv

### DIFF
--- a/lib/subghz/subghz_keystore.c
+++ b/lib/subghz/subghz_keystore.c
@@ -81,20 +81,25 @@ static void subghz_keystore_mess_with_iv(uint8_t* iv) {
     // Sharing them will bring some discomfort to legal owners
     // And potential legal action against you
     // While you reading this code think about your own personal responsibility
-    asm volatile("movs   r0, #0x0    \n"
-                 "movs   r1, #0x0    \n"
-                 "movs   r2, #0x0    \n"
-                 "nani:              \n"
-                 "ldrb   r1, [r0, %0]\n"
-                 "add    r1, r2      \n"
-                 "rsb    r2, r1      \n"
-                 "strb   r1, [r0, %0]\n"
-                 "adds   r0, #0x1    \n"
-                 "cmp    r0, #0xF    \n"
-                 "bls    nani        \n"
+    asm volatile("nani:                    \n"
+                 "ldrd  r0, r2, [%0, #0x0] \n"
+                 "lsl   r1, r0, #8         \n"
+                 "lsl   r3, r2, #8         \n"
+                 "orr   r3, r3, r0, lsr #24\n"
+                 "uadd8 r1, r1, r0         \n"
+                 "uadd8 r3, r3, r2         \n"
+                 "strd  r1, r3, [%0, #0x0] \n"
+                 "ldrd  r1, r3, [%0, #0x8] \n"
+                 "lsl   r0, r1, #8         \n"
+                 "orr   r0, r0, r2, lsr #24\n"
+                 "lsl   r2, r3, #8         \n"
+                 "orr   r2, r2, r1, lsr #24\n"
+                 "uadd8 r1, r1, r0         \n"
+                 "uadd8 r3, r3, r2         \n"
+                 "strd  r1, r3, [%0, #0x8] \n"
                  :
                  : "r"(iv)
-                 : "r0", "r1", "r2", "memory");
+                 : "r0", "r1", "r2", "r3", "memory");
 }
 
 static bool subghz_keystore_read_file(SubGhzKeystore* instance, File* file, uint8_t* iv) {

--- a/lib/subghz/subghz_keystore.c
+++ b/lib/subghz/subghz_keystore.c
@@ -84,19 +84,17 @@ static void subghz_keystore_mess_with_iv(uint8_t* iv) {
     asm volatile("movs   r0, #0x0    \n"
                  "movs   r1, #0x0    \n"
                  "movs   r2, #0x0    \n"
-                 "movs   r3, #0x0    \n"
                  "nani:              \n"
                  "ldrb   r1, [r0, %0]\n"
-                 "mov    r2, r1      \n"
-                 "add    r1, r3      \n"
-                 "mov    r3, r2      \n"
+                 "add    r1, r2      \n"
+                 "rsb    r2, r1      \n"
                  "strb   r1, [r0, %0]\n"
                  "adds   r0, #0x1    \n"
                  "cmp    r0, #0xF    \n"
                  "bls    nani        \n"
                  :
                  : "r"(iv)
-                 : "r0", "r1", "r2", "r3", "memory");
+                 : "r0", "r1", "r2", "memory");
 }
 
 static bool subghz_keystore_read_file(SubGhzKeystore* instance, File* file, uint8_t* iv) {


### PR DESCRIPTION
# What's new

- removed branching and used DSP instructions to reduce the total number of instructions from 132 to 15 for the same result

# Verification 

- should give same as before but much faster (checked on a M33 core)

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
