### PR TITLE
[FL-2383, FL-2384] iButton, Desktop bug fixes

### DIFF
--- a/applications/desktop/desktop_i.h
+++ b/applications/desktop/desktop_i.h
@@ -18,6 +18,8 @@
 #include <gui/modules/popup.h>
 #include <gui/scene_manager.h>
 
+#include <loader/loader.h>
+
 #define STATUS_BAR_Y_SHIFT 13
 
 typedef enum {
@@ -57,7 +59,7 @@ struct Desktop {
     ViewPort* lock_viewport;
 
     AnimationManager* animation_manager;
-    osSemaphoreId_t unload_animation_semaphore;
+    Loader* loader;
     FuriPubSubSubscription* app_start_stop_subscription;
 };
 

--- a/applications/desktop/scenes/desktop_scene_lock_menu.c
+++ b/applications/desktop/scenes/desktop_scene_lock_menu.c
@@ -60,10 +60,8 @@ bool desktop_scene_lock_menu_on_event(void* context, SceneManagerEvent event) {
                     desktop->scene_manager, DesktopSceneLocked, SCENE_LOCKED_FIRST_ENTER);
                 scene_manager_next_scene(desktop->scene_manager, DesktopSceneLocked);
             } else {
-                Loader* loader = furi_record_open("loader");
                 LoaderStatus status =
-                    loader_start(loader, "Desktop", DESKTOP_SETTINGS_RUN_PIN_SETUP_ARG);
-                furi_record_close("loader");
+                    loader_start(desktop->loader, "Desktop", DESKTOP_SETTINGS_RUN_PIN_SETUP_ARG);
                 if(status == LoaderStatusOk) {
                     scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 1);
                 } else {

--- a/applications/desktop/views/desktop_events.h
+++ b/applications/desktop/views/desktop_events.h
@@ -7,8 +7,6 @@ typedef enum {
     DesktopMainEventOpenMenu,
     DesktopMainEventOpenDebug,
     DesktopMainEventRightShort,
-    DesktopMainEventBeforeAppStarted,
-    DesktopMainEventAfterAppFinished,
 
     DesktopLockedEventUnlocked,
     DesktopLockedEventUpdate,
@@ -37,4 +35,7 @@ typedef enum {
     DesktopAnimationEventNewIdleAnimation,
     DesktopAnimationEventInteractAnimation,
 
+    // Global events
+    DesktopGlobalBeforeAppStarted,
+    DesktopGlobalAfterAppFinished,
 } DesktopEvent;

--- a/applications/ibutton/ibutton_cli.cpp
+++ b/applications/ibutton/ibutton_cli.cpp
@@ -209,6 +209,7 @@ void ibutton_cli_emulate(Cli* cli, string_t args) {
 
     while(!exit) {
         exit = cli_cmd_interrupt_received(cli);
+        delay(100);
     };
 
     worker->stop_emulate();

--- a/firmware/targets/f7/furi_hal/furi_hal_ibutton.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_ibutton.c
@@ -32,10 +32,6 @@ static void furi_hal_ibutton_emulate_isr() {
 void furi_hal_ibutton_init() {
     furi_hal_ibutton = malloc(sizeof(FuriHalIbutton));
     furi_hal_ibutton->state = FuriHalIbuttonStateIdle;
-
-    NVIC_SetPriority(
-        FURI_HAL_IBUTTON_TIMER_IRQ, NVIC_EncodePriority(NVIC_GetPriorityGrouping(), 5, 0));
-    NVIC_EnableIRQ(FURI_HAL_IBUTTON_TIMER_IRQ);
 }
 
 void furi_hal_ibutton_emulate_start(
@@ -49,7 +45,14 @@ void furi_hal_ibutton_emulate_start(
     furi_hal_ibutton->callback = callback;
     furi_hal_ibutton->context = context;
 
+    FURI_CRITICAL_ENTER();
+    LL_TIM_DeInit(FURI_HAL_IBUTTON_TIMER);
+    FURI_CRITICAL_EXIT();
+
     furi_hal_interrupt_set_timer_isr(FURI_HAL_IBUTTON_TIMER, furi_hal_ibutton_emulate_isr);
+    NVIC_SetPriority(
+        FURI_HAL_IBUTTON_TIMER_IRQ, NVIC_EncodePriority(NVIC_GetPriorityGrouping(), 5, 0));
+    NVIC_EnableIRQ(FURI_HAL_IBUTTON_TIMER_IRQ);
 
     LL_TIM_SetPrescaler(FURI_HAL_IBUTTON_TIMER, 0);
     LL_TIM_SetCounterMode(FURI_HAL_IBUTTON_TIMER, LL_TIM_COUNTERMODE_UP);
@@ -76,14 +79,15 @@ void furi_hal_ibutton_emulate_stop() {
     if(furi_hal_ibutton->state == FuriHalIbuttonStateRunning) {
         furi_hal_ibutton->state = FuriHalIbuttonStateIdle;
         LL_TIM_DisableCounter(FURI_HAL_IBUTTON_TIMER);
-        furi_hal_interrupt_set_timer_isr(FURI_HAL_IBUTTON_TIMER, NULL);
-
-        furi_hal_ibutton->callback = NULL;
-        furi_hal_ibutton->context = NULL;
 
         FURI_CRITICAL_ENTER();
         LL_TIM_DeInit(FURI_HAL_IBUTTON_TIMER);
         FURI_CRITICAL_EXIT();
+
+        furi_hal_interrupt_set_timer_isr(FURI_HAL_IBUTTON_TIMER, NULL);
+
+        furi_hal_ibutton->callback = NULL;
+        furi_hal_ibutton->context = NULL;
     }
 }
 

--- a/firmware/targets/f7/furi_hal/furi_hal_rfid.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_rfid.c
@@ -193,7 +193,6 @@ void furi_hal_rfid_tim_emulate_start(FuriHalRfidEmulateCallback callback, void* 
     }
 
     furi_hal_interrupt_set_timer_isr(FURI_HAL_RFID_EMULATE_TIMER, furi_hal_rfid_emulate_isr);
-
     NVIC_SetPriority(
         FURI_HAL_RFID_EMULATE_TIMER_IRQ, NVIC_EncodePriority(NVIC_GetPriorityGrouping(), 5, 0));
     NVIC_EnableIRQ(FURI_HAL_RFID_EMULATE_TIMER_IRQ);
@@ -204,9 +203,9 @@ void furi_hal_rfid_tim_emulate_start(FuriHalRfidEmulateCallback callback, void* 
 }
 
 void furi_hal_rfid_tim_emulate_stop() {
-    furi_hal_interrupt_set_timer_isr(FURI_HAL_RFID_EMULATE_TIMER, NULL);
     LL_TIM_DisableCounter(FURI_HAL_RFID_EMULATE_TIMER);
     LL_TIM_DisableAllOutputs(FURI_HAL_RFID_EMULATE_TIMER);
+    furi_hal_interrupt_set_timer_isr(FURI_HAL_RFID_EMULATE_TIMER, NULL);
 }
 
 void furi_hal_rfid_tim_reset() {

--- a/firmware/targets/f7/furi_hal/furi_hal_subghz.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_subghz.c
@@ -732,10 +732,6 @@ void furi_hal_subghz_start_async_rx(FuriHalSubGhzCaptureCallback callback, void*
     LL_TIM_CC_EnableChannel(TIM2, LL_TIM_CHANNEL_CH1);
     LL_TIM_CC_EnableChannel(TIM2, LL_TIM_CHANNEL_CH2);
 
-    // Enable NVIC
-    NVIC_SetPriority(TIM2_IRQn, NVIC_EncodePriority(NVIC_GetPriorityGrouping(), 5, 0));
-    NVIC_EnableIRQ(TIM2_IRQn);
-
     // Start timer
     LL_TIM_SetCounter(TIM2, 0);
     LL_TIM_EnableCounter(TIM2);
@@ -919,6 +915,9 @@ bool furi_hal_subghz_start_async_tx(FuriHalSubGhzAsyncTxCallback callback, void*
     LL_TIM_DisableMasterSlaveMode(TIM2);
 
     furi_hal_interrupt_set_timer_isr(TIM2, furi_hal_subghz_async_tx_timer_isr);
+    NVIC_SetPriority(TIM2_IRQn, NVIC_EncodePriority(NVIC_GetPriorityGrouping(), 5, 0));
+    NVIC_EnableIRQ(TIM2_IRQn);
+
     LL_TIM_EnableIT_UPDATE(TIM2);
     LL_TIM_EnableDMAReq_UPDATE(TIM2);
     LL_TIM_CC_EnableChannel(TIM2, LL_TIM_CHANNEL_CH2);
@@ -929,10 +928,6 @@ bool furi_hal_subghz_start_async_tx(FuriHalSubGhzAsyncTxCallback callback, void*
     hal_gpio_write(&FURI_HAL_SUBGHZ_TX_GPIO, true);
 #endif
     furi_hal_subghz_tx();
-
-    // Enable NVIC
-    NVIC_SetPriority(TIM2_IRQn, NVIC_EncodePriority(NVIC_GetPriorityGrouping(), 5, 0));
-    NVIC_EnableIRQ(TIM2_IRQn);
 
     LL_TIM_SetCounter(TIM2, 0);
     LL_TIM_EnableCounter(TIM2);


### PR DESCRIPTION
# What's new

- Correct init and emulation sequence for furi_hal_ibutton, fix FL-2383
- Desktop: fix crash caused by invalid animation manager state, described in FL-2384

# Verification 

- Execute `ikey emulate cyfral 0123` twice. Make sure Flipper is not frozen.
- Emulate iButton keys throw the GUI
- Desktop: lock, start application throw the cli, unlock, exit application

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
