### PR TITLE
fix "Nothing to be done for upload" error

### DIFF
--- a/make/rules.mk
+++ b/make/rules.mk
@@ -78,7 +78,6 @@ $(OBJ_DIR)/flash: $(OBJ_DIR)/$(PROJECT).bin
 
 $(OBJ_DIR)/upload: $(OBJ_DIR)/$(PROJECT).bin
 	dfu-util -d 0483:df11 -D $(OBJ_DIR)/$(PROJECT).bin -a 0 -s $(FLASH_ADDRESS) $(DFU_OPTIONS)
-	touch $@
 
 flash: $(OBJ_DIR)/flash
 


### PR DESCRIPTION
If this line is present, when you run the "make -C firmware upload" command a second time (repeatedly, after the first firmware), it gives an error "Nothing to be done for upload", which is not exactly what is expected from the firmware command (its behavior should not depend on the past runs). See https://t.me/flipperzero/3009

# What's new

- [ Describe changes here ]

# Verification 

- [ Describe how to verify changes ]

# Checklist (do not modify)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
