### PR TITLE
Fix address in I2C scanner

### DIFF
--- a/applications/cli/cli_commands.c
+++ b/applications/cli/cli_commands.c
@@ -472,8 +472,8 @@ void cli_command_i2c(Cli* cli, string_t args, void* context) {
     for(uint8_t row = 0; row < 0x8; row++) {
         printf("%x | ", row);
         for(uint8_t column = 0; column <= 0xF; column++) {
-            bool ret =
-                furi_hal_i2c_rx(&furi_hal_i2c_handle_external, (row << 4) + column, &test, 1, 2);
+            bool ret = furi_hal_i2c_rx(
+                &furi_hal_i2c_handle_external, ((row << 4) + column) << 1, &test, 1, 2);
             printf("%c ", ret ? '#' : '-');
         }
         printf("\r\n");


### PR DESCRIPTION
# What's new

I2C scanner didn't work. The least significant bit of the address is read/write bit, so the address should be shifted.

Tested on a real flipper with an I2C IMU connected.

# Verification 

Run I2C scanner with an I2C device connected.

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
