### PR TITLE
[FL-2215, FL-2168] Display long names and rename RAW files

### DIFF
--- a/applications/subghz/scenes/subghz_scene_delete_raw.c
+++ b/applications/subghz/scenes/subghz_scene_delete_raw.c
@@ -24,7 +24,8 @@ void subghz_scene_delete_raw_on_enter(void* context) {
 
     char delete_str[64];
     snprintf(delete_str, sizeof(delete_str), "\e#Delete %s?\e#", subghz->file_name);
-    widget_add_text_box_element(subghz->widget, 0, 0, 128, 23, AlignCenter, AlignCenter, delete_str);
+    widget_add_text_box_element(
+        subghz->widget, 0, 0, 128, 23, AlignCenter, AlignCenter, delete_str);
 
     widget_add_string_element(
         subghz->widget, 38, 25, AlignLeft, AlignTop, FontSecondary, "RAW signal");

--- a/applications/subghz/scenes/subghz_scene_delete_raw.c
+++ b/applications/subghz/scenes/subghz_scene_delete_raw.c
@@ -17,15 +17,14 @@ void subghz_scene_delete_raw_on_enter(void* context) {
     SubGhz* subghz = context;
     string_t frequency_str;
     string_t modulation_str;
-    string_t text;
+    //string_t text;
 
     string_init(frequency_str);
     string_init(modulation_str);
-    string_init(text);
 
-    string_printf(text, "Delete\n%s?", subghz->file_name);
-    widget_add_string_multiline_element(
-        subghz->widget, 64, 0, AlignCenter, AlignTop, FontPrimary, string_get_cstr(text));
+    char delete_str[64];
+    snprintf(delete_str, sizeof(delete_str), "\e#Delete %s?\e#", subghz->file_name);
+    widget_add_text_box_element(subghz->widget, 0, 0, 128, 23, AlignCenter, AlignCenter, delete_str);
 
     widget_add_string_element(
         subghz->widget, 38, 25, AlignLeft, AlignTop, FontSecondary, "RAW signal");
@@ -44,7 +43,6 @@ void subghz_scene_delete_raw_on_enter(void* context) {
 
     string_clear(frequency_str);
     string_clear(modulation_str);
-    string_clear(text);
 
     widget_add_button_element(
         subghz->widget, GuiButtonTypeRight, "Delete", subghz_scene_delete_raw_callback, subghz);

--- a/applications/subghz/scenes/subghz_scene_delete_raw.c
+++ b/applications/subghz/scenes/subghz_scene_delete_raw.c
@@ -17,7 +17,6 @@ void subghz_scene_delete_raw_on_enter(void* context) {
     SubGhz* subghz = context;
     string_t frequency_str;
     string_t modulation_str;
-    //string_t text;
 
     string_init(frequency_str);
     string_init(modulation_str);

--- a/applications/subghz/scenes/subghz_scene_more_raw.c
+++ b/applications/subghz/scenes/subghz_scene_more_raw.c
@@ -45,6 +45,7 @@ bool subghz_scene_more_raw_on_event(void* context, SceneManagerEvent event) {
             scene_manager_next_scene(subghz->scene_manager, SubGhzSceneDeleteRAW);
             return true;
         } else if(event.event == SubmenuIndexEdit) {
+            memset(subghz->file_name_tmp, 0, sizeof(subghz->file_name_tmp));
             scene_manager_set_scene_state(
                 subghz->scene_manager, SubGhzSceneMoreRAW, SubmenuIndexEdit);
             scene_manager_next_scene(subghz->scene_manager, SubGhzSceneSaveName);

--- a/applications/subghz/scenes/subghz_scene_read_raw.c
+++ b/applications/subghz/scenes/subghz_scene_read_raw.c
@@ -4,7 +4,7 @@
 #include <lib/subghz/subghz_parser.h>
 #include <lib/toolbox/path.h>
 
-#define RAW_FILE_NAME "Raw_temp"
+#define RAW_FILE_NAME "Raw_signal_"
 
 bool subghz_scene_read_raw_update_filename(SubGhz* subghz) {
     bool ret = false;

--- a/applications/subghz/scenes/subghz_scene_save_name.c
+++ b/applications/subghz/scenes/subghz_scene_save_name.c
@@ -19,7 +19,8 @@ void subghz_scene_save_name_on_enter(void* context) {
 
     if(!strcmp(subghz->file_name, "")) {
         set_random_name(subghz->file_name, sizeof(subghz->file_name));
-
+        //highlighting the entire filename by default
+        dev_name_empty = true;
     } else {
         strcpy(subghz->file_name_tmp, subghz->file_name);
         if(scene_manager_get_scene_state(subghz->scene_manager, SubGhzSceneReadRAW) ==
@@ -27,8 +28,6 @@ void subghz_scene_save_name_on_enter(void* context) {
             subghz_get_next_name_file(subghz);
         }
     }
-    //highlighting the entire filename by default
-    dev_name_empty = true;
 
     text_input_set_header_text(text_input, "Name signal");
     text_input_set_result_callback(
@@ -67,6 +66,8 @@ bool subghz_scene_save_name_on_event(void* context, SceneManagerEvent event) {
                    SubghzCustomEventManagerSet) {
                     subghz_protocol_raw_set_last_file_name(
                         (SubGhzProtocolRAW*)subghz->txrx->protocol_result, subghz->file_name);
+                    scene_manager_set_scene_state(
+                        subghz->scene_manager, SubGhzSceneReadRAW, SubghzCustomEventManagerNoSet);
                 } else {
                     subghz_file_name_clear(subghz);
                 }
@@ -86,12 +87,11 @@ bool subghz_scene_save_name_on_event(void* context, SceneManagerEvent event) {
 void subghz_scene_save_name_on_exit(void* context) {
     SubGhz* subghz = context;
 
-    // Clear view
+    // Clear validator
     void* validator_context = text_input_get_validator_callback_context(subghz->text_input);
     text_input_set_validator(subghz->text_input, NULL, NULL);
     validator_is_file_free(validator_context);
 
+    // Clear view
     text_input_reset(subghz->text_input);
-    scene_manager_set_scene_state(
-        subghz->scene_manager, SubGhzSceneReadRAW, SubghzCustomEventManagerNoSet);
 }

--- a/applications/subghz/views/subghz_read_raw.c
+++ b/applications/subghz/views/subghz_read_raw.c
@@ -237,8 +237,8 @@ void subghz_read_raw_draw(Canvas* canvas, SubghzReadRAWModel* model) {
         elements_button_left(canvas, "New");
         elements_button_center(canvas, "Send");
         elements_button_right(canvas, "More");
-        canvas_draw_str_aligned(
-            canvas, 58, 28, AlignCenter, AlignTop, string_get_cstr(model->file_name));
+        elements_text_box(
+            canvas, 4, 12, 110, 44, AlignCenter, AlignCenter, string_get_cstr(model->file_name));
         break;
 
     case SubghzReadRAWStatusTX:


### PR DESCRIPTION
# What's new

- [FL-2215] SubGhz: fix long names on RAW and Delete screens
- [FL-2168] SubGhz: fix rename RAW

# Verification 

- Compile and flash
- Run SubGhz -> Read RAW and see auto naming on quick save, displaying long names and renaming files

# Checklist (do not modify)

- [X] PR has description of feature/bug or link to Confluence/Jira task
- [X] Description contains actions to verify feature/bugfix
- [X] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-2215]: https://flipperzero.atlassian.net/browse/FL-2215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FL-2168]: https://flipperzero.atlassian.net/browse/FL-2168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ