### PR TITLE
add "reboot_to_dfu" and "reboot_to_app" cmd to make

### DIFF
--- a/make/rules.mk
+++ b/make/rules.mk
@@ -84,6 +84,15 @@ flash: $(OBJ_DIR)/flash
 
 upload: $(OBJ_DIR)/upload
 
+reboot_to_dfu:
+	stty -f /dev/cu.usbmodemflip_* 115200
+	echo -en "dfu\r\n" > /dev/cu.usbmodemflip_*
+
+reboot_to_app:
+	dfu-util -d 0483:df11 -a 0 -s :leave &> /dev/null ; exit 0
+	sleep 0.5
+	dfu-util -d 0483:df11 -s $(FLASH_ADDRESS) -a 0 -R &> /dev/null ; exit 0
+
 debug: flash
 	arm-none-eabi-gdb-py \
 		-ex 'target extended-remote | openocd -c "gdb_port pipe" $(OPENOCD_OPTS)' \


### PR DESCRIPTION
Adds two commands to reboot into the DFU and to reboot from the DFU into the main application in the makefile. The command is supposed to be used like this:
male -C firmware reboot_to_dfu upload reboot_to_app.
I am not sure if reboot_to_dfu will work correctly on all machines, but I have not found any other way to get the flipper port address. Also, this command has not been tested on Linux.

# What's new

- [ Describe changes here ]

# Verification 

- [ Describe how to verify changes ]

# Checklist (do not modify)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
