### PR TITLE
[FL-2086] SubGhz: Fix Errors

### DIFF
--- a/applications/cli/cli_commands.c
+++ b/applications/cli/cli_commands.c
@@ -466,7 +466,7 @@ void cli_command_i2c(Cli* cli, string_t args, void* context) {
     uint8_t test = 0;
     printf("Scanning external i2c on PC0(SCL)/PC1(SDA)\r\n"
            "Clock: 100khz, 7bit address\r\n"
-           "!!! Invasive mode (tx to device) !!!\r\n\r\n");
+           "\r\n");
     printf("  | 0 1 2 3 4 5 6 7 8 9 A B C D E F\r\n");
     printf("--+--------------------------------\r\n");
     for(uint8_t row = 0; row < 0x8; row++) {

--- a/applications/subghz/subghz_cli.c
+++ b/applications/subghz/subghz_cli.c
@@ -406,7 +406,7 @@ static void subghz_cli_command_chat(Cli* cli, string_t args) {
                 putc(c, stdout);
                 fflush(stdout);
                 string_push_back(input, c);
-            } else if((c == CliSymbolAsciiBackspace) || (c== CliSymbolAsciiDel)) {
+            } else if((c == CliSymbolAsciiBackspace) || (c == CliSymbolAsciiDel)) {
                 size_t len = string_size(input);
                 if(len > string_size(name)) {
                     printf("%s", "\e[D\e[1P");

--- a/applications/subghz/subghz_cli.c
+++ b/applications/subghz/subghz_cli.c
@@ -440,6 +440,7 @@ static void subghz_cli_command_chat(Cli* cli, string_t args) {
             printf("%s", string_get_cstr(input));
             fflush(stdout);
         }
+        osDelay(1);
     }
 
     printf("\r\nExit chat\r\n");

--- a/applications/subghz/subghz_cli.c
+++ b/applications/subghz/subghz_cli.c
@@ -406,16 +406,12 @@ static void subghz_cli_command_chat(Cli* cli, string_t args) {
                 putc(c, stdout);
                 fflush(stdout);
                 string_push_back(input, c);
-            } else if(c == CliSymbolAsciiBackspace) {
+            } else if((c == CliSymbolAsciiBackspace) || (c== CliSymbolAsciiDel)) {
                 size_t len = string_size(input);
                 if(len > string_size(name)) {
-                    string_set_strn(input, string_get_cstr(input), len - 1);
-                    printf("\r");
-                    for(uint8_t i = 0; i < len; i++) {
-                        printf(" ");
-                    }
-                    printf("\r%s", string_get_cstr(input));
+                    printf("%s", "\e[D\e[1P");
                     fflush(stdout);
+                    string_set_strn(input, string_get_cstr(input), len - 1);
                 }
             } else if(c == CliSymbolAsciiCR) {
                 printf("\r\n");

--- a/applications/subghz/subghz_i.c
+++ b/applications/subghz/subghz_i.c
@@ -320,7 +320,7 @@ bool subghz_save_protocol_to_file(SubGhz* subghz, const char* dev_name) {
             break;
         }
         // Create saved directory if necessary
-        if(!storage_simply_mkdir(storage, SUBGHZ_APP_FOLDER)) {
+        if(!storage_simply_mkdir(storage, SUBGHZ_APP_PATH_FOLDER)) {
             dialog_message_show_storage_error(subghz->dialogs, "Cannot create\nfolder");
             break;
         }


### PR DESCRIPTION
# What's new

- CLI: fix main GUI freeze while subghz chat is running
- CLI: fix processing backspace in the web console
- [FL-2086] SubGhz: fix can't save signals in sub'e to internal memory

# Verification 

- Compile and download
- Go to https://update.flipperzero.one/ in the web console run "subghz chat" and check the backspace ability, and the GUI hangs on the Flipper itself

# Checklist (do not modify)

- [X] PR has description of feature/bug or link to Confluence/Jira task
- [X] Description contains actions to verify feature/bugfix
- [X] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-2086]: https://flipperzero.atlassian.net/browse/FL-2086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ