### PR TITLE
[FL-2156] Switch to smaller radio stack.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ endif
 
 .PHONY: flash_radio
 flash_radio:
-	@$(PROJECT_ROOT)/scripts/flash.py core2radio 0x080C7000 $(COPRO_DIR)/stm32wb5x_BLE_Stack_full_fw.bin
+	@$(PROJECT_ROOT)/scripts/flash.py core2radio 0x080D7000 $(COPRO_DIR)/stm32wb5x_BLE_Stack_light_fw.bin
 	@$(PROJECT_ROOT)/scripts/ob.py set
 
 .PHONY: flash_radio_fus

--- a/firmware/targets/f6/ble-glue/app_conf.h
+++ b/firmware/targets/f6/ble-glue/app_conf.h
@@ -139,7 +139,7 @@
 /**
  * Maximum supported ATT_MTU size
  */
-#define CFG_BLE_MAX_ATT_MTU             (489)
+#define CFG_BLE_MAX_ATT_MTU             (256+128+16+8+4+2)
 
 /**
  * Size of the storage area for Attribute values
@@ -211,14 +211,36 @@
 #define CFG_BLE_VITERBI_MODE  1
 
 /**
- *  LL Only Mode
- *  1 : LL Only
- *  0 : LL + Host
+ * BLE stack Options flags to be configured with:
+ * - SHCI_C2_BLE_INIT_OPTIONS_LL_ONLY
+ * - SHCI_C2_BLE_INIT_OPTIONS_LL_HOST
+ * - SHCI_C2_BLE_INIT_OPTIONS_NO_SVC_CHANGE_DESC
+ * - SHCI_C2_BLE_INIT_OPTIONS_WITH_SVC_CHANGE_DESC
+ * - SHCI_C2_BLE_INIT_OPTIONS_DEVICE_NAME_RO
+ * - SHCI_C2_BLE_INIT_OPTIONS_DEVICE_NAME_RW
+ * - SHCI_C2_BLE_INIT_OPTIONS_EXT_ADV
+ * - SHCI_C2_BLE_INIT_OPTIONS_NO_EXT_ADV
+ * - SHCI_C2_BLE_INIT_OPTIONS_CS_ALGO2
+ * - SHCI_C2_BLE_INIT_OPTIONS_NO_CS_ALGO2
+ * - SHCI_C2_BLE_INIT_OPTIONS_POWER_CLASS_1
+ * - SHCI_C2_BLE_INIT_OPTIONS_POWER_CLASS_2_3
+ * which are used to set following configuration bits:
+ * (bit 0): 1: LL only
+ *          0: LL + host
+ * (bit 1): 1: no service change desc.
+ *          0: with service change desc.
+ * (bit 2): 1: device name Read-Only
+ *          0: device name R/W
+ * (bit 3): 1: extended advertizing supported       [NOT SUPPORTED]
+ *          0: extended advertizing not supported   [NOT SUPPORTED]
+ * (bit 4): 1: CS Algo #2 supported
+ *          0: CS Algo #2 not supported
+ * (bit 7): 1: LE Power Class 1
+ *          0: LE Power Class 2-3
+ * other bits: reserved (shall be set to 0)
  */
-#define CFG_BLE_LL_ONLY  0
-/******************************************************************************
- * Transport Layer
- ******************************************************************************/
+#define CFG_BLE_OPTIONS  (SHCI_C2_BLE_INIT_OPTIONS_LL_HOST | SHCI_C2_BLE_INIT_OPTIONS_WITH_SVC_CHANGE_DESC | SHCI_C2_BLE_INIT_OPTIONS_DEVICE_NAME_RW | SHCI_C2_BLE_INIT_OPTIONS_NO_EXT_ADV | SHCI_C2_BLE_INIT_OPTIONS_NO_CS_ALGO2 | SHCI_C2_BLE_INIT_OPTIONS_POWER_CLASS_2_3)
+
 /**
  * Queue length of BLE Event
  * This parameter defines the number of asynchronous events that can be stored in the HCI layer before

--- a/firmware/targets/f6/ble-glue/ble_app.c
+++ b/firmware/targets/f6/ble-glue/ble_app.c
@@ -67,24 +67,28 @@ bool ble_app_init() {
     SHCI_C2_Ble_Init_Cmd_Packet_t ble_init_cmd_packet = {
         .Header = {{0,0,0}}, // Header unused
         .Param = {
-            0, // pBleBufferAddress not used
-            0, // BleBufferSize not used
-            CFG_BLE_NUM_GATT_ATTRIBUTES,
-            CFG_BLE_NUM_GATT_SERVICES,
-            CFG_BLE_ATT_VALUE_ARRAY_SIZE,
-            CFG_BLE_NUM_LINK,
-            CFG_BLE_DATA_LENGTH_EXTENSION,
-            CFG_BLE_PREPARE_WRITE_LIST_SIZE,
-            CFG_BLE_MBLOCK_COUNT,
-            CFG_BLE_MAX_ATT_MTU,
-            CFG_BLE_SLAVE_SCA,
-            CFG_BLE_MASTER_SCA,
-            CFG_BLE_LSE_SOURCE,
-            CFG_BLE_MAX_CONN_EVENT_LENGTH,
-            CFG_BLE_HSE_STARTUP_TIME,
-            CFG_BLE_VITERBI_MODE,
-            CFG_BLE_LL_ONLY,
-            0,
+            .pBleBufferAddress = 0, // pBleBufferAddress not used
+            .BleBufferSize = 0, // BleBufferSize not used
+            .NumAttrRecord = CFG_BLE_NUM_GATT_ATTRIBUTES,
+            .NumAttrServ = CFG_BLE_NUM_GATT_SERVICES,
+            .AttrValueArrSize = CFG_BLE_ATT_VALUE_ARRAY_SIZE,
+            .NumOfLinks = CFG_BLE_NUM_LINK,
+            .ExtendedPacketLengthEnable = CFG_BLE_DATA_LENGTH_EXTENSION,
+            .PrWriteListSize = CFG_BLE_PREPARE_WRITE_LIST_SIZE,
+            .MblockCount = CFG_BLE_MBLOCK_COUNT,
+            .AttMtu = CFG_BLE_MAX_ATT_MTU,
+            .SlaveSca = CFG_BLE_SLAVE_SCA,
+            .MasterSca = CFG_BLE_MASTER_SCA,
+            .LsSource = CFG_BLE_LSE_SOURCE,
+            .MaxConnEventLength = CFG_BLE_MAX_CONN_EVENT_LENGTH,
+            .HsStartupTime = CFG_BLE_HSE_STARTUP_TIME,
+            .ViterbiEnable = CFG_BLE_VITERBI_MODE,
+            .Options = CFG_BLE_OPTIONS,
+            .HwVersion = 0,
+            .max_coc_initiator_nbr = 32,
+            .min_tx_power = 0,
+            .max_tx_power = 0,
+            .rx_model_config = 1,
         }
     };
     status = SHCI_C2_BLE_Init(&ble_init_cmd_packet);

--- a/firmware/targets/f7/ble-glue/app_conf.h
+++ b/firmware/targets/f7/ble-glue/app_conf.h
@@ -139,7 +139,7 @@
 /**
  * Maximum supported ATT_MTU size
  */
-#define CFG_BLE_MAX_ATT_MTU             (489)
+#define CFG_BLE_MAX_ATT_MTU             (256+128+16+8+4+2)
 
 /**
  * Size of the storage area for Attribute values
@@ -211,14 +211,36 @@
 #define CFG_BLE_VITERBI_MODE  1
 
 /**
- *  LL Only Mode
- *  1 : LL Only
- *  0 : LL + Host
+ * BLE stack Options flags to be configured with:
+ * - SHCI_C2_BLE_INIT_OPTIONS_LL_ONLY
+ * - SHCI_C2_BLE_INIT_OPTIONS_LL_HOST
+ * - SHCI_C2_BLE_INIT_OPTIONS_NO_SVC_CHANGE_DESC
+ * - SHCI_C2_BLE_INIT_OPTIONS_WITH_SVC_CHANGE_DESC
+ * - SHCI_C2_BLE_INIT_OPTIONS_DEVICE_NAME_RO
+ * - SHCI_C2_BLE_INIT_OPTIONS_DEVICE_NAME_RW
+ * - SHCI_C2_BLE_INIT_OPTIONS_EXT_ADV
+ * - SHCI_C2_BLE_INIT_OPTIONS_NO_EXT_ADV
+ * - SHCI_C2_BLE_INIT_OPTIONS_CS_ALGO2
+ * - SHCI_C2_BLE_INIT_OPTIONS_NO_CS_ALGO2
+ * - SHCI_C2_BLE_INIT_OPTIONS_POWER_CLASS_1
+ * - SHCI_C2_BLE_INIT_OPTIONS_POWER_CLASS_2_3
+ * which are used to set following configuration bits:
+ * (bit 0): 1: LL only
+ *          0: LL + host
+ * (bit 1): 1: no service change desc.
+ *          0: with service change desc.
+ * (bit 2): 1: device name Read-Only
+ *          0: device name R/W
+ * (bit 3): 1: extended advertizing supported       [NOT SUPPORTED]
+ *          0: extended advertizing not supported   [NOT SUPPORTED]
+ * (bit 4): 1: CS Algo #2 supported
+ *          0: CS Algo #2 not supported
+ * (bit 7): 1: LE Power Class 1
+ *          0: LE Power Class 2-3
+ * other bits: reserved (shall be set to 0)
  */
-#define CFG_BLE_LL_ONLY  0
-/******************************************************************************
- * Transport Layer
- ******************************************************************************/
+#define CFG_BLE_OPTIONS  (SHCI_C2_BLE_INIT_OPTIONS_LL_HOST | SHCI_C2_BLE_INIT_OPTIONS_WITH_SVC_CHANGE_DESC | SHCI_C2_BLE_INIT_OPTIONS_DEVICE_NAME_RW | SHCI_C2_BLE_INIT_OPTIONS_NO_EXT_ADV | SHCI_C2_BLE_INIT_OPTIONS_NO_CS_ALGO2 | SHCI_C2_BLE_INIT_OPTIONS_POWER_CLASS_2_3)
+
 /**
  * Queue length of BLE Event
  * This parameter defines the number of asynchronous events that can be stored in the HCI layer before

--- a/firmware/targets/f7/ble-glue/ble_app.c
+++ b/firmware/targets/f7/ble-glue/ble_app.c
@@ -67,24 +67,28 @@ bool ble_app_init() {
     SHCI_C2_Ble_Init_Cmd_Packet_t ble_init_cmd_packet = {
         .Header = {{0,0,0}}, // Header unused
         .Param = {
-            0, // pBleBufferAddress not used
-            0, // BleBufferSize not used
-            CFG_BLE_NUM_GATT_ATTRIBUTES,
-            CFG_BLE_NUM_GATT_SERVICES,
-            CFG_BLE_ATT_VALUE_ARRAY_SIZE,
-            CFG_BLE_NUM_LINK,
-            CFG_BLE_DATA_LENGTH_EXTENSION,
-            CFG_BLE_PREPARE_WRITE_LIST_SIZE,
-            CFG_BLE_MBLOCK_COUNT,
-            CFG_BLE_MAX_ATT_MTU,
-            CFG_BLE_SLAVE_SCA,
-            CFG_BLE_MASTER_SCA,
-            CFG_BLE_LSE_SOURCE,
-            CFG_BLE_MAX_CONN_EVENT_LENGTH,
-            CFG_BLE_HSE_STARTUP_TIME,
-            CFG_BLE_VITERBI_MODE,
-            CFG_BLE_LL_ONLY,
-            0,
+            .pBleBufferAddress = 0, // pBleBufferAddress not used
+            .BleBufferSize = 0, // BleBufferSize not used
+            .NumAttrRecord = CFG_BLE_NUM_GATT_ATTRIBUTES,
+            .NumAttrServ = CFG_BLE_NUM_GATT_SERVICES,
+            .AttrValueArrSize = CFG_BLE_ATT_VALUE_ARRAY_SIZE,
+            .NumOfLinks = CFG_BLE_NUM_LINK,
+            .ExtendedPacketLengthEnable = CFG_BLE_DATA_LENGTH_EXTENSION,
+            .PrWriteListSize = CFG_BLE_PREPARE_WRITE_LIST_SIZE,
+            .MblockCount = CFG_BLE_MBLOCK_COUNT,
+            .AttMtu = CFG_BLE_MAX_ATT_MTU,
+            .SlaveSca = CFG_BLE_SLAVE_SCA,
+            .MasterSca = CFG_BLE_MASTER_SCA,
+            .LsSource = CFG_BLE_LSE_SOURCE,
+            .MaxConnEventLength = CFG_BLE_MAX_CONN_EVENT_LENGTH,
+            .HsStartupTime = CFG_BLE_HSE_STARTUP_TIME,
+            .ViterbiEnable = CFG_BLE_VITERBI_MODE,
+            .Options = CFG_BLE_OPTIONS,
+            .HwVersion = 0,
+            .max_coc_initiator_nbr = 32,
+            .min_tx_power = 0,
+            .max_tx_power = 0,
+            .rx_model_config = 1,
         }
     };
     status = SHCI_C2_BLE_Init(&ble_init_cmd_packet);

--- a/scripts/flipper/copro.py
+++ b/scripts/flipper/copro.py
@@ -14,7 +14,7 @@ MANIFEST_TEMPLATE = {
         "fus": {"version": {"major": 1, "minor": 2, "sub": 0}, "files": []},
         "radio": {
             "version": {
-                "type": 1,
+                "type": 3,
                 "major": 1,
                 "minor": 13,
                 "sub": 0,
@@ -88,8 +88,8 @@ class Copro:
         # BLE Full Stack
         self.addFile(
             manifest["copro"]["radio"]["files"],
-            "stm32wb5x_BLE_Stack_full_fw.bin",
-            address="0x080C7000",
+            "stm32wb5x_BLE_Stack_light_fw.bin",
+            address="0x080D7000",
         )
         # Save manifest to
         json.dump(manifest, open(manifest_file, "w"))


### PR DESCRIPTION
# What's new

- Switch to smaller radio stack.
- BleGlue: update params to match new stack.
- Update scripts.

# Verification 

- Compile and upload
- Flash radio with `make flash_radio`
- Check BLE functions 

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [X] I've built this code, uploaded it to the device and verified feature/bugfix
