### PR TITLE
CI: check that submodules point to correct branches

### DIFF
--- a/.github/workflows/check_submodules.yml
+++ b/.github/workflows/check_submodules.yml
@@ -1,0 +1,17 @@
+name: 'Check submodules'
+
+on:
+  pull_request:
+
+jobs:
+  protobuf:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Checkout code'
+      uses: actions/checkout@v2
+    - name: 'Check submodule commit branch'
+      uses: jtmullen/submodule-branch-check-action@v1
+      with:
+        path: assets/protobuf
+        branch: dev
+        fetch_depth: 50


### PR DESCRIPTION
# What's new

- Added a CI job that will ensure submodules (only `flipperzero-protobuf` for now) point to correct branches

# Verification 

- Try making `assets/protobuf` point to a non-`dev` commit, get a ❌

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
