### PR TITLE
Fix pid and vid for dfu-util

### DIFF
--- a/make/rules.mk
+++ b/make/rules.mk
@@ -77,7 +77,7 @@ $(OBJ_DIR)/flash: $(OBJ_DIR)/$(PROJECT).bin
 	touch $@
 
 $(OBJ_DIR)/upload: $(OBJ_DIR)/$(PROJECT).bin
-	dfu-util -d 0xdf11:0x0483 -D $(OBJ_DIR)/$(PROJECT).bin -a 0 -s $(FLASH_ADDRESS) $(DFU_OPTIONS)
+	dfu-util -d 0483:df11 -D $(OBJ_DIR)/$(PROJECT).bin -a 0 -s $(FLASH_ADDRESS) $(DFU_OPTIONS)
 	touch $@
 
 flash: $(OBJ_DIR)/flash


### PR DESCRIPTION
My latest PR #877 contained error, sorry for that. Correct VID:PID are 0483:df11 not df11:0483.

BUT.

For some strange reason uploading works with ANY VID:PID specified and there is no conflict with another device. But if not to specify VID:PID then the conflict occures.

@skotopes 