### PR TITLE
U2F: check files before register/login

### DIFF
--- a/applications/u2f/scenes/u2f_scene_main.c
+++ b/applications/u2f/scenes/u2f_scene_main.c
@@ -28,6 +28,8 @@ static void u2f_scene_main_event_callback(U2fNotifyEvent evt, void* context) {
         view_dispatcher_send_custom_event(app->view_dispatcher, U2fCustomEventConnect);
     else if(evt == U2fNotifyDisconnect)
         view_dispatcher_send_custom_event(app->view_dispatcher, U2fCustomEventDisconnect);
+    else if(evt == U2fNotifyError)
+        view_dispatcher_send_custom_event(app->view_dispatcher, U2fCustomEventDataError);
 }
 
 static void u2f_scene_main_timer_callback(void* context) {
@@ -75,10 +77,13 @@ bool u2f_scene_main_on_event(void* context, SceneManagerEvent event) {
             if(app->event_cur != U2fCustomEventNone) {
                 u2f_confirm_user_present(app->u2f_instance);
             }
+        } else if(event.event == U2fCustomEventDataError) {
+            osTimerStop(app->timer);
+            u2f_view_set_state(app->u2f_view, U2fMsgError);
         }
         consumed = true;
-    } else if(event.type == SceneManagerEventTypeTick) {
     }
+
     return consumed;
 }
 

--- a/applications/u2f/u2f.c
+++ b/applications/u2f/u2f.c
@@ -186,6 +186,13 @@ static uint16_t u2f_register(U2fData* U2F, uint8_t* buf) {
     uint8_t hash[32];
     uint8_t signature[64];
 
+    if(u2f_data_check(false) == false) {
+        U2F->ready = false;
+        if(U2F->callback != NULL) U2F->callback(U2fNotifyError, U2F->context);
+        memcpy(&buf[0], state_not_supported, 2);
+        return 2;
+    }
+
     if(U2F->callback != NULL) U2F->callback(U2fNotifyRegister, U2F->context);
     if(U2F->user_present == false) {
         memcpy(&buf[0], state_user_missing, 2);
@@ -249,6 +256,13 @@ static uint16_t u2f_authenticate(U2fData* U2F, uint8_t* buf) {
     uint8_t flags = 0;
     uint8_t hash[32];
     uint8_t signature[64];
+
+    if(u2f_data_check(false) == false) {
+        U2F->ready = false;
+        if(U2F->callback != NULL) U2F->callback(U2fNotifyError, U2F->context);
+        memcpy(&buf[0], state_not_supported, 2);
+        return 2;
+    }
 
     if(U2F->callback != NULL) U2F->callback(U2fNotifyAuth, U2F->context);
     if(U2F->user_present == true) {

--- a/applications/u2f/u2f.h
+++ b/applications/u2f/u2f.h
@@ -13,6 +13,7 @@ typedef enum {
     U2fNotifyWink,
     U2fNotifyConnect,
     U2fNotifyDisconnect,
+    U2fNotifyError,
 } U2fNotifyEvent;
 
 typedef struct U2fData U2fData;

--- a/applications/u2f/u2f_app.c
+++ b/applications/u2f/u2f_app.c
@@ -48,7 +48,7 @@ U2fApp* u2f_app_alloc() {
     view_dispatcher_add_view(
         app->view_dispatcher, U2fAppViewMain, u2f_view_get_view(app->u2f_view));
 
-    if(u2f_data_check()) {
+    if(u2f_data_check(true)) {
         scene_manager_next_scene(app->scene_manager, U2fSceneMain);
     } else {
         scene_manager_next_scene(app->scene_manager, U2fSceneError);

--- a/applications/u2f/u2f_app_i.h
+++ b/applications/u2f/u2f_app_i.h
@@ -20,6 +20,7 @@ typedef enum {
 
     U2fCustomEventConnect,
     U2fCustomEventDisconnect,
+    U2fCustomEventDataError,
 
     U2fCustomEventRegister,
     U2fCustomEventAuth,

--- a/applications/u2f/u2f_data.h
+++ b/applications/u2f/u2f_data.h
@@ -6,7 +6,7 @@ extern "C" {
 
 #include <furi.h>
 
-bool u2f_data_check();
+bool u2f_data_check(bool cert_only);
 
 bool u2f_data_cert_check();
 


### PR DESCRIPTION
# What's new

- Lock U2F app and show error if SD card / U2F files are missing

# Verification 

- Run U2F app, pull out SD card and try to login/register

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
