### PR TITLE
Fix butthurt and battery

### DIFF
--- a/applications/dolphin/dolphin.c
+++ b/applications/dolphin/dolphin.c
@@ -88,7 +88,6 @@ static void dolphin_check_butthurt(DolphinState* state) {
     float diff_time = difftime(state->data.timestamp, dolphin_state_timestamp());
 
     if((fabs(diff_time)) > DOLPHIN_TIMEGATE) {
-        FURI_LOG_I("DolphinState", "Increasing butthurt");
         dolphin_state_butthurted(state);
     }
 }

--- a/applications/dolphin/helpers/dolphin_state.c
+++ b/applications/dolphin/helpers/dolphin_state.c
@@ -12,6 +12,9 @@
 #define DOLPHIN_LVL_THRESHOLD 20.0f
 #define LEVEL2_THRESHOLD 20
 #define LEVEL3_THRESHOLD 100
+#define BUTTHURT_MAX    14
+#define BUTTHURT_MIN    0
+
 
 DolphinState* dolphin_state_alloc() {
     return furi_alloc(sizeof(DolphinState));
@@ -44,20 +47,26 @@ bool dolphin_state_save(DolphinState* dolphin_state) {
 }
 
 bool dolphin_state_load(DolphinState* dolphin_state) {
-    bool loaded = saved_struct_load(
+    bool success = saved_struct_load(
         DOLPHIN_STATE_PATH,
         &dolphin_state->data,
         sizeof(DolphinStoreData),
         DOLPHIN_STATE_HEADER_MAGIC,
         DOLPHIN_STATE_HEADER_VERSION);
 
-    if(!loaded) {
+    if (success) {
+        if ((dolphin_state->data.butthurt > BUTTHURT_MAX) || (dolphin_state->data.butthurt < BUTTHURT_MIN)) {
+            success = false;
+        }
+    }
+
+    if(!success) {
         FURI_LOG_W(TAG, "Reset dolphin-state");
         memset(dolphin_state, 0, sizeof(*dolphin_state));
         dolphin_state->dirty = true;
     }
 
-    return loaded;
+    return success;
 }
 
 uint64_t dolphin_state_timestamp() {
@@ -125,7 +134,7 @@ bool dolphin_state_on_deed(DolphinState* dolphin_state, DolphinDeed deed) {
     }
 
     uint32_t new_butthurt =
-        CLAMP(((int32_t)dolphin_state->data.butthurt) + deed_weight->butthurt, 14, 0);
+        CLAMP(((int32_t)dolphin_state->data.butthurt) + deed_weight->butthurt, BUTTHURT_MAX, BUTTHURT_MIN);
 
     if(!!dolphin_state->data.butthurt != !!new_butthurt) {
         mood_changed = true;
@@ -138,9 +147,12 @@ bool dolphin_state_on_deed(DolphinState* dolphin_state, DolphinDeed deed) {
 }
 
 void dolphin_state_butthurted(DolphinState* dolphin_state) {
-    dolphin_state->data.butthurt++;
-    dolphin_state->data.timestamp = dolphin_state_timestamp();
-    dolphin_state->dirty = true;
+    if (dolphin_state->data.butthurt < BUTTHURT_MAX) {
+        dolphin_state->data.butthurt++;
+        FURI_LOG_I("DolphinState", "Increasing butthurt");
+        dolphin_state->data.timestamp = dolphin_state_timestamp();
+        dolphin_state->dirty = true;
+    }
 }
 
 void dolphin_state_increase_level(DolphinState* dolphin_state) {

--- a/applications/dolphin/helpers/dolphin_state.c
+++ b/applications/dolphin/helpers/dolphin_state.c
@@ -12,9 +12,8 @@
 #define DOLPHIN_LVL_THRESHOLD 20.0f
 #define LEVEL2_THRESHOLD 20
 #define LEVEL3_THRESHOLD 100
-#define BUTTHURT_MAX    14
-#define BUTTHURT_MIN    0
-
+#define BUTTHURT_MAX 14
+#define BUTTHURT_MIN 0
 
 DolphinState* dolphin_state_alloc() {
     return furi_alloc(sizeof(DolphinState));
@@ -54,8 +53,9 @@ bool dolphin_state_load(DolphinState* dolphin_state) {
         DOLPHIN_STATE_HEADER_MAGIC,
         DOLPHIN_STATE_HEADER_VERSION);
 
-    if (success) {
-        if ((dolphin_state->data.butthurt > BUTTHURT_MAX) || (dolphin_state->data.butthurt < BUTTHURT_MIN)) {
+    if(success) {
+        if((dolphin_state->data.butthurt > BUTTHURT_MAX) ||
+           (dolphin_state->data.butthurt < BUTTHURT_MIN)) {
             success = false;
         }
     }
@@ -133,8 +133,10 @@ bool dolphin_state_on_deed(DolphinState* dolphin_state, DolphinDeed deed) {
         dolphin_state->data.icounter += MIN(xp_to_levelup, deed_weight->icounter);
     }
 
-    uint32_t new_butthurt =
-        CLAMP(((int32_t)dolphin_state->data.butthurt) + deed_weight->butthurt, BUTTHURT_MAX, BUTTHURT_MIN);
+    uint32_t new_butthurt = CLAMP(
+        ((int32_t)dolphin_state->data.butthurt) + deed_weight->butthurt,
+        BUTTHURT_MAX,
+        BUTTHURT_MIN);
 
     if(!!dolphin_state->data.butthurt != !!new_butthurt) {
         mood_changed = true;
@@ -147,7 +149,7 @@ bool dolphin_state_on_deed(DolphinState* dolphin_state, DolphinDeed deed) {
 }
 
 void dolphin_state_butthurted(DolphinState* dolphin_state) {
-    if (dolphin_state->data.butthurt < BUTTHURT_MAX) {
+    if(dolphin_state->data.butthurt < BUTTHURT_MAX) {
         dolphin_state->data.butthurt++;
         FURI_LOG_I("DolphinState", "Increasing butthurt");
         dolphin_state->data.timestamp = dolphin_state_timestamp();

--- a/applications/power/power_service/power.c
+++ b/applications/power/power_service/power.c
@@ -7,7 +7,7 @@
 #include <gui/view.h>
 
 #define POWER_OFF_TIMEOUT 90
-#define POWER_BATTERY_WELL_LEVEL 99
+#define POWER_BATTERY_WELL_LEVEL 70
 
 bool power_is_battery_well(PowerInfo* info) {
     return info->health > POWER_BATTERY_WELL_LEVEL;
@@ -172,6 +172,7 @@ static void power_check_battery_level_change(Power* power) {
 int32_t power_srv(void* p) {
     (void)p;
     Power* power = power_alloc();
+    power_update_info(power);
     furi_record_create("power", power);
 
     while(1) {


### PR DESCRIPTION
# What's new

- Fix crashing: butthurt overrun (> 14) causes no animation to select and furi_assert() hanging
- Fix false battery warning animation: can get 'power' record before it actually has battery_info
- Decrease battery warn level 99 -> 70

# Verification 

- Get high butthurt and wait for 1 day
- Get high butthurt, restart flipper

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
