### PR TITLE
[FL-2423] Storage: blocking dir open

### DIFF
--- a/applications/storage/storage.h
+++ b/applications/storage/storage.h
@@ -24,6 +24,7 @@ typedef enum {
     StorageEventTypeCardUnmount,
     StorageEventTypeCardMountError,
     StorageEventTypeFileClose,
+    StorageEventTypeDirClose,
 } StorageEventType;
 
 typedef struct {
@@ -64,6 +65,12 @@ bool storage_file_close(File* file);
  * @return bool true if file is open
  */
 bool storage_file_is_open(File* file);
+
+/** Tells if the file is a directory
+ * @param file pointer to a file object
+ * @return bool true if file is a directory
+ */
+bool storage_file_is_dir(File* file);
 
 /** Reads bytes from a file into a buffer
  * @param file pointer to file object.

--- a/applications/storage/storage_processing.c
+++ b/applications/storage/storage_processing.c
@@ -285,6 +285,9 @@ bool storage_process_dir_close(Storage* app, File* file) {
     } else {
         FS_CALL(storage, dir.close(storage, file));
         storage_pop_storage_file(file, storage);
+
+        StorageEvent event = {.type = StorageEventTypeDirClose};
+        furi_pubsub_publish(app->pubsub, &event);
     }
 
     return ret;

--- a/applications/tests/storage/storage_test.c
+++ b/applications/tests/storage/storage_test.c
@@ -4,6 +4,7 @@
 #include <storage/storage.h>
 
 #define STORAGE_LOCKED_FILE "/ext/locked_file.test"
+#define STORAGE_LOCKED_DIR "/int"
 
 static void storage_file_open_lock_setup() {
     Storage* storage = furi_record_open("storage");
@@ -68,13 +69,103 @@ MU_TEST(storage_file_open_lock) {
     mu_assert(result, "cannot open locked file");
 }
 
+MU_TEST(storage_file_open_close) {
+    Storage* storage = furi_record_open("storage");
+    File* file;
+
+    file = storage_file_alloc(storage);
+    mu_check(storage_file_open(file, STORAGE_LOCKED_FILE, FSAM_READ_WRITE, FSOM_OPEN_EXISTING));
+    storage_file_close(file);
+    storage_file_free(file);
+
+    for(size_t i = 0; i < 10; i++) {
+        file = storage_file_alloc(storage);
+        mu_check(
+            storage_file_open(file, STORAGE_LOCKED_FILE, FSAM_READ_WRITE, FSOM_OPEN_EXISTING));
+        storage_file_free(file);
+    }
+
+    furi_record_close("storage");
+}
+
 MU_TEST_SUITE(storage_file) {
     storage_file_open_lock_setup();
+    MU_RUN_TEST(storage_file_open_close);
     MU_RUN_TEST(storage_file_open_lock);
     storage_file_open_lock_teardown();
 }
 
+MU_TEST(storage_dir_open_close) {
+    Storage* storage = furi_record_open("storage");
+    File* file;
+
+    file = storage_file_alloc(storage);
+    mu_check(storage_dir_open(file, STORAGE_LOCKED_DIR));
+    storage_dir_close(file);
+    storage_file_free(file);
+
+    for(size_t i = 0; i < 10; i++) {
+        file = storage_file_alloc(storage);
+        mu_check(storage_dir_open(file, STORAGE_LOCKED_DIR));
+        storage_file_free(file);
+    }
+
+    furi_record_close("storage");
+}
+
+static int32_t storage_dir_locker(void* ctx) {
+    Storage* storage = furi_record_open("storage");
+    osSemaphoreId_t semaphore = ctx;
+    File* file = storage_file_alloc(storage);
+    furi_check(storage_dir_open(file, STORAGE_LOCKED_DIR));
+    osSemaphoreRelease(semaphore);
+    furi_hal_delay_ms(1000);
+
+    furi_check(storage_dir_close(file));
+    furi_record_close("storage");
+    storage_file_free(file);
+    return 0;
+}
+
+MU_TEST(storage_dir_open_lock) {
+    Storage* storage = furi_record_open("storage");
+    bool result = false;
+    osSemaphoreId_t semaphore = osSemaphoreNew(1, 0, NULL);
+    File* file = storage_file_alloc(storage);
+
+    // file_locker thread start
+    FuriThread* locker_thread = furi_thread_alloc();
+    furi_thread_set_name(locker_thread, "StorageDirLocker");
+    furi_thread_set_stack_size(locker_thread, 2048);
+    furi_thread_set_context(locker_thread, semaphore);
+    furi_thread_set_callback(locker_thread, storage_dir_locker);
+    mu_check(furi_thread_start(locker_thread));
+
+    // wait for dir lock
+    osSemaphoreAcquire(semaphore, osWaitForever);
+    osSemaphoreDelete(semaphore);
+
+    result = storage_dir_open(file, STORAGE_LOCKED_DIR);
+    storage_dir_close(file);
+
+    // file_locker thread stop
+    mu_check(furi_thread_join(locker_thread) == osOK);
+    furi_thread_free(locker_thread);
+
+    // clean data
+    storage_file_free(file);
+    furi_record_close("storage");
+
+    mu_assert(result, "cannot open locked dir");
+}
+
+MU_TEST_SUITE(storage_dir) {
+    MU_RUN_TEST(storage_dir_open_close);
+    MU_RUN_TEST(storage_dir_open_lock);
+}
+
 int run_minunit_test_storage() {
     MU_RUN_SUITE(storage_file);
+    MU_RUN_SUITE(storage_dir);
     return MU_EXIT_CODE;
 }


### PR DESCRIPTION
# What's new

- Opening an already open directory no longer returns an error, instead the function will wait until the directory is closed.

# Verification 

- Run unit_tests. Look for storage_dir_open_lock() test.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
