### PR TITLE
[Fl-2236] Desktop: fix crash caused by unconsumed back button long press

### DIFF
--- a/applications/desktop/views/desktop_main.c
+++ b/applications/desktop/views/desktop_main.c
@@ -35,25 +35,26 @@ bool desktop_main_input(InputEvent* event, void* context) {
     furi_assert(context);
 
     DesktopMainView* main_view = context;
-    bool consumed = false;
 
-    if(event->key == InputKeyOk && event->type == InputTypeShort) {
-        main_view->callback(DesktopMainEventOpenMenu, main_view->context);
-    } else if(event->key == InputKeyDown && event->type == InputTypeLong) {
-        main_view->callback(DesktopMainEventOpenDebug, main_view->context);
-    } else if(event->key == InputKeyUp && event->type == InputTypeShort) {
-        main_view->callback(DesktopMainEventOpenLockMenu, main_view->context);
-    } else if(event->key == InputKeyDown && event->type == InputTypeShort) {
-        main_view->callback(DesktopMainEventOpenArchive, main_view->context);
-    } else if(event->key == InputKeyLeft && event->type == InputTypeShort) {
-        main_view->callback(DesktopMainEventOpenFavorite, main_view->context);
-    } else if(event->key == InputKeyRight && event->type == InputTypeShort) {
-        main_view->callback(DesktopMainEventRightShort, main_view->context);
-    } else if(event->key == InputKeyBack && event->type == InputTypeShort) {
-        consumed = true;
+    if(event->type == InputTypeShort) {
+        if(event->key == InputKeyOk) {
+            main_view->callback(DesktopMainEventOpenMenu, main_view->context);
+        } else if(event->key == InputKeyUp) {
+            main_view->callback(DesktopMainEventOpenLockMenu, main_view->context);
+        } else if(event->key == InputKeyDown) {
+            main_view->callback(DesktopMainEventOpenArchive, main_view->context);
+        } else if(event->key == InputKeyLeft) {
+            main_view->callback(DesktopMainEventOpenFavorite, main_view->context);
+        } else if(event->key == InputKeyRight) {
+            main_view->callback(DesktopMainEventRightShort, main_view->context);
+        }
+    } else if(event->type == InputTypeLong) {
+        if(event->key == InputKeyDown) {
+            main_view->callback(DesktopMainEventOpenDebug, main_view->context);
+        }
     }
 
-    return consumed;
+    return true;
 }
 
 DesktopMainView* desktop_main_alloc() {

--- a/applications/gui/view_stack.c
+++ b/applications/gui/view_stack.c
@@ -105,13 +105,14 @@ static bool view_stack_input(InputEvent* event, void* context) {
     furi_assert(event);
     furi_assert(context);
 
-    bool consumed = false;
     ViewStack* view_stack = context;
 
+    bool consumed = false;
     ViewStackModel* model = view_get_model(view_stack->view);
-    for(int i = MAX_VIEWS - 1; !consumed && (i >= 0); --i) {
-        if(model->views[i]) {
-            consumed = view_input(model->views[i], event);
+    for(int i = MAX_VIEWS - 1; i >= 0; i--) {
+        if(model->views[i] && view_input(model->views[i], event)) {
+            consumed = true;
+            break;
         }
     }
     view_commit_model(view_stack->view, false);


### PR DESCRIPTION
# What's new

- Desktop: fix crash caused by unconsumed back button long press

# Verification 

- Compile and upload
- Back button long press is not crashing desktop service anymore. 

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
