### PR TITLE
Removed power 3v3 options

### DIFF
--- a/applications/power/power_cli.c
+++ b/applications/power/power_cli.c
@@ -34,6 +34,16 @@ void power_cli_5v(Cli* cli, string_t args) {
     }
 }
 
+void power_cli_3v3(Cli* cli, string_t args) {
+    if(!string_cmp(args, "0")) {
+        furi_hal_power_disable_external_3_3v();
+    } else if(!string_cmp(args, "1")) {
+        furi_hal_power_enable_external_3_3v();
+    } else {
+        cli_print_usage("power_ext", "<1|0>", string_get_cstr(args));
+    }
+}
+
 static void power_cli_command_print_usage() {
     printf("Usage:\r\n");
     printf("power <cmd> <args>\r\n");
@@ -44,6 +54,9 @@ static void power_cli_command_print_usage() {
     printf("\treboot2dfu\t - reboot to dfu bootloader\r\n");
     printf("\tdebug\t - show debug information\r\n");
     printf("\t5v <0 or 1>\t - enable or disable 5v ext\r\n");
+    if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagDebug)) { 
+        printf("\t3v3 <0 or 1>\t - enable or disable 3v3 ext\r\n");
+    }
 }
 
 void power_cli(Cli* cli, string_t args, void* context) {
@@ -79,6 +92,13 @@ void power_cli(Cli* cli, string_t args, void* context) {
         if(string_cmp_str(cmd, "5v") == 0) {
             power_cli_5v(cli, args);
             break;
+        }
+
+        if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagDebug)) { 
+            if(string_cmp_str(cmd, "3v3") == 0) {
+                power_cli_3v3(cli, args);
+                break;
+            }
         }
 
         power_cli_command_print_usage();

--- a/applications/power/power_cli.c
+++ b/applications/power/power_cli.c
@@ -34,16 +34,6 @@ void power_cli_5v(Cli* cli, string_t args) {
     }
 }
 
-void power_cli_3v3(Cli* cli, string_t args) {
-    if(!string_cmp(args, "0")) {
-        furi_hal_power_disable_external_3_3v();
-    } else if(!string_cmp(args, "1")) {
-        furi_hal_power_enable_external_3_3v();
-    } else {
-        cli_print_usage("power_ext", "<1|0>", string_get_cstr(args));
-    }
-}
-
 static void power_cli_command_print_usage() {
     printf("Usage:\r\n");
     printf("power <cmd> <args>\r\n");
@@ -54,7 +44,6 @@ static void power_cli_command_print_usage() {
     printf("\treboot2dfu\t - reboot to dfu bootloader\r\n");
     printf("\tdebug\t - show debug information\r\n");
     printf("\t5v <0 or 1>\t - enable or disable 5v ext\r\n");
-    printf("\t3v3 <0 or 1>\t - enable or disable 3v3 ext\r\n");
 }
 
 void power_cli(Cli* cli, string_t args, void* context) {
@@ -89,11 +78,6 @@ void power_cli(Cli* cli, string_t args, void* context) {
 
         if(string_cmp_str(cmd, "5v") == 0) {
             power_cli_5v(cli, args);
-            break;
-        }
-
-        if(string_cmp_str(cmd, "3v3") == 0) {
-            power_cli_3v3(cli, args);
             break;
         }
 

--- a/applications/power/power_cli.c
+++ b/applications/power/power_cli.c
@@ -54,7 +54,7 @@ static void power_cli_command_print_usage() {
     printf("\treboot2dfu\t - reboot to dfu bootloader\r\n");
     printf("\tdebug\t - show debug information\r\n");
     printf("\t5v <0 or 1>\t - enable or disable 5v ext\r\n");
-    if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagDebug)) { 
+    if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagDebug)) {
         printf("\t3v3 <0 or 1>\t - enable or disable 3v3 ext\r\n");
     }
 }
@@ -94,7 +94,7 @@ void power_cli(Cli* cli, string_t args, void* context) {
             break;
         }
 
-        if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagDebug)) { 
+        if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagDebug)) {
             if(string_cmp_str(cmd, "3v3") == 0) {
                 power_cli_3v3(cli, args);
                 break;


### PR DESCRIPTION
# What's new

- Per skotopes, "3.3V: this line is used to power SD-Card it is highly unrecommended to turn this line off(power will be re-enabled to scan sdcard). We will remove this command in future releases." - #1020 

So I removed it here. No longer an option and should not be possible to switch on and off 3v3 via the power command. 

# Verification 

- Tested via PuTTY. Option no longer available and multi-meter does not report voltage changes when command is executed (as command is no longer valid). 

![puttyTest](https://user-images.githubusercontent.com/101580720/158266506-3d24b2c4-0f31-41c5-a24a-379c62c85305.PNG)

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix

