### PR TITLE
[FL-2165] Do not allow "write" for keys that do not have write ability.

### DIFF
--- a/applications/ibutton/scene/ibutton_scene_readed_key_menu.cpp
+++ b/applications/ibutton/scene/ibutton_scene_readed_key_menu.cpp
@@ -16,7 +16,9 @@ void iButtonSceneReadedKeyMenu::on_enter(iButtonApp* app) {
     Submenu* submenu = view_manager->get_submenu();
     auto callback = cbc::obtain_connector(this, &iButtonSceneReadedKeyMenu::submenu_callback);
 
-    submenu_add_item(submenu, "Write", SubmenuIndexWrite, callback, app);
+    if(app->get_key()->get_key_type() == iButtonKeyType::KeyDallas) {
+        submenu_add_item(submenu, "Write", SubmenuIndexWrite, callback, app);
+    }
     submenu_add_item(submenu, "Name and save", SubmenuIndexNameAndSave, callback, app);
     submenu_add_item(submenu, "Emulate", SubmenuIndexEmulate, callback, app);
     submenu_add_item(submenu, "Read new key", SubmenuIndexReadNewKey, callback, app);

--- a/applications/ibutton/scene/ibutton_scene_saved_key_menu.cpp
+++ b/applications/ibutton/scene/ibutton_scene_saved_key_menu.cpp
@@ -18,7 +18,9 @@ void iButtonSceneSavedKeyMenu::on_enter(iButtonApp* app) {
     auto callback = cbc::obtain_connector(this, &iButtonSceneSavedKeyMenu::submenu_callback);
 
     submenu_add_item(submenu, "Emulate", SubmenuIndexEmulate, callback, app);
-    submenu_add_item(submenu, "Write", SubmenuIndexWrite, callback, app);
+    if(app->get_key()->get_key_type() == iButtonKeyType::KeyDallas) {
+        submenu_add_item(submenu, "Write", SubmenuIndexWrite, callback, app);
+    }
     submenu_add_item(submenu, "Edit", SubmenuIndexEdit, callback, app);
     submenu_add_item(submenu, "Delete", SubmenuIndexDelete, callback, app);
     submenu_add_item(submenu, "Info", SubmenuIndexInfo, callback, app);


### PR DESCRIPTION
# What's new

- Hidden write item for Metakom and Cyfral.

# Verification 

- Read Metakom or Cyfral key, check that now it cannot be written.
- Load Metakom or Cyfral key, check that now it cannot be written.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
