### PR TITLE
BadUSB: fix \r\n line endings

### DIFF
--- a/applications/bad_usb/bad_usb_script.c
+++ b/applications/bad_usb/bad_usb_script.c
@@ -199,7 +199,7 @@ static bool ducky_altstring(const char* param) {
 
 static bool ducky_string(const char* param) {
     uint32_t i = 0;
-    while(param[i] != '\0') { // TODO:check for none
+    while(param[i] != '\0') {
         uint16_t keycode = HID_ASCII_TO_KEY(param[i]);
         if(keycode != KEY_NONE) {
             furi_hal_hid_kb_press(keycode);


### PR DESCRIPTION
# What's new

- BadUSB now supports scripts with both \n and \r\n line endings

# Verification 

- Try to run demo scripts with line endings changed to \r\n (windows)

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
