### PR TITLE
[FL-2288] Ble: hide pin code if device is locked

### DIFF
--- a/firmware/targets/f6/ble_glue/gap.c
+++ b/firmware/targets/f6/ble_glue/gap.c
@@ -186,7 +186,11 @@ SVCCTL_UserEvtFlowStatus_t SVCCTL_App_Notification(void* pckt) {
             // Generate random PIN code
             uint32_t pin = rand() % 999999;
             aci_gap_pass_key_resp(gap->service.connection_handle, pin);
-            FURI_LOG_I(TAG, "Pass key request event. Pin: %06d", pin);
+            if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagLock)) {
+                FURI_LOG_I(TAG, "Pass key request event. Pin: ******");
+            } else {
+                FURI_LOG_I(TAG, "Pass key request event. Pin: %06d", pin);
+            }
             GapEvent event = {.type = GapEventTypePinCodeShow, .data.pin_code = pin};
             gap->on_event_cb(event, gap->context);
         } break;

--- a/firmware/targets/f7/ble_glue/gap.c
+++ b/firmware/targets/f7/ble_glue/gap.c
@@ -186,7 +186,11 @@ SVCCTL_UserEvtFlowStatus_t SVCCTL_App_Notification(void* pckt) {
             // Generate random PIN code
             uint32_t pin = rand() % 999999;
             aci_gap_pass_key_resp(gap->service.connection_handle, pin);
-            FURI_LOG_I(TAG, "Pass key request event. Pin: %06d", pin);
+            if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagLock)) {
+                FURI_LOG_I(TAG, "Pass key request event. Pin: ******");
+            } else {
+                FURI_LOG_I(TAG, "Pass key request event. Pin: %06d", pin);
+            }
             GapEvent event = {.type = GapEventTypePinCodeShow, .data.pin_code = pin};
             gap->on_event_cb(event, gap->context);
         } break;


### PR DESCRIPTION
# What's new

- Ble: hide pin code if device is locked

# Verification 

- Compile and upload
- Set pin and lock device
- Pair BLE

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
