### PR TITLE
add vscode config for dev and debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,10 @@ bindings/
 Brewfile.lock.json
 
 # Visual Studio Code
-.vscode/
+/.vscode/c_cpp_properties.json
+/.vscode/.cortex-debug.registers.state.json
+/.vscode/.cortex-debug.peripherals.state.json
+/.vscode/*.log
 
 # legendary cmake's
 build

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,43 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Upload & Run Flipper",
+      "cwd": "${workspaceRoot}",
+      "executable": "./firmware/.obj/f7/firmware.elf",
+      "request": "launch",
+      "type": "cortex-debug",
+      "servertype": "openocd",
+      "device": "stlink",
+      "preLaunchTask": "Build",
+      "svdFile": "./debug/STM32WB55_CM4.svd",
+      "configFiles": [
+        "interface/stlink.cfg",
+        "./debug/stm32wbx.cfg"
+      ],
+      "showDevDebugOutput": false,
+      "rtos": "FreeRTOS",
+    },
+    {
+      "name": "Attach Flipper",
+      "cwd": "${workspaceRoot}",
+      "executable": "./firmware/.obj/f7/firmware.elf",
+      "request": "attach",
+      "type": "cortex-debug",
+      "servertype": "openocd",
+      "device": "stlink",
+      "svdFile": "./debug/STM32WB55_CM4.svd",
+      "configFiles": [
+        "interface/stlink.cfg",
+        "./debug/stm32wbx.cfg"
+      ],
+      "showDevDebugOutput": false,
+      "rtos": "FreeRTOS",
+    }
+  ]
+}
+
+
+
+
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cortex-debug.armToolchainPath": "/usr/local/bin/",
+  "cortex-debug.openocdPath": "/usr/local/bin/openocd",
+  "cortex-debug.gdbPath": "/usr/local/bin/arm-none-eabi-gdb",
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,25 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build",
+      "type": "shell",
+      "group": "build",
+      "command": "make",
+      "problemMatcher": []
+    },
+    {
+      "label": "Clean",
+      "type": "shell",
+      "group": "build",
+      "command": "make clean",
+      "problemMatcher": []
+    },
+    {
+      "label": "Write firmware",
+      "type": "shell",
+      "command": "make firmware_flash",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/Flipper.code-workspace
+++ b/Flipper.code-workspace
@@ -1,0 +1,23 @@
+{
+"folders": [
+	{
+		"path": "."
+	}
+],
+   "settings": {
+      "git.ignoreLimitWarning": true,
+      "workbench.colorCustomizations": {
+         "activityBar.background": "#aa8d4a",
+         "titleBar.activeBackground": "#7f5e11",
+         "titleBar.activeForeground": "#FFFFFF",
+      },
+      "python.pythonPath": "/usr/bin/python",
+      "makefile.extensionOutputFolder": "./.vscode",
+      "files.associations": {
+         "Makefile*": "makefile",
+         "furi.h": "c",
+         "freertos.h": "c",
+         "timers.h": "c"
+      }
+   }
+}


### PR DESCRIPTION
Suggestion: A few files for easy debugging in VS Code and a few settings for working on code.
Additionally, a non-boring coloring of the development environment in flipper colors. Additionally, need install ms-vscode.cpptools, marus25.cortex-debug, ms-vscode.makefile-tools packets

# What's new

- [ Describe changes here ]

# Verification 

- [ Describe how to verify changes ]

# Checklist (do not modify)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
