### PR TITLE
[FL-2254] IR: fix hardfault, correct remote loading

### DIFF
--- a/applications/gui/modules/button_menu.c
+++ b/applications/gui/modules/button_menu.c
@@ -99,8 +99,6 @@ static void button_menu_view_draw_callback(Canvas* canvas, void* _model) {
     furi_assert(_model);
 
     ButtonMenuModel* model = (ButtonMenuModel*)_model;
-
-    canvas_clear(canvas);
     canvas_set_font(canvas, FontSecondary);
 
     uint8_t item_position = 0;
@@ -117,11 +115,14 @@ static void button_menu_view_draw_callback(Canvas* canvas, void* _model) {
         canvas_draw_icon(canvas, 28, 123, &I_IrdaArrowDown_4x8);
     }
 
-    string_t disp_str;
-    string_init_set_str(disp_str, model->header);
-    elements_string_fit_width(canvas, disp_str, ITEM_WIDTH - 6);
-    canvas_draw_str_aligned(canvas, 32, 10, AlignCenter, AlignCenter, string_get_cstr(disp_str));
-    string_clear(disp_str);
+    if(model->header) {
+        string_t disp_str;
+        string_init_set_str(disp_str, model->header);
+        elements_string_fit_width(canvas, disp_str, ITEM_WIDTH - 6);
+        canvas_draw_str_aligned(
+            canvas, 32, 10, AlignCenter, AlignCenter, string_get_cstr(disp_str));
+        string_clear(disp_str);
+    }
 
     for(ButtonMenuItemArray_it(it, model->items); !ButtonMenuItemArray_end_p(it);
         ButtonMenuItemArray_next(it), ++item_position) {
@@ -248,6 +249,7 @@ void button_menu_reset(ButtonMenu* button_menu) {
         button_menu->view, (ButtonMenuModel * model) {
             ButtonMenuItemArray_reset(model->items);
             model->position = 0;
+            model->header = NULL;
             return true;
         });
 }

--- a/applications/irda/irda_app_remote_manager.cpp
+++ b/applications/irda/irda_app_remote_manager.cpp
@@ -110,10 +110,11 @@ std::string IrdaAppRemoteManager::get_button_name(uint32_t index) {
 }
 
 std::string IrdaAppRemoteManager::get_remote_name() {
-    return remote ? remote->name : std::string();
+    return remote.get() ? remote->name : std::string();
 }
 
 int IrdaAppRemoteManager::find_remote_name(const std::vector<std::string>& strings) {
+    furi_assert(remote.get() != nullptr);
     int i = 0;
     for(const auto& str : strings) {
         if(!str.compare(remote->name)) {

--- a/applications/irda/irda_app_signal.cpp
+++ b/applications/irda/irda_app_signal.cpp
@@ -70,8 +70,6 @@ IrdaAppSignal::IrdaAppSignal(const IrdaAppSignal& other) {
 }
 
 IrdaAppSignal::IrdaAppSignal(IrdaAppSignal&& other) {
-    clear_timings();
-
     raw_signal = other.raw_signal;
     if(!raw_signal) {
         payload.message = other.payload.message;

--- a/applications/irda/scene/irda_app_scene_remote_list.cpp
+++ b/applications/irda/scene/irda_app_scene_remote_list.cpp
@@ -15,6 +15,11 @@ void IrdaAppSceneRemoteList::on_enter(IrdaApp* app) {
         last_selected_remote.size() ? last_selected_remote.c_str() : nullptr;
     auto filename_ts = std::make_unique<TextStore>(IrdaAppRemoteManager::max_remote_name_length);
 
+    IrdaAppViewManager* view_manager = app->get_view_manager();
+    ButtonMenu* button_menu = view_manager->get_button_menu();
+    button_menu_reset(button_menu);
+    view_manager->switch_to(IrdaAppViewManager::ViewType::ButtonMenu);
+
     file_select_result = file_worker.file_select(
         IrdaApp::irda_directory,
         IrdaApp::irda_extension,


### PR DESCRIPTION
* Bugfix: remove freeing of uninitialized object (IrdaAppSignal).
Therefore rubbish in memory sometimes caused HardFault.
* Fix: can glimpse previous scene's view while remote is parsing.

# What's new

- HardFault fixes

# Verification 

- Run Infrared application, test any remotes

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
