### PR TITLE
[FL-2457] Changed dist names for firmware files

### DIFF
--- a/scripts/dist.py
+++ b/scripts/dist.py
@@ -34,6 +34,9 @@ class Main(App):
         self.parser_copy.set_defaults(func=self.copy)
 
     def get_project_filename(self, project, filetype):
+        #  Temporary fix
+        if project == "firmware" and filetype != "elf":
+            project = "full"
         return f"flipper-z-{self.args.target}-{project}-{self.args.suffix}.{filetype}"
 
     def get_dist_filepath(self, filename):


### PR DESCRIPTION
# What's new

- [FL-2457]  Renamed "firmware" arfifacts to "full"

# Verification 

- Build firmware with make

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-2457]: https://flipperzero.atlassian.net/browse/FL-2457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ