### PR TITLE
Round up the charge % when drawing battery icon

### DIFF
--- a/applications/power/power_service/power.c
+++ b/applications/power/power_service/power.c
@@ -17,7 +17,7 @@ void power_draw_battery_callback(Canvas* canvas, void* context) {
     furi_assert(context);
     Power* power = context;
     canvas_draw_icon(canvas, 0, 0, &I_Battery_26x8);
-    canvas_draw_box(canvas, 2, 2, power->info.charge / 5, 4);
+    canvas_draw_box(canvas, 2, 2, (power->info.charge + 4) / 5, 4);
 }
 
 static ViewPort* power_battery_view_port_alloc(Power* power) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3237013/146604901-6154e187-88ca-4b1e-905e-d6117625ac06.png)

# What's new

- Battery icon gauge is now drawn rounding the charge percentage up, instead of rounding down

# Verification 

- The battery should appear full on the standby screen at 96—99% charge

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
