### PR TITLE
subghz chat: add vibration on input message, send joined/left events …

### DIFF
--- a/applications/subghz/subghz_cli.c
+++ b/applications/subghz/subghz_cli.c
@@ -395,13 +395,16 @@ static void subghz_cli_command_chat(Cli* cli, string_t args) {
     char c;
     bool exit = false;
 
+    NotificationApp* notification = furi_record_open("notification");
+
     string_printf(name, "\033[0;33m%s\033[0m: ", furi_hal_version_get_name_ptr());
     string_set(input, name);
     printf("%s", string_get_cstr(input));
     fflush(stdout);
 
     string_printf(sysmsg, "\033[0;34m%s joined chat.\033[0m", furi_hal_version_get_name_ptr());
-    subghz_tx_rx_worker_write(subghz_txrx, (uint8_t*)string_get_cstr(sysmsg), strlen(string_get_cstr(sysmsg)));
+    subghz_tx_rx_worker_write(
+        subghz_txrx, (uint8_t*)string_get_cstr(sysmsg), strlen(string_get_cstr(sysmsg)));
 
     while(!exit) {
         if(furi_hal_vcp_rx_with_timeout((uint8_t*)&c, 1, 0) == 1) {
@@ -443,15 +446,14 @@ static void subghz_cli_command_chat(Cli* cli, string_t args) {
             printf("%s", string_get_cstr(input));
             fflush(stdout);
 
-            NotificationApp* notification = furi_record_open("notification");
-            notification_message_block(notification, &sequence_single_vibro);
-            furi_record_close("notification");
+            notification_message(notification, &sequence_single_vibro);
         }
         osDelay(1);
     }
 
     string_printf(sysmsg, "\033[0;31m%s left chat.\033[0m", furi_hal_version_get_name_ptr());
-    subghz_tx_rx_worker_write(subghz_txrx, (uint8_t*)string_get_cstr(sysmsg), strlen(string_get_cstr(sysmsg)));
+    subghz_tx_rx_worker_write(
+        subghz_txrx, (uint8_t*)string_get_cstr(sysmsg), strlen(string_get_cstr(sysmsg)));
     osDelay(10);
 
     printf("\r\nExit chat\r\n");
@@ -459,6 +461,7 @@ static void subghz_cli_command_chat(Cli* cli, string_t args) {
     string_clear(name);
     string_clear(sysmsg);
     furi_hal_power_suppress_charge_exit();
+    furi_record_close("notification");
 
     if(subghz_tx_rx_worker_is_running(subghz_txrx)) {
         subghz_tx_rx_worker_stop(subghz_txrx);

--- a/applications/subghz/subghz_cli.c
+++ b/applications/subghz/subghz_cli.c
@@ -11,6 +11,8 @@
 #include <lib/subghz/protocols/subghz_protocol_princeton.h>
 #include <lib/subghz/subghz_tx_rx_worker.h>
 
+#include <notification/notification-messages.h>
+
 #define SUBGHZ_FREQUENCY_RANGE_STR \
     "299999755...348000000 or 386999938...464000000 or 778999847...928000000"
 
@@ -388,6 +390,8 @@ static void subghz_cli_command_chat(Cli* cli, string_t args) {
     string_init(input);
     string_t name;
     string_init(name);
+    string_t sysmsg;
+    string_init(sysmsg);
     char c;
     bool exit = false;
 
@@ -395,6 +399,9 @@ static void subghz_cli_command_chat(Cli* cli, string_t args) {
     string_set(input, name);
     printf("%s", string_get_cstr(input));
     fflush(stdout);
+
+    string_printf(sysmsg, "\033[0;34m%s joined chat.\033[0m", furi_hal_version_get_name_ptr());
+    subghz_tx_rx_worker_write(subghz_txrx, (uint8_t*)string_get_cstr(sysmsg), strlen(string_get_cstr(sysmsg)));
 
     while(!exit) {
         if(furi_hal_vcp_rx_with_timeout((uint8_t*)&c, 1, 0) == 1) {
@@ -435,13 +442,22 @@ static void subghz_cli_command_chat(Cli* cli, string_t args) {
 
             printf("%s", string_get_cstr(input));
             fflush(stdout);
+
+            NotificationApp* notification = furi_record_open("notification");
+            notification_message_block(notification, &sequence_single_vibro);
+            furi_record_close("notification");
         }
         osDelay(1);
     }
 
+    string_printf(sysmsg, "\033[0;31m%s left chat.\033[0m", furi_hal_version_get_name_ptr());
+    subghz_tx_rx_worker_write(subghz_txrx, (uint8_t*)string_get_cstr(sysmsg), strlen(string_get_cstr(sysmsg)));
+    osDelay(10);
+
     printf("\r\nExit chat\r\n");
     string_clear(input);
     string_clear(name);
+    string_clear(sysmsg);
     furi_hal_power_suppress_charge_exit();
 
     if(subghz_tx_rx_worker_is_running(subghz_txrx)) {


### PR DESCRIPTION

# What's new

- vibration on input message
- send message when user join or left chat

# Verification 

- start `subghz chat` in CLI on two devices
- try to send message
- see output

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
