### PR TITLE
[FL-2225] About: add serial number to hardware info screen

### DIFF
--- a/applications/about/about.c
+++ b/applications/about/about.c
@@ -89,6 +89,12 @@ static DialogMessageButton hw_version_screen(DialogsApp* dialogs, DialogMessage*
         furi_hal_version_get_hw_connect(),
         my_name ? my_name : "Unknown");
 
+    string_cat_printf(buffer, "Serial number:\n");
+    const uint8_t* uid = furi_hal_version_uid();
+    for(size_t i = 0; i < furi_hal_version_uid_size(); i++) {
+        string_cat_printf(buffer, "%02X", uid[i]);
+    }
+
     dialog_message_set_header(message, "HW Version info:", 0, 0, AlignLeft, AlignTop);
     dialog_message_set_text(message, string_get_cstr(buffer), 0, 13, AlignLeft, AlignTop);
     result = dialog_message_show(dialogs, message);


### PR DESCRIPTION
# What's new

- About: add serial number to hardware info screen

# Verification 

- Compile and upload
- Check device serial in  Settings -> About

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
