### PR TITLE
[FL-2243] Restart BT advertising after forgetting devices

### DIFF
--- a/applications/bt/bt_service/bt_keys_storage.c
+++ b/applications/bt/bt_service/bt_keys_storage.c
@@ -43,10 +43,11 @@ bool bt_save_key_storage(Bt* bt) {
 bool bt_delete_key_storage(Bt* bt) {
     furi_assert(bt);
     bool delete_succeed = false;
+    bool bt_is_active = furi_hal_bt_is_active();
 
     furi_hal_bt_stop_advertising();
     delete_succeed = furi_hal_bt_clear_white_list();
-    if(bt->bt_settings.enabled) {
+    if(bt_is_active) {
         furi_hal_bt_start_advertising();
     }
 

--- a/firmware/targets/f6/furi_hal/furi_hal_bt.c
+++ b/firmware/targets/f6/furi_hal/furi_hal_bt.c
@@ -246,7 +246,7 @@ bool furi_hal_bt_change_app(FuriHalBtProfile profile, GapEventCallback event_cb,
     return ret;
 }
 
-static bool furi_hal_bt_is_active() {
+bool furi_hal_bt_is_active() {
     return gap_get_state() > GapStateIdle;
 }
 

--- a/firmware/targets/f7/furi_hal/furi_hal_bt.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_bt.c
@@ -246,7 +246,7 @@ bool furi_hal_bt_change_app(FuriHalBtProfile profile, GapEventCallback event_cb,
     return ret;
 }
 
-static bool furi_hal_bt_is_active() {
+bool furi_hal_bt_is_active() {
     return gap_get_state() > GapStateIdle;
 }
 

--- a/firmware/targets/furi_hal_include/furi_hal_bt.h
+++ b/firmware/targets/furi_hal_include/furi_hal_bt.h
@@ -84,6 +84,12 @@ bool furi_hal_bt_change_app(FuriHalBtProfile profile, GapEventCallback event_cb,
  */
 void furi_hal_bt_update_battery_level(uint8_t battery_level);
 
+/** Checks if BLE state is active
+ *
+ * @return          true if device is connected or advertising, false otherwise
+ */
+bool furi_hal_bt_is_active();
+
 /** Start advertising
  */
 void furi_hal_bt_start_advertising();


### PR DESCRIPTION
# What's new

- Restart advertising after forgetting keys

# Verification 

- Disable bluetooth. Restart Flipper. Enable bluetooth, forget keys. Verify bluetooth advertising

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
