### PR TITLE
iButton fix data layout

### DIFF
--- a/applications/ibutton/scene/ibutton_scene_delete_confirm.cpp
+++ b/applications/ibutton/scene/ibutton_scene_delete_confirm.cpp
@@ -14,14 +14,14 @@ void iButtonSceneDeleteConfirm::on_enter(iButtonApp* app) {
 
     app->set_text_store("\e#Delete %s?\e#", key->get_name());
     widget_add_text_box_element(
-        widget, 0, 0, 128, 23, AlignCenter, AlignCenter, app->get_text_store());
+        widget, 0, 0, 128, 27, AlignCenter, AlignCenter, app->get_text_store());
     widget_add_button_element(widget, GuiButtonTypeLeft, "Back", callback, app);
     widget_add_button_element(widget, GuiButtonTypeRight, "Delete", callback, app);
 
     switch(key->get_key_type()) {
     case iButtonKeyType::KeyDallas:
         app->set_text_store(
-            "%02X %02X %02X %02X %02X %02X %02X %02X\nDallas",
+            "%02X %02X %02X %02X %02X %02X %02X %02X",
             key_data[0],
             key_data[1],
             key_data[2],
@@ -30,17 +30,27 @@ void iButtonSceneDeleteConfirm::on_enter(iButtonApp* app) {
             key_data[5],
             key_data[6],
             key_data[7]);
+        widget_add_string_element(
+            widget, 64, 33, AlignCenter, AlignBottom, FontSecondary, app->get_text_store());
+        widget_add_string_element(
+            widget, 64, 45, AlignCenter, AlignBottom, FontSecondary, "Dallas");
         break;
     case iButtonKeyType::KeyCyfral:
-        app->set_text_store("%02X %02X\nCyfral", key_data[0], key_data[1]);
+        app->set_text_store("%02X %02X", key_data[0], key_data[1]);
+        widget_add_string_element(
+            widget, 64, 33, AlignCenter, AlignBottom, FontSecondary, app->get_text_store());
+        widget_add_string_element(
+            widget, 64, 45, AlignCenter, AlignBottom, FontSecondary, "Cyfral");
         break;
     case iButtonKeyType::KeyMetakom:
         app->set_text_store(
-            "%02X %02X %02X %02X\nMetakom", key_data[0], key_data[1], key_data[2], key_data[3]);
+            "%02X %02X %02X %02X", key_data[0], key_data[1], key_data[2], key_data[3]);
+        widget_add_string_element(
+            widget, 64, 33, AlignCenter, AlignBottom, FontSecondary, app->get_text_store());
+        widget_add_string_element(
+            widget, 64, 45, AlignCenter, AlignBottom, FontSecondary, "Metakom");
         break;
     }
-    widget_add_string_multiline_element(
-        widget, 64, 23, AlignCenter, AlignTop, FontSecondary, app->get_text_store());
 
     view_manager->switch_to(iButtonAppViewManager::Type::iButtonAppViewWidget);
 }

--- a/applications/ibutton/scene/ibutton_scene_delete_confirm.cpp
+++ b/applications/ibutton/scene/ibutton_scene_delete_confirm.cpp
@@ -31,14 +31,10 @@ void iButtonSceneDeleteConfirm::on_enter(iButtonApp* app) {
             key_data[6],
             key_data[7]);
         widget_add_string_element(
-            widget, 64, 33, AlignCenter, AlignBottom, FontSecondary, app->get_text_store());
-        widget_add_string_element(
             widget, 64, 45, AlignCenter, AlignBottom, FontSecondary, "Dallas");
         break;
     case iButtonKeyType::KeyCyfral:
         app->set_text_store("%02X %02X", key_data[0], key_data[1]);
-        widget_add_string_element(
-            widget, 64, 33, AlignCenter, AlignBottom, FontSecondary, app->get_text_store());
         widget_add_string_element(
             widget, 64, 45, AlignCenter, AlignBottom, FontSecondary, "Cyfral");
         break;
@@ -46,11 +42,11 @@ void iButtonSceneDeleteConfirm::on_enter(iButtonApp* app) {
         app->set_text_store(
             "%02X %02X %02X %02X", key_data[0], key_data[1], key_data[2], key_data[3]);
         widget_add_string_element(
-            widget, 64, 33, AlignCenter, AlignBottom, FontSecondary, app->get_text_store());
-        widget_add_string_element(
             widget, 64, 45, AlignCenter, AlignBottom, FontSecondary, "Metakom");
         break;
     }
+    widget_add_string_element(
+        widget, 64, 33, AlignCenter, AlignBottom, FontSecondary, app->get_text_store());
 
     view_manager->switch_to(iButtonAppViewManager::Type::iButtonAppViewWidget);
 }

--- a/applications/ibutton/scene/ibutton_scene_info.cpp
+++ b/applications/ibutton/scene/ibutton_scene_info.cpp
@@ -30,26 +30,22 @@ void iButtonSceneInfo::on_enter(iButtonApp* app) {
             key_data[6],
             key_data[7]);
         widget_add_string_element(
-            widget, 64, 33, AlignCenter, AlignBottom, FontPrimary, app->get_text_store());
-        widget_add_string_element(
             widget, 64, 45, AlignCenter, AlignBottom, FontSecondary, "Dallas");
         break;
     case iButtonKeyType::KeyMetakom:
         app->set_text_store(
             "%02X %02X %02X %02X", key_data[0], key_data[1], key_data[2], key_data[3]);
         widget_add_string_element(
-            widget, 64, 33, AlignCenter, AlignBottom, FontPrimary, app->get_text_store());
-        widget_add_string_element(
             widget, 64, 45, AlignCenter, AlignBottom, FontSecondary, "Metakom");
         break;
     case iButtonKeyType::KeyCyfral:
         app->set_text_store("%02X %02X", key_data[0], key_data[1]);
         widget_add_string_element(
-            widget, 64, 33, AlignCenter, AlignBottom, FontPrimary, app->get_text_store());
-        widget_add_string_element(
             widget, 64, 45, AlignCenter, AlignBottom, FontSecondary, "Cyfral");
         break;
     }
+    widget_add_string_element(
+        widget, 64, 33, AlignCenter, AlignBottom, FontPrimary, app->get_text_store());
 
     view_manager->switch_to(iButtonAppViewManager::Type::iButtonAppViewWidget);
 }

--- a/applications/ibutton/scene/ibutton_scene_info.cpp
+++ b/applications/ibutton/scene/ibutton_scene_info.cpp
@@ -14,13 +14,13 @@ void iButtonSceneInfo::on_enter(iButtonApp* app) {
 
     app->set_text_store("%s", key->get_name());
     widget_add_text_box_element(
-        widget, 0, 0, 128, 23, AlignCenter, AlignCenter, app->get_text_store());
+        widget, 0, 0, 128, 27, AlignCenter, AlignCenter, app->get_text_store());
     widget_add_button_element(widget, GuiButtonTypeLeft, "Back", callback, app);
 
     switch(key->get_key_type()) {
     case iButtonKeyType::KeyDallas:
         app->set_text_store(
-            "\e#%02X %02X %02X %02X %02X %02X %02X %02X\e#\nDallas",
+            "%02X %02X %02X %02X %02X %02X %02X %02X",
             key_data[0],
             key_data[1],
             key_data[2],
@@ -29,21 +29,27 @@ void iButtonSceneInfo::on_enter(iButtonApp* app) {
             key_data[5],
             key_data[6],
             key_data[7]);
+        widget_add_string_element(
+            widget, 64, 33, AlignCenter, AlignBottom, FontPrimary, app->get_text_store());
+        widget_add_string_element(
+            widget, 64, 45, AlignCenter, AlignBottom, FontSecondary, "Dallas");
         break;
     case iButtonKeyType::KeyMetakom:
         app->set_text_store(
-            "\e#%02X %02X %02X %02X\e#\nMetakom",
-            key_data[0],
-            key_data[1],
-            key_data[2],
-            key_data[3]);
+            "%02X %02X %02X %02X", key_data[0], key_data[1], key_data[2], key_data[3]);
+        widget_add_string_element(
+            widget, 64, 33, AlignCenter, AlignBottom, FontPrimary, app->get_text_store());
+        widget_add_string_element(
+            widget, 64, 45, AlignCenter, AlignBottom, FontSecondary, "Metakom");
         break;
     case iButtonKeyType::KeyCyfral:
-        app->set_text_store("\e#%02X %02X\e#\nCyfral", key_data[0], key_data[1]);
+        app->set_text_store("%02X %02X", key_data[0], key_data[1]);
+        widget_add_string_element(
+            widget, 64, 33, AlignCenter, AlignBottom, FontPrimary, app->get_text_store());
+        widget_add_string_element(
+            widget, 64, 45, AlignCenter, AlignBottom, FontSecondary, "Cyfral");
         break;
     }
-    widget_add_text_box_element(
-        widget, 0, 23, 128, 40, AlignCenter, AlignTop, app->get_text_store());
 
     view_manager->switch_to(iButtonAppViewManager::Type::iButtonAppViewWidget);
 }

--- a/applications/loader/loader.c
+++ b/applications/loader/loader.c
@@ -217,9 +217,11 @@ static void loader_thread_state_callback(FuriThreadState thread_state, void* con
     LoaderEvent event;
 
     if(thread_state == FuriThreadStateRunning) {
-        instance->free_heap_size = memmgr_get_free_heap();
         event.type = LoaderEventTypeApplicationStarted;
         furi_pubsub_publish(loader_instance->pubsub, &event);
+
+        // Snapshot current memory usage
+        instance->free_heap_size = memmgr_get_free_heap();
     } else if(thread_state == FuriThreadStateStopped) {
         /*
          * Current Leak Sanitizer assumes that memory is allocated and freed
@@ -240,6 +242,7 @@ static void loader_thread_state_callback(FuriThreadState thread_state, void* con
             furi_thread_get_heap_size(instance->thread));
         furi_hal_power_insomnia_exit();
         loader_unlock(instance);
+
         event.type = LoaderEventTypeApplicationStopped;
         furi_pubsub_publish(loader_instance->pubsub, &event);
     }


### PR DESCRIPTION
# What's new

- Fix data layout in delete and info scenes
- Fix incorrect heap allocation balance

# Verification 

- Data layout is consistent with Miro
- Heap allocation balance is 0 after app exit (except apps which use timers)

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
