### PR TITLE
Fix readme typos

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -148,7 +148,7 @@ make whole
   * cli - Console service
   * debug_tools - different tools that we use on factory and for debug
   * dialogs - service for showing GUI dialogs
-  * dolphin - dolphin service and supplientary apps
+  * dolphin - dolphin service and supplementary apps
   * gpio-tester - GPIO control application
   * gui - GUI service
   * ibutton - ibutton application, onewire keys and more
@@ -187,7 +187,7 @@ make whole
   * app-scened-template - scened template app library
   * app-template - template app library
   * callback-connector - callback connector library
-  * common-api - common api delaration library
+  * common-api - common api declaration library
   * cyfral - cyfral library
   * drivers - drivers that we wrote
   * fatfs - external storage file system

--- a/assets/ReadMe.md
+++ b/assets/ReadMe.md
@@ -18,12 +18,12 @@ make all
 
 - `NAME`    - mandatory - Asset name in CamelCase. [A-Za-z0-9], special symbols not allowed
 - `VARIANT` - optional  - icon variant: can relate to state or rendering conditions. Examples: active, inactive, inverted.
-- `SIZE`    - mandatory - size in px. Example squere 10, 20, 24, etc. Example rectangular: 10x8, 19x5, etc.
+- `SIZE`    - mandatory - size in px. Example square 10, 20, 24, etc. Example rectangular: 10x8, 19x5, etc.
 
 Image names will be automatically prefixed with `I_`, animation names with `A_`.
 Icons and Animations will be gathered into `icon.h` and `icon.c`.
 
 # Important notes
 
-Don't include assets that you are not using, compiller is not going to strip unusued assets.
+Don't include assets that you are not using, compiler is not going to strip unused assets.
 

--- a/bootloader/ReadMe.md
+++ b/bootloader/ReadMe.md
@@ -16,7 +16,7 @@ What it does?
 | f7        | 0x08000000    | 0x00008000    | L+Back    | L+Back, hold L    |
 
 Also there is a ST bootloader combo available on empty device: L+Ok+Back, release Back,Left.
-Target independend code and headers in `src` and `target/include` folders.
+Target independent code and headers in `src` and `target/include` folders.
 
 # Building
 

--- a/firmware/ReadMe.md
+++ b/firmware/ReadMe.md
@@ -16,7 +16,7 @@ What it does?
 | f7        | 0x08000000    | 0x00008000    | L+Back    | L+Back, hold L    |
 
 Also there is a ST bootloader combo available on empty device: L+Ok+Back, release Back,Left.
-Target independend code and headers in `target/include` folders.
+Target independent code and headers in `target/include` folders.
 
 # Building
 

--- a/scripts/ReadMe.md
+++ b/scripts/ReadMe.md
@@ -6,7 +6,7 @@ You will need to add STM32_Programmer_CLI to your path to use them.
 
 # Flashing empty MCU/Flipper
 
-Always flash your device in the folllowing sequence:
+Always flash your device in the following sequence:
 
 - OTP (Only on empty MCU)
 - Core1 and Core2 firmware flashing
@@ -19,7 +19,7 @@ Always flash your device in the folllowing sequence:
 Normally OTP data generated and flashed at the factory.
 In case if MCU was replaced you'll need correct OTP data to be able to use companion applications.
 Use `otp.py` to generate and flash OTP data.
-You will need exact main board revision to genrate OTP data. It can be found on main PCB.
+You will need exact main board revision to generate OTP data. It can be found on main PCB.
 Also display type, region and etc...
 
 !!! Flashing incorrect OTP may permanently brick your device !!!
@@ -32,12 +32,12 @@ Never flash FUS or you will loose your job, girlfriend and keys in secure enclav
 
 ## Option Bytes
 
-!!! Setting incorrect Otion Bytes may brick your MCU !!!
+!!! Setting incorrect Option Bytes may brick your MCU !!!
 
 Defaults are mostly OK, but there are couple things that we'd like to tune.
 Also OB may be damaged, so we've made couple scripts to check and set option bytes.
 
-!!! Setting incorrect Otion Bytes may brick your MCU !!!
+!!! Setting incorrect Option Bytes may brick your MCU !!!
 
 Checking option bytes:
 


### PR DESCRIPTION
There is also a lot of markdown format issues (like multiple first-level headers, etc) in readme files, I can fix them as well if you'd like.