### PR TITLE
CI: Remove pycache from artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,11 @@ jobs:
           echo "::set-output name=short-hash::${SHA}"
           echo "::set-output name=default-target::${DEFAULT_TARGET}"
 
+      - name: 'Bundle scripts'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        run: |
+          tar czpf artifacts/flipper-z-any-scripts-${{steps.names.outputs.suffix}}.tgz scripts
+
       - name: 'Build the firmware in docker'
         uses: ./.github/actions/docker
         with:
@@ -91,11 +96,6 @@ jobs:
             do
               mv dist/${TARGET}/* artifacts/
             done
-
-      - name: 'Bundle scripts'
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-          tar czpf artifacts/flipper-z-any-scripts-${{steps.names.outputs.suffix}}.tgz scripts
 
       - name: 'Bundle resources'
         if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,14 +92,6 @@ jobs:
               mv dist/${TARGET}/* artifacts/
             done
 
-      - name: 'Bundle core2 firmware'
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-          test -d core2_firmware && rm -rf core2_firmware || true
-          mkdir core2_firmware
-          ./scripts/assets.py copro lib/STM32CubeWB core2_firmware STM32WB5x
-          tar czpf artifacts/flipper-z-any-core2_firmware-${{steps.names.outputs.suffix}}.tgz core2_firmware
-
       - name: 'Bundle scripts'
         if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
@@ -110,6 +102,14 @@ jobs:
         run: |
           ./scripts/assets.py manifest assets/resources
           tar czpf artifacts/flipper-z-any-resources-${{steps.names.outputs.suffix}}.tgz -C assets resources
+
+      - name: 'Bundle core2 firmware'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        run: |
+          test -d core2_firmware && rm -rf core2_firmware || true
+          mkdir core2_firmware
+          ./scripts/assets.py copro lib/STM32CubeWB core2_firmware STM32WB5x
+          tar czpf artifacts/flipper-z-any-core2_firmware-${{steps.names.outputs.suffix}}.tgz core2_firmware
 
       - name: 'Upload artifacts to update server'
         if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/scripts/meta.py
+++ b/scripts/meta.py
@@ -35,7 +35,7 @@ class Main(App):
     def generate(self):
         meta = {}
         for k, v in vars(self.args).items():
-            if k == "project" or k == "func":
+            if k in ["project", "func", "debug"]:
                 continue
             if isinstance(v, str):
                 v = v.strip('"')


### PR DESCRIPTION
# What's new

- Reordered CI steps to avoid `pycache` getting into artifacts
- Fixed `_debug` fields appearing in core1 meta json files

# Verification 

- [flipper-z-any-scripts.tgz](https://update.flipperzero.one/builds/firmware/ktq/ci_fix_artifacts/flipper-z-any-scripts-ktq_ci_fix_artifacts-01122021-8b38250f.tgz) has no `flipper/__pycache__/` folder inside
- [flipper-z-f7-full.json](https://update.flipperzero.one/builds/firmware/ktq/ci_fix_artifacts/flipper-z-f7-full-ktq_ci_fix_artifacts-01122021-8b38250f.json) has no `bootloader_debug` and `firmware_debug` fields

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
