### PR TITLE
[FL-2468] Reboot to update with RPC

### DIFF
--- a/applications/power/power_service/power.h
+++ b/applications/power/power_service/power.h
@@ -9,6 +9,7 @@ typedef struct Power Power;
 typedef enum {
     PowerBootModeNormal,
     PowerBootModeDfu,
+    PowerBootModeUpdateStart,
 } PowerBootMode;
 
 typedef enum {

--- a/applications/power/power_service/power_api.c
+++ b/applications/power/power_service/power_api.c
@@ -17,6 +17,8 @@ void power_reboot(PowerBootMode mode) {
         furi_hal_rtc_set_boot_mode(FuriHalRtcBootModeNormal);
     } else if(mode == PowerBootModeDfu) {
         furi_hal_rtc_set_boot_mode(FuriHalRtcBootModeDfu);
+    } else if(mode == PowerBootModeUpdateStart) {
+        furi_hal_rtc_set_boot_mode(FuriHalRtcBootModePreUpdate);
     }
     furi_hal_power_reset();
 }

--- a/applications/rpc/rpc_system.c
+++ b/applications/rpc/rpc_system.c
@@ -61,6 +61,8 @@ static void rpc_system_system_reboot_process(const PB_Main* request, void* conte
         power_reboot(PowerBootModeNormal);
     } else if(mode == PB_System_RebootRequest_RebootMode_DFU) {
         power_reboot(PowerBootModeDfu);
+    } else if(mode == PB_System_RebootRequest_RebootMode_UPDATE) {
+        power_reboot(PowerBootModeUpdateStart);
     } else {
         rpc_send_and_release_empty(
             session, request->command_id, PB_CommandStatus_ERROR_INVALID_PARAMETERS);
@@ -274,7 +276,7 @@ static void rpc_system_system_update_request_process(const PB_Main* request, voi
     furi_assert(session);
 
     bool update_prepare_result =
-        update_operation_prepare(request->content.system_update_request.update_folder) ==
+        update_operation_prepare(request->content.system_update_request.update_manifest) ==
         UpdatePrepareResultOK;
 
     PB_Main* response = malloc(sizeof(PB_Main));

--- a/applications/updater/updater.c
+++ b/applications/updater/updater.c
@@ -77,10 +77,12 @@ Updater* updater_alloc(const char* arg) {
         updater->view_dispatcher, UpdaterViewWidget, widget_get_view(updater->widget));
 #endif
 
+    FuriHalRtcBootMode boot_mode = furi_hal_rtc_get_boot_mode();
 #ifdef FURI_RAM_EXEC
     if(true) {
 #else
-    if(!arg) {
+    if(!arg && ((boot_mode == FuriHalRtcBootModePreUpdate) ||
+                (boot_mode == FuriHalRtcBootModePostUpdate))) {
 #endif
         updater->update_task = update_task_alloc();
         update_task_set_progress_cb(updater->update_task, status_update_cb, updater->main_view);

--- a/applications/updater/updater.c
+++ b/applications/updater/updater.c
@@ -77,10 +77,10 @@ Updater* updater_alloc(const char* arg) {
         updater->view_dispatcher, UpdaterViewWidget, widget_get_view(updater->widget));
 #endif
 
-    FuriHalRtcBootMode boot_mode = furi_hal_rtc_get_boot_mode();
 #ifdef FURI_RAM_EXEC
     if(true) {
 #else
+    FuriHalRtcBootMode boot_mode = furi_hal_rtc_get_boot_mode();
     if(!arg && ((boot_mode == FuriHalRtcBootModePreUpdate) ||
                 (boot_mode == FuriHalRtcBootModePostUpdate))) {
 #endif

--- a/assets/compiled/system.pb.h
+++ b/assets/compiled/system.pb.h
@@ -12,7 +12,8 @@
 /* Enum definitions */
 typedef enum _PB_System_RebootRequest_RebootMode { 
     PB_System_RebootRequest_RebootMode_OS = 0, 
-    PB_System_RebootRequest_RebootMode_DFU = 1 
+    PB_System_RebootRequest_RebootMode_DFU = 1, 
+    PB_System_RebootRequest_RebootMode_UPDATE = 2 
 } PB_System_RebootRequest_RebootMode;
 
 /* Struct definitions */
@@ -59,7 +60,7 @@ typedef struct _PB_System_ProtobufVersionRequest {
 } PB_System_ProtobufVersionRequest;
 
 typedef struct _PB_System_UpdateRequest { 
-    char *update_folder; 
+    char *update_manifest; 
 } PB_System_UpdateRequest;
 
 typedef struct _PB_System_DateTime { 
@@ -96,8 +97,8 @@ typedef struct _PB_System_SetDateTimeRequest {
 
 /* Helper constants for enums */
 #define _PB_System_RebootRequest_RebootMode_MIN PB_System_RebootRequest_RebootMode_OS
-#define _PB_System_RebootRequest_RebootMode_MAX PB_System_RebootRequest_RebootMode_DFU
-#define _PB_System_RebootRequest_RebootMode_ARRAYSIZE ((PB_System_RebootRequest_RebootMode)(PB_System_RebootRequest_RebootMode_DFU+1))
+#define _PB_System_RebootRequest_RebootMode_MAX PB_System_RebootRequest_RebootMode_UPDATE
+#define _PB_System_RebootRequest_RebootMode_ARRAYSIZE ((PB_System_RebootRequest_RebootMode)(PB_System_RebootRequest_RebootMode_UPDATE+1))
 
 
 #ifdef __cplusplus
@@ -145,7 +146,7 @@ extern "C" {
 #define PB_System_PingResponse_data_tag          1
 #define PB_System_PowerInfoResponse_key_tag      1
 #define PB_System_PowerInfoResponse_value_tag    2
-#define PB_System_UpdateRequest_update_folder_tag 1
+#define PB_System_UpdateRequest_update_manifest_tag 1
 #define PB_System_DateTime_hour_tag              1
 #define PB_System_DateTime_minute_tag            2
 #define PB_System_DateTime_second_tag            3
@@ -236,7 +237,7 @@ X(a, STATIC,   SINGULAR, UINT32,   minor,             2)
 #define PB_System_ProtobufVersionResponse_DEFAULT NULL
 
 #define PB_System_UpdateRequest_FIELDLIST(X, a) \
-X(a, POINTER,  SINGULAR, STRING,   update_folder,     1)
+X(a, POINTER,  SINGULAR, STRING,   update_manifest,   1)
 #define PB_System_UpdateRequest_CALLBACK NULL
 #define PB_System_UpdateRequest_DEFAULT NULL
 


### PR DESCRIPTION
# What's new

- [FL-2468] Added Update reboot option to RPC; fixed argument for update rpc call
- Fixed minor issues with updater app arg parsing

# Verification 

- Upload update & call RPC
- Check that `loader open UpdaterApp /ext/update/aaaa/update.fuf` or `loader open UpdaterApp` shows proper status on screen 

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-2468]: https://flipperzero.atlassian.net/browse/FL-2468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ