### PR TITLE
[FL-2439] SubGhz: fix magic numbers and description in crash

### DIFF
--- a/applications/subghz/scenes/subghz_scene_read_raw.c
+++ b/applications/subghz/scenes/subghz_scene_read_raw.c
@@ -181,7 +181,7 @@ bool subghz_scene_read_raw_on_event(void* context, SceneManagerEvent event) {
                 scene_manager_next_scene(subghz->scene_manager, SubGhzSceneMoreRAW);
                 return true;
             } else {
-                furi_crash(NULL);
+                furi_crash("SugGhz: RAW file name update error.");
             }
             break;
 

--- a/applications/subghz/subghz_i.c
+++ b/applications/subghz/subghz_i.c
@@ -69,7 +69,7 @@ void subghz_begin(SubGhz* subghz, FuriHalSubGhzPreset preset) {
 uint32_t subghz_rx(SubGhz* subghz, uint32_t frequency) {
     furi_assert(subghz);
     if(!furi_hal_subghz_is_frequency_valid(frequency)) {
-        furi_crash("SugGhz: Incorrect received frequency.");
+        furi_crash("SugGhz: Incorrect RX frequency.");
     }
     furi_assert(
         subghz->txrx->txrx_state != SubGhzTxRxStateRx &&
@@ -90,7 +90,7 @@ uint32_t subghz_rx(SubGhz* subghz, uint32_t frequency) {
 static bool subghz_tx(SubGhz* subghz, uint32_t frequency) {
     furi_assert(subghz);
     if(!furi_hal_subghz_is_frequency_valid(frequency)) {
-        furi_crash("SugGhz: Transmission frequency is incorrect.");
+        furi_crash("SugGhz: Incorrect TX frequency.");
     }
     furi_assert(subghz->txrx->txrx_state != SubGhzTxRxStateSleep);
     furi_hal_subghz_idle();
@@ -309,22 +309,19 @@ bool subghz_key_load(SubGhz* subghz, const char* file_path) {
     switch(load_key_state) {
     case SubGhzLoadKeyStateParseErr:
         dialog_message_show_storage_error(subghz->dialogs, "Cannot parse\nfile");
-        break;
+        return false;
 
     case SubGhzLoadKeyStateOnlyRx:
         subghz_dialog_message_show_only_rx(subghz);
-        break;
+        return false;
 
     case SubGhzLoadKeyStateOK:
         return true;
-        break;
 
     default:
-        furi_crash("SubGhz: Load key state unknown.");
-        break;
+        furi_crash("SubGhz: Unknown load_key_state.");
+        return false;
     }
-
-    return false;
 }
 
 bool subghz_get_next_name_file(SubGhz* subghz, uint8_t max_len) {

--- a/applications/subghz/subghz_i.c
+++ b/applications/subghz/subghz_i.c
@@ -52,7 +52,7 @@ void subghz_get_frequency_modulation(SubGhz* subghz, string_t frequency, string_
             subghz->txrx->preset == FuriHalSubGhzPreset2FSKDev476Async) {
             string_set(modulation, "FM");
         } else {
-            furi_crash(NULL);
+            furi_crash("SugGhz: Modulation is incorrect.");
         }
     }
 }
@@ -69,7 +69,7 @@ void subghz_begin(SubGhz* subghz, FuriHalSubGhzPreset preset) {
 uint32_t subghz_rx(SubGhz* subghz, uint32_t frequency) {
     furi_assert(subghz);
     if(!furi_hal_subghz_is_frequency_valid(frequency)) {
-        furi_crash(NULL);
+        furi_crash("SugGhz: Incorrect received frequency.");
     }
     furi_assert(
         subghz->txrx->txrx_state != SubGhzTxRxStateRx &&
@@ -90,7 +90,7 @@ uint32_t subghz_rx(SubGhz* subghz, uint32_t frequency) {
 static bool subghz_tx(SubGhz* subghz, uint32_t frequency) {
     furi_assert(subghz);
     if(!furi_hal_subghz_is_frequency_valid(frequency)) {
-        furi_crash(NULL);
+        furi_crash("SugGhz: Transmission frequency is incorrect.");
     }
     furi_assert(subghz->txrx->txrx_state != SubGhzTxRxStateSleep);
     furi_hal_subghz_idle();
@@ -221,8 +221,7 @@ bool subghz_key_load(SubGhz* subghz, const char* file_path) {
     FlipperFormat* fff_data_file = flipper_format_file_alloc(storage);
     Stream* fff_data_stream = flipper_format_get_raw_stream(subghz->txrx->fff_data);
 
-    uint8_t err = 1;
-    bool loaded = false;
+    SubGhzLoadKeyState load_key_state = SubGhzLoadKeyStateParseErr;
     string_t temp_str;
     string_init(temp_str);
     uint32_t temp_data32;
@@ -259,7 +258,7 @@ bool subghz_key_load(SubGhz* subghz, const char* file_path) {
 
         if(!furi_hal_subghz_is_tx_allowed(temp_data32)) {
             FURI_LOG_E(TAG, "This frequency can only be used for RX in your region");
-            err = 2;
+            load_key_state = SubGhzLoadKeyStateOnlyRx;
             break;
         }
         subghz->txrx->frequency = temp_data32;
@@ -300,30 +299,32 @@ bool subghz_key_load(SubGhz* subghz, const char* file_path) {
             break;
         }
 
-        loaded = true;
+        load_key_state = SubGhzLoadKeyStateOK;
     } while(0);
-
-    if(!loaded) {
-        switch(err) {
-        case 1:
-            dialog_message_show_storage_error(subghz->dialogs, "Cannot parse\nfile");
-            break;
-
-        case 2:
-            subghz_dialog_message_show_only_rx(subghz);
-            break;
-
-        default:
-            furi_crash(NULL);
-            break;
-        }
-    }
 
     string_clear(temp_str);
     flipper_format_free(fff_data_file);
     furi_record_close("storage");
 
-    return loaded;
+    switch(load_key_state) {
+    case SubGhzLoadKeyStateParseErr:
+        dialog_message_show_storage_error(subghz->dialogs, "Cannot parse\nfile");
+        break;
+
+    case SubGhzLoadKeyStateOnlyRx:
+        subghz_dialog_message_show_only_rx(subghz);
+        break;
+
+    case SubGhzLoadKeyStateOK:
+        return true;
+        break;
+
+    default:
+        furi_crash("SubGhz: Load key state unknown.");
+        break;
+    }
+
+    return false;
 }
 
 bool subghz_get_next_name_file(SubGhz* subghz, uint8_t max_len) {

--- a/applications/subghz/subghz_i.h
+++ b/applications/subghz/subghz_i.h
@@ -79,6 +79,14 @@ typedef enum {
     SubGhzRxKeyStateRAWSave,
 } SubGhzRxKeyState;
 
+/** SubGhzLoadKeyState state */
+typedef enum {
+    SubGhzLoadKeyStateUnknown,
+    SubGhzLoadKeyStateOK,
+    SubGhzLoadKeyStateParseErr,
+    SubGhzLoadKeyStateOnlyRx,
+} SubGhzLoadKeyState;
+
 struct SubGhzTxRx {
     SubGhzWorker* worker;
 

--- a/firmware/targets/f7/furi_hal/furi_hal_subghz.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_subghz.c
@@ -412,7 +412,7 @@ void furi_hal_subghz_load_preset(FuriHalSubGhzPreset preset) {
         furi_hal_subghz_load_registers(furi_hal_subghz_preset_gfsk_9_99kb_async_regs);
         furi_hal_subghz_load_patable(furi_hal_subghz_preset_gfsk_async_patable);
     } else {
-        furi_crash("SugGhz: Config missing.");
+        furi_crash("SugGhz: Missing config.");
     }
     furi_hal_subghz_preset = preset;
 }
@@ -564,7 +564,7 @@ uint32_t furi_hal_subghz_set_frequency_and_path(uint32_t value) {
     } else if(value >= 778999847 && value <= 928000000) {
         furi_hal_subghz_set_path(FuriHalSubGhzPath868);
     } else {
-        furi_crash("SugGhz: Frequency set incorrect.");
+        furi_crash("SugGhz: Incorrect frequency during set.");
     }
     return value;
 }
@@ -650,7 +650,7 @@ void furi_hal_subghz_set_path(FuriHalSubGhzPath path) {
         furi_hal_gpio_write(&gpio_rf_sw_0, 0);
         cc1101_write_reg(&furi_hal_spi_bus_handle_subghz, CC1101_IOCFG2, CC1101IocfgHW);
     } else {
-        furi_crash("SubGhz: Path set incorrect.");
+        furi_crash("SubGhz: Incorrect path during set.");
     }
     furi_hal_spi_release(&furi_hal_spi_bus_handle_subghz);
 }

--- a/firmware/targets/f7/furi_hal/furi_hal_subghz.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_subghz.c
@@ -412,7 +412,7 @@ void furi_hal_subghz_load_preset(FuriHalSubGhzPreset preset) {
         furi_hal_subghz_load_registers(furi_hal_subghz_preset_gfsk_9_99kb_async_regs);
         furi_hal_subghz_load_patable(furi_hal_subghz_preset_gfsk_async_patable);
     } else {
-        furi_crash(NULL);
+        furi_crash("SugGhz: Config missing.");
     }
     furi_hal_subghz_preset = preset;
 }
@@ -564,7 +564,7 @@ uint32_t furi_hal_subghz_set_frequency_and_path(uint32_t value) {
     } else if(value >= 778999847 && value <= 928000000) {
         furi_hal_subghz_set_path(FuriHalSubGhzPath868);
     } else {
-        furi_crash(NULL);
+        furi_crash("SugGhz: Frequency set incorrect.");
     }
     return value;
 }
@@ -650,7 +650,7 @@ void furi_hal_subghz_set_path(FuriHalSubGhzPath path) {
         furi_hal_gpio_write(&gpio_rf_sw_0, 0);
         cc1101_write_reg(&furi_hal_spi_bus_handle_subghz, CC1101_IOCFG2, CC1101IocfgHW);
     } else {
-        furi_crash(NULL);
+        furi_crash("SubGhz: Path set incorrect.");
     }
     furi_hal_spi_release(&furi_hal_spi_bus_handle_subghz);
 }


### PR DESCRIPTION
# What's new

- [FL-2439] SubGhz: fix magic numbers and description in crash

# Verification 

- Сheck spelling in source code

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-2439]: https://flipperzero.atlassian.net/browse/FL-2439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ