### PR TITLE
fix build for Python versions <3.9

### DIFF
--- a/scripts/meta.py
+++ b/scripts/meta.py
@@ -49,7 +49,7 @@ class Main(App):
         for path in self.args.input[0]:
             with open(path, mode="r") as file:
                 dict = json.loads(file.read())
-                full |= dict
+                full.update(dict)
 
         print(json.dumps(full, indent=4))
         return 0


### PR DESCRIPTION
# What's new

- Fix the following build issue on Ubuntu 20.04:

```
  File "./scripts/meta.py", line 52, in merge
    full |= dict
TypeError: unsupported operand type(s) for |=: 'dict' and 'dict'
make: *** [Makefile:17: all] Error 1
```

The merge (|) and update (|=) operators for dictionaries were introduced in Python 3.9 so they do not work in older versions. Use an equivalent

# Verification 

- Compile

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
