### PR TITLE
[FL-2132] IRDA: fix crush in Saved Remote (OK + back)

### DIFF
--- a/applications/irda/scene/irda-app-scene-remote.cpp
+++ b/applications/irda/scene/irda-app-scene-remote.cpp
@@ -115,8 +115,10 @@ bool IrdaAppSceneRemote::on_event(IrdaApp* app, IrdaAppEvent* event) {
             break;
         }
     } else if(event->type == IrdaAppEvent::Type::Back) {
-        app->search_and_switch_to_previous_scene(
-            {IrdaApp::Scene::Start, IrdaApp::Scene::RemoteList});
+        if(!button_pressed) {
+            app->search_and_switch_to_previous_scene(
+                {IrdaApp::Scene::Start, IrdaApp::Scene::RemoteList});
+        }
     } else {
         consumed = false;
     }


### PR DESCRIPTION
Pressing Back button before releasing Ok on Saved Remote scene
freezes application, because it doesn't expect that button is
pressed when leaving Saved Remote scene.

Issue: #893

# What's new

- Fix IRDA freeze in Saved Remotes menu

# Verification 

- Run IRDA app, go to Saved Remotes, choose any, press Ok for starting continuous sending, press Back before releasing Ok

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
