### PR TITLE
[FL-2388] Fix Mifare Classic exit

### DIFF
--- a/applications/nfc/nfc_worker.h
+++ b/applications/nfc/nfc_worker.h
@@ -25,6 +25,10 @@ typedef enum {
 } NfcWorkerState;
 
 typedef enum {
+    // Reserve first 50 events for application events
+    NfcWorkerEventReserved = 50,
+
+    // Nfc worker common events
     NfcWorkerEventSuccess,
     NfcWorkerEventFail,
     NfcWorkerEventNoCardDetected,


### PR DESCRIPTION
# What's new

- Add nfc worker events offset to avoid mifare classic scene reenter after exit

# Verification 

- Go to nfc -> run special actions -> read mifare classic. Verify exit works correctly

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
