### PR TITLE
Bootloader size optimizations

### DIFF
--- a/bootloader/targets/f6/furi-hal/furi-hal-version.c
+++ b/bootloader/targets/f6/furi-hal/furi-hal-version.c
@@ -87,29 +87,7 @@ typedef struct {
 static FuriHalVersion furi_hal_version = {0};
 
 static void furi_hal_version_set_name(const char* name) {
-    if(name != NULL) {
-        strlcpy(furi_hal_version.name, name, FURI_HAL_VERSION_ARRAY_NAME_LENGTH);
-        snprintf(
-            furi_hal_version.device_name,
-            FURI_HAL_VERSION_DEVICE_NAME_LENGTH,
-            "xFlipper %s",
-            furi_hal_version.name);
-    } else {
-        snprintf(furi_hal_version.device_name, FURI_HAL_VERSION_DEVICE_NAME_LENGTH, "xFlipper");
-    }
-
     furi_hal_version.device_name[0] = 0;
-
-    // BLE Mac address
-    uint32_t udn = LL_FLASH_GetUDN();
-    uint32_t company_id = LL_FLASH_GetSTCompanyID();
-    uint32_t device_id = LL_FLASH_GetDeviceID();
-    furi_hal_version.ble_mac[0] = (uint8_t)(udn & 0x000000FF);
-    furi_hal_version.ble_mac[1] = (uint8_t)((udn & 0x0000FF00) >> 8);
-    furi_hal_version.ble_mac[2] = (uint8_t)((udn & 0x00FF0000) >> 16);
-    furi_hal_version.ble_mac[3] = (uint8_t)device_id;
-    furi_hal_version.ble_mac[4] = (uint8_t)(company_id & 0x000000FF);
-    furi_hal_version.ble_mac[5] = (uint8_t)((company_id & 0x0000FF00) >> 8);
 }
 
 static void furi_hal_version_load_otp_default() {

--- a/bootloader/targets/f6/target.c
+++ b/bootloader/targets/f6/target.c
@@ -194,10 +194,12 @@ void target_display_init() {
     // Create payload
     u8g2_ClearBuffer(&fb);
     u8g2_SetDrawColor(&fb, 0x01);
-    u8g2_SetFont(&fb, u8g2_font_helvB08_tf);
     u8g2_DrawXBM(&fb, 0, 64 - 50, 128, 50, I_DFU_128x50);
+#ifndef SLIM_BOOTLOADER
+    u8g2_SetFont(&fb, u8g2_font_helvB08_tf);
     u8g2_DrawStr(&fb, 2, 8, "Update & Recovery Mode");
     u8g2_DrawStr(&fb, 2, 21, "DFU started");
+#endif
     // Send buffer
     u8g2_SetPowerSave(&fb, 0);
     u8g2_SendBuffer(&fb);

--- a/bootloader/targets/f7/furi-hal/furi-hal-version.c
+++ b/bootloader/targets/f7/furi-hal/furi-hal-version.c
@@ -87,29 +87,7 @@ typedef struct {
 static FuriHalVersion furi_hal_version = {0};
 
 static void furi_hal_version_set_name(const char* name) {
-    if(name != NULL) {
-        strlcpy(furi_hal_version.name, name, FURI_HAL_VERSION_ARRAY_NAME_LENGTH);
-        snprintf(
-            furi_hal_version.device_name,
-            FURI_HAL_VERSION_DEVICE_NAME_LENGTH,
-            "xFlipper %s",
-            furi_hal_version.name);
-    } else {
-        snprintf(furi_hal_version.device_name, FURI_HAL_VERSION_DEVICE_NAME_LENGTH, "xFlipper");
-    }
-
     furi_hal_version.device_name[0] = 0;
-
-    // BLE Mac address
-    uint32_t udn = LL_FLASH_GetUDN();
-    uint32_t company_id = LL_FLASH_GetSTCompanyID();
-    uint32_t device_id = LL_FLASH_GetDeviceID();
-    furi_hal_version.ble_mac[0] = (uint8_t)(udn & 0x000000FF);
-    furi_hal_version.ble_mac[1] = (uint8_t)((udn & 0x0000FF00) >> 8);
-    furi_hal_version.ble_mac[2] = (uint8_t)((udn & 0x00FF0000) >> 16);
-    furi_hal_version.ble_mac[3] = (uint8_t)device_id;
-    furi_hal_version.ble_mac[4] = (uint8_t)(company_id & 0x000000FF);
-    furi_hal_version.ble_mac[5] = (uint8_t)((company_id & 0x0000FF00) >> 8);
 }
 
 static void furi_hal_version_load_otp_default() {

--- a/bootloader/targets/f7/target.c
+++ b/bootloader/targets/f7/target.c
@@ -194,10 +194,12 @@ void target_display_init() {
     // Create payload
     u8g2_ClearBuffer(&fb);
     u8g2_SetDrawColor(&fb, 0x01);
-    u8g2_SetFont(&fb, u8g2_font_helvB08_tf);
     u8g2_DrawXBM(&fb, 0, 64 - 50, 128, 50, I_DFU_128x50);
+#ifndef SLIM_BOOTLOADER
+    u8g2_SetFont(&fb, u8g2_font_helvB08_tf);
     u8g2_DrawStr(&fb, 2, 8, "Update & Recovery Mode");
     u8g2_DrawStr(&fb, 2, 21, "DFU started");
+#endif
     // Send buffer
     u8g2_SetPowerSave(&fb, 0);
     u8g2_SendBuffer(&fb);

--- a/firmware/targets/f6/target.mk
+++ b/firmware/targets/f6/target.mk
@@ -19,9 +19,9 @@ BOOT_CFLAGS		= -DBOOT_ADDRESS=$(BOOT_ADDRESS) -DFW_ADDRESS=$(FW_ADDRESS) -DOS_OF
 MCU_FLAGS		= -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=hard
 
 CFLAGS			+= $(MCU_FLAGS) $(BOOT_CFLAGS) -DSTM32WB55xx -Wall -fdata-sections -ffunction-sections
-LDFLAGS			+= $(MCU_FLAGS) -specs=nosys.specs -specs=nano.specs 
+LDFLAGS			+= $(MCU_FLAGS) -specs=nosys.specs -specs=nano.specs -u _printf_float
 
-CPPFLAGS		+= -fno-rtti -fno-use-cxa-atexit -fno-exceptions 
+CPPFLAGS		+= -fno-rtti -fno-use-cxa-atexit -fno-exceptions
 LDFLAGS			+= -Wl,--start-group -lstdc++ -lsupc++ -Wl,--end-group
 
 HARDWARE_TARGET = 6

--- a/firmware/targets/f7/target.mk
+++ b/firmware/targets/f7/target.mk
@@ -19,9 +19,9 @@ BOOT_CFLAGS		= -DBOOT_ADDRESS=$(BOOT_ADDRESS) -DFW_ADDRESS=$(FW_ADDRESS) -DOS_OF
 MCU_FLAGS		= -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=hard
 
 CFLAGS			+= $(MCU_FLAGS) $(BOOT_CFLAGS) -DSTM32WB55xx -Wall -fdata-sections -ffunction-sections
-LDFLAGS			+= $(MCU_FLAGS) -specs=nosys.specs -specs=nano.specs 
+LDFLAGS			+= $(MCU_FLAGS) -specs=nosys.specs -specs=nano.specs -u _printf_float
 
-CPPFLAGS		+= -fno-rtti -fno-use-cxa-atexit -fno-exceptions 
+CPPFLAGS		+= -fno-rtti -fno-use-cxa-atexit -fno-exceptions
 LDFLAGS			+= -Wl,--start-group -lstdc++ -lsupc++ -Wl,--end-group
 
 HARDWARE_TARGET = 7

--- a/make/toolchain.mk
+++ b/make/toolchain.mk
@@ -27,4 +27,4 @@ endif
 
 CFLAGS		+= -fdata-sections -ffunction-sections -fno-math-errno -fstack-usage -MMD -MP -MF"$(@:%.o=%.d)"
 CPPFLAGS	+= -fno-threadsafe-statics -fno-use-cxa-atexit -fno-exceptions -fno-rtti
-LDFLAGS		+= -Wl,-Map=$(OBJ_DIR)/$(PROJECT).map,--cref -Wl,--gc-sections -Wl,--undefined=uxTopUsedPriority -u _printf_float -n
+LDFLAGS		+= -Wl,-Map=$(OBJ_DIR)/$(PROJECT).map,--cref -Wl,--gc-sections -Wl,--undefined=uxTopUsedPriority -n


### PR DESCRIPTION
# What's new

- Removed  `-u _printf_float` linker flag for bootloader project - drastically reduces binary size
- Removed Bluetooth-specific init in BL - also removes `snprintf` dependency, further reducing binary size. Anyway, `furi_hal_version.device_name[0]` was zeroed-out after all string formatting shenanigans.
- Introduced `SLIM_BOOTLOADER` definition (NOT active by default) - when defined, removes `Update & Recovery Mode` from bootloader screen, saving ~3kb on font data. That string can be included in splash screen bitmap, storing it much more efficiently.

# Verification 

- Build, check basic bootloader functionality and reduced size.

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
