### PR TITLE
[FL-2410] SubGhz: fix launching an incorrect Sub-GHz key from the archive

### DIFF
--- a/applications/subghz/subghz.c
+++ b/applications/subghz/subghz.c
@@ -309,20 +309,26 @@ int32_t subghz_app(void* p) {
     subghz_environment_load_keystore(
         subghz->txrx->environment, "/ext/subghz/assets/keeloq_mfcodes_user");
     // Check argument and run corresponding scene
-    if(p && subghz_key_load(subghz, p)) {
-        string_t filename;
-        string_init(filename);
+    if(p) {
+        if(subghz_key_load(subghz, p)) {
+            string_t filename;
+            string_init(filename);
 
-        path_extract_filename_no_ext(p, filename);
-        strcpy(subghz->file_name, string_get_cstr(filename));
-        string_clear(filename);
-        if((!strcmp(subghz->txrx->decoder_result->protocol->name, "RAW"))) {
-            //Load Raw TX
-            subghz->txrx->rx_key_state = SubGhzRxKeyStateRAWLoad;
-            scene_manager_next_scene(subghz->scene_manager, SubGhzSceneReadRAW);
+            path_extract_filename_no_ext(p, filename);
+            strcpy(subghz->file_name, string_get_cstr(filename));
+            string_clear(filename);
+            if((!strcmp(subghz->txrx->decoder_result->protocol->name, "RAW"))) {
+                //Load Raw TX
+                subghz->txrx->rx_key_state = SubGhzRxKeyStateRAWLoad;
+                scene_manager_next_scene(subghz->scene_manager, SubGhzSceneReadRAW);
+            } else {
+                //Load transmitter TX
+                scene_manager_next_scene(subghz->scene_manager, SubGhzSceneTransmitter);
+            }
         } else {
-            //Load transmitter TX
-            scene_manager_next_scene(subghz->scene_manager, SubGhzSceneTransmitter);
+            //exit app
+            scene_manager_stop(subghz->scene_manager);
+            view_dispatcher_stop(subghz->view_dispatcher);
         }
     } else {
         if(load_database) {

--- a/applications/subghz/subghz_i.c
+++ b/applications/subghz/subghz_i.c
@@ -277,7 +277,6 @@ bool subghz_key_load(SubGhz* subghz, const char* file_path) {
     }
 
     string_clear(temp_str);
-    //string_clear(path);
     flipper_format_free(fff_data_file);
     furi_record_close("storage");
 


### PR DESCRIPTION
# What's new

- [FL-2410] SubGhz: fix launching an incorrect Sub-GHz key from the archive.

# Verification 

- Compile and run
- Сheck menu navigation when launching an incorrect file from an archive

# Checklist (For Reviewer)

- [Х] PR has description of feature/bug or link to Confluence/Jira task
- [Х] Description contains actions to verify feature/bugfix
- [Х] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-2410]: https://flipperzero.atlassian.net/browse/FL-2410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ