### PR TITLE
Gui: refactor text input module and fix debug on MacOS 12.3

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,6 @@
 cask "gcc-arm-embedded"
 brew "protobuf"
+brew "gdb"
 brew "heatshrink"
 brew "open-ocd"
 brew "clang-format"

--- a/applications/gui/modules/text_input.c
+++ b/applications/gui/modules/text_input.c
@@ -338,81 +338,71 @@ static bool text_input_view_input_callback(InputEvent* event, void* context) {
         model->valadator_message_visible = false;
         consumed = true;
     } else if(event->type == InputTypeShort) {
+        consumed = true;
         switch(event->key) {
         case InputKeyUp:
             text_input_handle_up(text_input, model);
-            consumed = true;
             break;
         case InputKeyDown:
             text_input_handle_down(text_input, model);
-            consumed = true;
             break;
         case InputKeyLeft:
             text_input_handle_left(text_input, model);
-            consumed = true;
             break;
         case InputKeyRight:
             text_input_handle_right(text_input, model);
-            consumed = true;
             break;
         case InputKeyOk:
             text_input_handle_ok(text_input, model, false);
-            consumed = true;
             break;
         default:
+            consumed = false;
             break;
         }
     } else if(event->type == InputTypeLong) {
+        consumed = true;
         switch(event->key) {
         case InputKeyUp:
             text_input_handle_up(text_input, model);
-            consumed = true;
             break;
         case InputKeyDown:
             text_input_handle_down(text_input, model);
-            consumed = true;
             break;
         case InputKeyLeft:
             text_input_handle_left(text_input, model);
-            consumed = true;
             break;
         case InputKeyRight:
             text_input_handle_right(text_input, model);
-            consumed = true;
             break;
         case InputKeyOk:
             text_input_handle_ok(text_input, model, true);
-            consumed = true;
         case InputKeyBack:
             text_input_backspace_cb(model);
-            consumed = true;
             break;
         default:
+            consumed = false;
             break;
         }
     } else if(event->type == InputTypeRepeat) {
+        consumed = true;
         switch(event->key) {
         case InputKeyUp:
             text_input_handle_up(text_input, model);
-            consumed = true;
             break;
         case InputKeyDown:
             text_input_handle_down(text_input, model);
-            consumed = true;
             break;
         case InputKeyLeft:
             text_input_handle_left(text_input, model);
-            consumed = true;
             break;
         case InputKeyRight:
             text_input_handle_right(text_input, model);
-            consumed = true;
             break;
         case InputKeyBack:
             text_input_backspace_cb(model);
-            consumed = true;
             break;
         default:
+            consumed = false;
             break;
         }
     }

--- a/applications/gui/modules/text_input.c
+++ b/applications/gui/modules/text_input.c
@@ -259,172 +259,171 @@ static void text_input_view_draw_callback(Canvas* canvas, void* _model) {
     }
 }
 
-static void text_input_handle_up(TextInput* text_input) {
-    with_view_model(
-        text_input->view, (TextInputModel * model) {
-            if(model->selected_row > 0) {
-                model->selected_row--;
-                if(model->selected_column > get_row_size(model->selected_row) - 6) {
-                    model->selected_column = model->selected_column + 1;
-                }
-            }
-            return true;
-        });
+static void text_input_handle_up(TextInput* text_input, TextInputModel* model) {
+    if(model->selected_row > 0) {
+        model->selected_row--;
+        if(model->selected_column > get_row_size(model->selected_row) - 6) {
+            model->selected_column = model->selected_column + 1;
+        }
+    }
 }
 
-static void text_input_handle_down(TextInput* text_input) {
-    with_view_model(
-        text_input->view, (TextInputModel * model) {
-            if(model->selected_row < keyboard_row_count - 1) {
-                model->selected_row++;
-                if(model->selected_column > get_row_size(model->selected_row) - 4) {
-                    model->selected_column = model->selected_column - 1;
-                }
-            }
-            return true;
-        });
+static void text_input_handle_down(TextInput* text_input, TextInputModel* model) {
+    if(model->selected_row < keyboard_row_count - 1) {
+        model->selected_row++;
+        if(model->selected_column > get_row_size(model->selected_row) - 4) {
+            model->selected_column = model->selected_column - 1;
+        }
+    }
 }
 
-static void text_input_handle_left(TextInput* text_input) {
-    with_view_model(
-        text_input->view, (TextInputModel * model) {
-            if(model->selected_column > 0) {
-                model->selected_column--;
-            } else {
-                model->selected_column = get_row_size(model->selected_row) - 1;
-            }
-            return true;
-        });
+static void text_input_handle_left(TextInput* text_input, TextInputModel* model) {
+    if(model->selected_column > 0) {
+        model->selected_column--;
+    } else {
+        model->selected_column = get_row_size(model->selected_row) - 1;
+    }
 }
 
-static void text_input_handle_right(TextInput* text_input) {
-    with_view_model(
-        text_input->view, (TextInputModel * model) {
-            if(model->selected_column < get_row_size(model->selected_row) - 1) {
-                model->selected_column++;
-            } else {
-                model->selected_column = 0;
-            }
-            return true;
-        });
+static void text_input_handle_right(TextInput* text_input, TextInputModel* model) {
+    if(model->selected_column < get_row_size(model->selected_row) - 1) {
+        model->selected_column++;
+    } else {
+        model->selected_column = 0;
+    }
 }
 
-static void text_input_handle_ok(TextInput* text_input, bool shift) {
-    with_view_model(
-        text_input->view, (TextInputModel * model) {
-            char selected = get_selected_char(model);
-            uint8_t text_length = strlen(model->text_buffer);
+static void text_input_handle_ok(TextInput* text_input, TextInputModel* model, bool shift) {
+    char selected = get_selected_char(model);
+    uint8_t text_length = strlen(model->text_buffer);
 
-            if(shift) {
-                selected = char_to_uppercase(selected);
-            }
+    if(shift) {
+        selected = char_to_uppercase(selected);
+    }
 
-            if(selected == ENTER_KEY) {
-                if(model->validator_callback && (!model->validator_callback(
-                                                    model->text_buffer,
-                                                    model->validator_text,
-                                                    model->validator_callback_context))) {
-                    model->valadator_message_visible = true;
-                    osTimerStart(text_input->timer, osKernelGetTickFreq() * 4);
-                } else if(model->callback != 0 && text_length > 0) {
-                    model->callback(model->callback_context);
-                }
-            } else if(selected == BACKSPACE_KEY) {
-                text_input_backspace_cb(model);
-            } else if(text_length < (model->text_buffer_size - 1)) {
-                if(model->clear_default_text) {
-                    text_length = 0;
-                }
-                if(text_length == 0 && char_is_lowercase(selected)) {
-                    selected = char_to_uppercase(selected);
-                }
-                model->text_buffer[text_length] = selected;
-                model->text_buffer[text_length + 1] = 0;
-            }
-            model->clear_default_text = false;
-            return true;
-        });
+    if(selected == ENTER_KEY) {
+        if(model->validator_callback &&
+           (!model->validator_callback(
+               model->text_buffer, model->validator_text, model->validator_callback_context))) {
+            model->valadator_message_visible = true;
+            osTimerStart(text_input->timer, osKernelGetTickFreq() * 4);
+        } else if(model->callback != 0 && text_length > 0) {
+            model->callback(model->callback_context);
+        }
+    } else if(selected == BACKSPACE_KEY) {
+        text_input_backspace_cb(model);
+    } else if(text_length < (model->text_buffer_size - 1)) {
+        if(model->clear_default_text) {
+            text_length = 0;
+        }
+        if(text_length == 0 && char_is_lowercase(selected)) {
+            selected = char_to_uppercase(selected);
+        }
+        model->text_buffer[text_length] = selected;
+        model->text_buffer[text_length + 1] = 0;
+    }
+    model->clear_default_text = false;
 }
 
 static bool text_input_view_input_callback(InputEvent* event, void* context) {
     TextInput* text_input = context;
     furi_assert(text_input);
+
     bool consumed = false;
 
-    if(event->type == InputTypeShort) {
-        with_view_model(
-            text_input->view, (TextInputModel * model) {
-                if(model->valadator_message_visible) {
-                    if(event->key == InputKeyBack) {
-                        consumed = true;
-                    }
-                }
-                model->valadator_message_visible = false;
-                return false;
-            });
-        switch(event->key) {
-        case InputKeyUp:
-            text_input_handle_up(text_input);
+    // Acquire model
+    TextInputModel* model = view_get_model(text_input->view);
+
+    do {
+        if(model->valadator_message_visible) {
+            model->valadator_message_visible = false;
             consumed = true;
-            break;
-        case InputKeyDown:
-            text_input_handle_down(text_input);
-            consumed = true;
-            break;
-        case InputKeyLeft:
-            text_input_handle_left(text_input);
-            consumed = true;
-            break;
-        case InputKeyRight:
-            text_input_handle_right(text_input);
-            consumed = true;
-            break;
-        case InputKeyOk:
-            text_input_handle_ok(text_input, false);
-            consumed = true;
-            break;
-        default:
             break;
         }
-    }
 
-    if((event->type == InputTypeLong || event->type == InputTypeRepeat) &&
-       event->key == InputKeyBack) {
-        with_view_model(
-            text_input->view, (TextInputModel * model) {
-                if(model->valadator_message_visible) {
-                    model->valadator_message_visible = false;
-                } else {
-                    text_input_backspace_cb(model);
-                }
-                return true;
-            });
-
-        consumed = true;
-    }
-
-    // Allow shift key on long press
-    if(event->type == InputTypeLong && event->key == InputKeyOk) {
-        with_view_model(
-            text_input->view, (TextInputModel * model) {
-                if(model->valadator_message_visible) {
-                    if(event->key == InputKeyBack) {
-                        consumed = true;
-                    }
-                }
-                model->valadator_message_visible = false;
-                return false;
-            });
-
-        switch(event->key) {
-        case InputKeyOk:
-            text_input_handle_ok(text_input, true);
-            consumed = true;
-            break;
-        default:
-            break;
+        if(event->type == InputTypeShort) {
+            switch(event->key) {
+            case InputKeyUp:
+                text_input_handle_up(text_input, model);
+                consumed = true;
+                break;
+            case InputKeyDown:
+                text_input_handle_down(text_input, model);
+                consumed = true;
+                break;
+            case InputKeyLeft:
+                text_input_handle_left(text_input, model);
+                consumed = true;
+                break;
+            case InputKeyRight:
+                text_input_handle_right(text_input, model);
+                consumed = true;
+                break;
+            case InputKeyOk:
+                text_input_handle_ok(text_input, model, false);
+                consumed = true;
+                break;
+            default:
+                break;
+            }
+        } else if(event->type == InputTypeLong) {
+            switch(event->key) {
+            case InputKeyUp:
+                text_input_handle_up(text_input, model);
+                consumed = true;
+                break;
+            case InputKeyDown:
+                text_input_handle_down(text_input, model);
+                consumed = true;
+                break;
+            case InputKeyLeft:
+                text_input_handle_left(text_input, model);
+                consumed = true;
+                break;
+            case InputKeyRight:
+                text_input_handle_right(text_input, model);
+                consumed = true;
+                break;
+            case InputKeyOk:
+                text_input_handle_ok(text_input, model, true);
+                consumed = true;
+            case InputKeyBack:
+                text_input_backspace_cb(model);
+                consumed = true;
+                break;
+            default:
+                break;
+            }
+        } else if(event->type == InputTypeRepeat) {
+            switch(event->key) {
+            case InputKeyUp:
+                text_input_handle_up(text_input, model);
+                consumed = true;
+                break;
+            case InputKeyDown:
+                text_input_handle_down(text_input, model);
+                consumed = true;
+                break;
+            case InputKeyLeft:
+                text_input_handle_left(text_input, model);
+                consumed = true;
+                break;
+            case InputKeyRight:
+                text_input_handle_right(text_input, model);
+                consumed = true;
+                break;
+            case InputKeyBack:
+                text_input_backspace_cb(model);
+                consumed = true;
+                break;
+            default:
+                break;
+            }
         }
-    }
+    } while(0);
+
+    // Commit model
+    view_commit_model(text_input->view, consumed);
 
     return consumed;
 }

--- a/applications/gui/modules/text_input.c
+++ b/applications/gui/modules/text_input.c
@@ -334,7 +334,8 @@ static bool text_input_view_input_callback(InputEvent* event, void* context) {
     // Acquire model
     TextInputModel* model = view_get_model(text_input->view);
 
-    if(model->valadator_message_visible) {
+    if((!(event->type == InputTypePress) && !(event->type == InputTypeRelease)) &&
+       model->valadator_message_visible) {
         model->valadator_message_visible = false;
         consumed = true;
     } else if(event->type == InputTypeShort) {
@@ -376,6 +377,7 @@ static bool text_input_view_input_callback(InputEvent* event, void* context) {
             break;
         case InputKeyOk:
             text_input_handle_ok(text_input, model, true);
+            break;
         case InputKeyBack:
             text_input_backspace_cb(model);
             break;

--- a/applications/gui/modules/text_input.c
+++ b/applications/gui/modules/text_input.c
@@ -334,93 +334,88 @@ static bool text_input_view_input_callback(InputEvent* event, void* context) {
     // Acquire model
     TextInputModel* model = view_get_model(text_input->view);
 
-    do {
-        if(model->valadator_message_visible) {
-            model->valadator_message_visible = false;
+    if(model->valadator_message_visible) {
+        model->valadator_message_visible = false;
+        consumed = true;
+    } else if(event->type == InputTypeShort) {
+        switch(event->key) {
+        case InputKeyUp:
+            text_input_handle_up(text_input, model);
             consumed = true;
             break;
+        case InputKeyDown:
+            text_input_handle_down(text_input, model);
+            consumed = true;
+            break;
+        case InputKeyLeft:
+            text_input_handle_left(text_input, model);
+            consumed = true;
+            break;
+        case InputKeyRight:
+            text_input_handle_right(text_input, model);
+            consumed = true;
+            break;
+        case InputKeyOk:
+            text_input_handle_ok(text_input, model, false);
+            consumed = true;
+            break;
+        default:
+            break;
         }
-
-        if(event->type == InputTypeShort) {
-            switch(event->key) {
-            case InputKeyUp:
-                text_input_handle_up(text_input, model);
-                consumed = true;
-                break;
-            case InputKeyDown:
-                text_input_handle_down(text_input, model);
-                consumed = true;
-                break;
-            case InputKeyLeft:
-                text_input_handle_left(text_input, model);
-                consumed = true;
-                break;
-            case InputKeyRight:
-                text_input_handle_right(text_input, model);
-                consumed = true;
-                break;
-            case InputKeyOk:
-                text_input_handle_ok(text_input, model, false);
-                consumed = true;
-                break;
-            default:
-                break;
-            }
-        } else if(event->type == InputTypeLong) {
-            switch(event->key) {
-            case InputKeyUp:
-                text_input_handle_up(text_input, model);
-                consumed = true;
-                break;
-            case InputKeyDown:
-                text_input_handle_down(text_input, model);
-                consumed = true;
-                break;
-            case InputKeyLeft:
-                text_input_handle_left(text_input, model);
-                consumed = true;
-                break;
-            case InputKeyRight:
-                text_input_handle_right(text_input, model);
-                consumed = true;
-                break;
-            case InputKeyOk:
-                text_input_handle_ok(text_input, model, true);
-                consumed = true;
-            case InputKeyBack:
-                text_input_backspace_cb(model);
-                consumed = true;
-                break;
-            default:
-                break;
-            }
-        } else if(event->type == InputTypeRepeat) {
-            switch(event->key) {
-            case InputKeyUp:
-                text_input_handle_up(text_input, model);
-                consumed = true;
-                break;
-            case InputKeyDown:
-                text_input_handle_down(text_input, model);
-                consumed = true;
-                break;
-            case InputKeyLeft:
-                text_input_handle_left(text_input, model);
-                consumed = true;
-                break;
-            case InputKeyRight:
-                text_input_handle_right(text_input, model);
-                consumed = true;
-                break;
-            case InputKeyBack:
-                text_input_backspace_cb(model);
-                consumed = true;
-                break;
-            default:
-                break;
-            }
+    } else if(event->type == InputTypeLong) {
+        switch(event->key) {
+        case InputKeyUp:
+            text_input_handle_up(text_input, model);
+            consumed = true;
+            break;
+        case InputKeyDown:
+            text_input_handle_down(text_input, model);
+            consumed = true;
+            break;
+        case InputKeyLeft:
+            text_input_handle_left(text_input, model);
+            consumed = true;
+            break;
+        case InputKeyRight:
+            text_input_handle_right(text_input, model);
+            consumed = true;
+            break;
+        case InputKeyOk:
+            text_input_handle_ok(text_input, model, true);
+            consumed = true;
+        case InputKeyBack:
+            text_input_backspace_cb(model);
+            consumed = true;
+            break;
+        default:
+            break;
         }
-    } while(0);
+    } else if(event->type == InputTypeRepeat) {
+        switch(event->key) {
+        case InputKeyUp:
+            text_input_handle_up(text_input, model);
+            consumed = true;
+            break;
+        case InputKeyDown:
+            text_input_handle_down(text_input, model);
+            consumed = true;
+            break;
+        case InputKeyLeft:
+            text_input_handle_left(text_input, model);
+            consumed = true;
+            break;
+        case InputKeyRight:
+            text_input_handle_right(text_input, model);
+            consumed = true;
+            break;
+        case InputKeyBack:
+            text_input_backspace_cb(model);
+            consumed = true;
+            break;
+        default:
+            break;
+        }
+    }
 
     // Commit model
     view_commit_model(text_input->view, consumed);

--- a/make/rules.mk
+++ b/make/rules.mk
@@ -94,7 +94,7 @@ upload: $(OBJ_DIR)/upload
 
 .PHONY: debug
 debug: flash
-	arm-none-eabi-gdb-py \
+	$(GDB) \
 		-ex 'target extended-remote | openocd -c "gdb_port pipe" $(OPENOCD_OPTS)' \
 		-ex "set confirm off" \
 		-ex "source ../debug/FreeRTOS/FreeRTOS.py" \
@@ -105,7 +105,7 @@ debug: flash
 
 .PHONY: debug_other
 debug_other:
-	arm-none-eabi-gdb-py \
+	$(GDB) \
 		-ex 'target extended-remote | openocd -c "gdb_port pipe" $(OPENOCD_OPTS)' \
 		-ex "set confirm off" \
 		-ex "source ../debug/PyCortexMDebug/PyCortexMDebug.py" \
@@ -113,7 +113,7 @@ debug_other:
 
 .PHONY: blackmagic
 blackmagic:
-	arm-none-eabi-gdb-py \
+	$(GDB) \
 		-ex 'target extended-remote $(BLACKMAGIC)' \
 		-ex 'monitor swdp_scan' \
 		-ex 'monitor debug_bmp enable' \

--- a/make/toolchain.mk
+++ b/make/toolchain.mk
@@ -1,3 +1,5 @@
+OS := $(shell uname -s)
+
 # Compiller 
 ifeq ($(TOOLCHAIN), arm)
 PREFIX = arm-none-eabi-
@@ -14,6 +16,12 @@ CP	= $(PREFIX)objcopy
 SZ	= $(PREFIX)size
 HEX	= $(CP) -O ihex
 BIN	= $(CP) -O binary -S
+
+ifeq ($(OS), Darwin)
+GDB	= gdb
+else 
+GDB	= $(PREFIX)gdb-py
+endif
 
 DEBUG ?= 1
 COMPACT ?= 0


### PR DESCRIPTION
# What's new

- Gui: refactor text input module
- Fix broken debug with gdb on MacOS 12.3

# Verification 

- Compile and upload
- Verify TextInput module behaviour
- On MacOS 12.3: `brew bundle --verbose` and verify that `make debug` is working 

# Checklist (do not modify)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
