### PR TITLE
CI: conditional compact build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: 'Build'
 
-on: 
+on:
   push:
     branches:
       - dev
@@ -14,8 +14,8 @@ env:
   DEFAULT_TARGET: f7
 
 jobs:
-  build:
-    runs-on: [self-hosted]
+  main:
+    runs-on: [self-hosted,Office]
     steps:
       - name: 'Cleanup workspace'
         uses: AutoModality/action-clean@v1
@@ -34,13 +34,6 @@ jobs:
           fetch-depth: 0
           submodules: true
           ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: 'Docker cache'
-        uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: docker-cache-${{ hashFiles('docker/**') }}-{hash}
-          restore-keys: docker-cache-${{ hashFiles('docker/**') }}-
 
       - name: 'Build docker image'
         uses: ./.github/actions/docker
@@ -85,7 +78,7 @@ jobs:
             set -e
             for TARGET in ${TARGETS}
             do
-              make TARGET=${TARGET}
+              make TARGET=${TARGET} ${{ startsWith(github.ref, 'refs/tags') && 'DEBUG=0 COMPACT=1' || '' }}
             done
 
       - name: 'Move upload files'
@@ -149,3 +142,56 @@ jobs:
           body: |
             [Click here](https://update.flipperzero.one/?url=https://update.flipperzero.one/builds/firmware/${{steps.names.outputs.artifacts-path}}/flipper-z-${{steps.names.outputs.default-target}}-full-${{steps.names.outputs.suffix}}.dfu&channel=${{steps.names.outputs.artifacts-path}}&version=${{steps.names.outputs.short-hash}}&target=${{steps.names.outputs.default-target}}) to flash the `${{steps.names.outputs.short-hash}}` version of this branch via WebUSB.
           edit-mode: replace
+  compact:
+    if: ${{ !startsWith(github.ref, 'refs/tags') }}
+    runs-on: [self-hosted,koteeq]
+    steps:
+      - name: 'Cleanup workspace'
+        uses: AutoModality/action-clean@v1
+
+      - name: 'Decontaminate previous build leftovers'
+        run: |
+          if [ -d .git ]
+          then
+            git submodule status \
+              || git checkout `git rev-list --max-parents=0 HEAD | tail -n 1`
+          fi
+
+      - name: 'Checkout code'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: 'Build docker image'
+        uses: ./.github/actions/docker
+      
+      - name: 'Generate suffix and folder name'
+        id: names
+        run: |
+          REF=${{ github.ref }}
+          if [[ ${{ github.event_name }} == 'pull_request' ]]; then
+            REF=${{ github.head_ref }}
+          fi
+          BRANCH_OR_TAG=${REF#refs/*/}
+          SHA=$(git rev-parse --short HEAD)
+          
+          if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
+            SUFFIX=${BRANCH_OR_TAG//\//_}
+          else
+            SUFFIX=${BRANCH_OR_TAG//\//_}-$(date +'%d%m%Y')-${SHA}
+          fi
+          
+          echo "WORKFLOW_BRANCH_OR_TAG=${BRANCH_OR_TAG}" >> $GITHUB_ENV
+          echo "DIST_SUFFIX=${SUFFIX}" >> $GITHUB_ENV
+
+      - name: 'Build the firmware in docker'
+        uses: ./.github/actions/docker
+        with:
+          run: |
+            set -e
+            for TARGET in ${TARGETS}
+            do
+              make TARGET=${TARGET} DEBUG=0 COMPACT=1
+            done

--- a/.github/workflows/lint_c.yml
+++ b/.github/workflows/lint_c.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   lint_c_cpp:
-    runs-on: [self-hosted]
+    runs-on: [self-hosted,Office]
     steps:
       - name: 'Cleanup workspace'
         uses: AutoModality/action-clean@v1

--- a/.github/workflows/reindex.yml
+++ b/.github/workflows/reindex.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   reindex:
     name: 'Reindex updates'
-    runs-on: [self-hosted]
+    runs-on: [self-hosted,Office]
     steps:
       - name: Trigger reindex
         uses: wei/curl@master

--- a/applications/rpc/rpc.c
+++ b/applications/rpc/rpc.c
@@ -393,7 +393,7 @@ RpcSession* rpc_session_open(Rpc* rpc) {
         };
         rpc_add_handler(rpc, PB_Main_stop_session_tag, &rpc_handler);
 
-        FURI_LOG_D(TAG, "Session started\r\n");
+        FURI_LOG_D(TAG, "Session started");
     }
 
     return result ? &rpc->session : NULL; /* support 1 open session for now */


### PR DESCRIPTION
# What's new

- Builds are now based on the git ref type
- Removed useless Docker layer caching
#### All tags (releases and release-candidates)
- One job (`main`)
- Runs on the `Office` runners
- Always with `DEBUG=0 COMPACT=1` production flags

#### Other refs (pull requests, dev)
- Two jobs (`main` and `compact`), are run in parallel
- `main` is a fat debug build which runs on the `Office` runners and gets uploaded to the artifacts storage
- `compact` is a `DEBUG=0 COMPACT=1` build which runs on the `koteeq` runners and drops artifacts

# Verification 

- (・・ ) ?

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
