### PR TITLE
[FL-2367] Fix ikey write command hanging

### DIFF
--- a/applications/ibutton/ibutton_cli.cpp
+++ b/applications/ibutton/ibutton_cli.cpp
@@ -164,6 +164,8 @@ void ibutton_cli_write(Cli* cli, string_t args) {
             exit = true;
             break;
         }
+
+        delay(100);
     };
 
     worker->stop_write();


### PR DESCRIPTION
# What's new

- Added delay to ibutton_cli_write to prevent it from hanging the whole system

# Verification 

- Check ikey write command

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
