### PR TITLE
Bt Settings fix incorrect switch to forget devices

### DIFF
--- a/applications/bt/bt_settings_app/bt_settings_app.h
+++ b/applications/bt/bt_settings_app/bt_settings_app.h
@@ -14,6 +14,14 @@
 #include "../bt_settings.h"
 #include "scenes/bt_settings_scene.h"
 
+enum BtSettingsCustomEvent {
+    // Keep first 10 events reserved for button types and indexes
+    BtSettingsCustomEventReserved = 10,
+
+    BtSettingsCustomEventForgetDevices,
+    BtSettingsCustomEventExitView,
+};
+
 typedef struct {
     BtSettings settings;
     Bt* bt;

--- a/applications/bt/bt_settings_app/scenes/bt_settings_scene_forget_dev_success.c
+++ b/applications/bt/bt_settings_app/scenes/bt_settings_scene_forget_dev_success.c
@@ -1,11 +1,9 @@
 #include "../bt_settings_app.h"
 #include "furi_hal_bt.h"
 
-#define SCENE_FORGET_DEV_SUCCESS_CUSTOM_EVENT (0UL)
-
 void bt_settings_app_scene_forget_dev_success_popup_callback(void* context) {
     BtSettingsApp* app = context;
-    view_dispatcher_send_custom_event(app->view_dispatcher, SCENE_FORGET_DEV_SUCCESS_CUSTOM_EVENT);
+    view_dispatcher_send_custom_event(app->view_dispatcher, BtSettingsCustomEventExitView);
 }
 
 void bt_settings_scene_forget_dev_success_on_enter(void* context) {
@@ -26,7 +24,7 @@ bool bt_settings_scene_forget_dev_success_on_event(void* context, SceneManagerEv
     bool consumed = false;
 
     if(event.type == SceneManagerEventTypeCustom) {
-        if(event.event == SCENE_FORGET_DEV_SUCCESS_CUSTOM_EVENT) {
+        if(event.event == BtSettingsCustomEventExitView) {
             if(scene_manager_has_previous_scene(app->scene_manager, BtSettingsAppSceneStart)) {
                 consumed = scene_manager_search_and_switch_to_previous_scene(
                     app->scene_manager, BtSettingsAppSceneStart);

--- a/applications/bt/bt_settings_app/scenes/bt_settings_scene_start.c
+++ b/applications/bt/bt_settings_app/scenes/bt_settings_scene_start.c
@@ -1,12 +1,15 @@
 #include "../bt_settings_app.h"
 #include "furi_hal_bt.h"
 
-#define SCENE_START_FORGET_DEV_SELECTED_EVENT (10UL)
-
 enum BtSetting {
     BtSettingOff,
     BtSettingOn,
     BtSettingNum,
+};
+
+enum BtSettingIndex {
+    BtSettingIndexSwitchBt,
+    BtSettingIndexForgetDev,
 };
 
 const char* const bt_settings_text[BtSettingNum] = {
@@ -25,7 +28,10 @@ static void bt_settings_scene_start_var_list_change_callback(VariableItem* item)
 static void bt_settings_scene_start_var_list_enter_callback(void* context, uint32_t index) {
     furi_assert(context);
     BtSettingsApp* app = context;
-    view_dispatcher_send_custom_event(app->view_dispatcher, SCENE_START_FORGET_DEV_SELECTED_EVENT);
+    if(index == BtSettingIndexForgetDev) {
+        view_dispatcher_send_custom_event(
+            app->view_dispatcher, BtSettingsCustomEventForgetDevices);
+    }
 }
 
 void bt_settings_scene_start_on_enter(void* context) {
@@ -72,7 +78,7 @@ bool bt_settings_scene_start_on_event(void* context, SceneManagerEvent event) {
             app->settings.enabled = false;
             furi_hal_bt_stop_advertising();
             consumed = true;
-        } else if(event.event == SCENE_START_FORGET_DEV_SELECTED_EVENT) {
+        } else if(event.event == BtSettingsCustomEventForgetDevices) {
             scene_manager_next_scene(app->scene_manager, BtSettingsAppSceneForgetDevConfirm);
             consumed = true;
         }


### PR DESCRIPTION
# What's new

- Fix incorrect switch to forget devices

# Verification 

- Pressing OK on Bluetooth ON/OFF does not switch to Forget Devices scene

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
