### PR TITLE
archive: bump MAX_FILES to 800

### DIFF
--- a/applications/archive/helpers/archive_files.h
+++ b/applications/archive/helpers/archive_files.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "file_worker.h"
 
-#define MAX_FILES 100 //temp
+#define MAX_FILES 800 //temp
 
 typedef enum {
     ArchiveFileTypeIButton,


### PR DESCRIPTION
# What's new

- Increase Archive's directory entry limit from 100 to 800.  It seems that the OOM this limit guards against happens somewhere between `MAX_FILES=800` and `MAX_FILES=1000`, so we still can't remove the limit entirely.

# Verification 

- View a directory with many files or subdirectories in Archive, observe that truncation happens at 800 entries now, rather than 100.  <https://github.com/Spexivus/csv2ir>'s `ir/` directory is a good test case with 618 entries, and is what motivated me to make this change.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
