### PR TITLE
[FL-2168] SubGhz: fix auto highlight name when saving RAW

### DIFF
--- a/applications/subghz/helpers/subghz_custom_event.h
+++ b/applications/subghz/helpers/subghz_custom_event.h
@@ -3,6 +3,7 @@
 typedef enum {
     SubghzCustomEventManagerNoSet = 0,
     SubghzCustomEventManagerSet,
+    SubghzCustomEventManagerSetRAW,
 
     SubghzCustomEventSceneDeleteSuccess = 100,
     SubghzCustomEventSceneDelete,

--- a/applications/subghz/scenes/subghz_scene_read_raw.c
+++ b/applications/subghz/scenes/subghz_scene_read_raw.c
@@ -261,7 +261,7 @@ bool subghz_scene_read_raw_on_event(void* context, SceneManagerEvent event) {
         case SubghzCustomEventViewReadRAWSave:
             if(subghz_scene_read_raw_update_filename(subghz)) {
                 scene_manager_set_scene_state(
-                    subghz->scene_manager, SubGhzSceneReadRAW, SubghzCustomEventManagerSet);
+                    subghz->scene_manager, SubGhzSceneReadRAW, SubghzCustomEventManagerSetRAW);
                 subghz->txrx->rx_key_state = SubGhzRxKeyStateBack;
                 scene_manager_next_scene(subghz->scene_manager, SubGhzSceneSaveName);
             }

--- a/applications/subghz/scenes/subghz_scene_save_name.c
+++ b/applications/subghz/scenes/subghz_scene_save_name.c
@@ -23,9 +23,13 @@ void subghz_scene_save_name_on_enter(void* context) {
         dev_name_empty = true;
     } else {
         strcpy(subghz->file_name_tmp, subghz->file_name);
-        if(scene_manager_get_scene_state(subghz->scene_manager, SubGhzSceneReadRAW) ==
-           SubghzCustomEventManagerSet) {
+        if(scene_manager_get_scene_state(subghz->scene_manager, SubGhzSceneReadRAW) !=
+           SubghzCustomEventManagerNoSet) {
             subghz_get_next_name_file(subghz);
+            if(scene_manager_get_scene_state(subghz->scene_manager, SubGhzSceneReadRAW) ==
+               SubghzCustomEventManagerSetRAW) {
+                dev_name_empty = true;
+            }
         }
     }
 
@@ -62,8 +66,8 @@ bool subghz_scene_save_name_on_event(void* context, SceneManagerEvent event) {
                     subghz_save_protocol_to_file(subghz, subghz->file_name);
                 }
 
-                if(scene_manager_get_scene_state(subghz->scene_manager, SubGhzSceneReadRAW) ==
-                   SubghzCustomEventManagerSet) {
+                if(scene_manager_get_scene_state(subghz->scene_manager, SubGhzSceneReadRAW) !=
+                   SubghzCustomEventManagerNoSet) {
                     subghz_protocol_raw_set_last_file_name(
                         (SubGhzProtocolRAW*)subghz->txrx->protocol_result, subghz->file_name);
                     scene_manager_set_scene_state(


### PR DESCRIPTION
# What's new

- [FL-2168] SubGhz: fix auto highlight name when saving RAW

# Verification 

- Compile and upload
- Run SubGhz app -> read RAW accept new signal and press save, check that name is automatically highlighted

# Checklist (do not modify)

- [X] PR has description of feature/bug or link to Confluence/Jira task
- [X] Description contains actions to verify feature/bugfix
- [X] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-2168]: https://flipperzero.atlassian.net/browse/FL-2168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ