### PR TITLE
[FL-2450] Desktop: use right button to open passport

### DIFF
--- a/applications/desktop/animations/animation_manager.c
+++ b/applications/desktop/animations/animation_manager.c
@@ -161,8 +161,9 @@ void animation_manager_new_idle_process(AnimationManager* animation_manager) {
 }
 
 /* reaction to animation_manager->interact_callback() */
-void animation_manager_interact_process(AnimationManager* animation_manager) {
+bool animation_manager_interact_process(AnimationManager* animation_manager) {
     furi_assert(animation_manager);
+    bool consumed = true;
 
     if(animation_manager->levelup_pending) {
         animation_manager->levelup_pending = false;
@@ -181,7 +182,11 @@ void animation_manager_interact_process(AnimationManager* animation_manager) {
         if(!blocked) {
             animation_manager_start_new_idle(animation_manager);
         }
+    } else {
+        consumed = false;
     }
+
+    return consumed;
 }
 
 static void animation_manager_start_new_idle(AnimationManager* animation_manager) {

--- a/applications/desktop/animations/animation_manager.h
+++ b/applications/desktop/animations/animation_manager.h
@@ -130,8 +130,9 @@ void animation_manager_set_interact_callback(
  * set_new_idle_callback's call.
  *
  * @animation_manager   instance
+ * @return              true if event was consumed
  */
-void animation_manager_interact_process(AnimationManager* animation_manager);
+bool animation_manager_interact_process(AnimationManager* animation_manager);
 
 /** Check if animation loaded
  *

--- a/applications/desktop/scenes/desktop_scene_main.c
+++ b/applications/desktop/scenes/desktop_scene_main.c
@@ -116,7 +116,6 @@ bool desktop_scene_main_on_event(void* context, SceneManagerEvent event) {
             }
             consumed = true;
             break;
-
         case DesktopAnimationEventCheckAnimation:
             animation_manager_check_blocking_process(desktop->animation_manager);
             consumed = true;
@@ -126,7 +125,12 @@ bool desktop_scene_main_on_event(void* context, SceneManagerEvent event) {
             consumed = true;
             break;
         case DesktopAnimationEventInteractAnimation:
-            animation_manager_interact_process(desktop->animation_manager);
+            if(!animation_manager_interact_process(desktop->animation_manager)) {
+                LoaderStatus status = loader_start(desktop->loader, "Passport", NULL);
+                if(status != LoaderStatusOk) {
+                    FURI_LOG_E(TAG, "loader_start failed: %d", status);
+                }
+            }
             consumed = true;
             break;
         case DesktopLockedEventUpdate:

--- a/applications/desktop/views/desktop_events.h
+++ b/applications/desktop/views/desktop_events.h
@@ -6,7 +6,7 @@ typedef enum {
     DesktopMainEventOpenFavorite,
     DesktopMainEventOpenMenu,
     DesktopMainEventOpenDebug,
-    DesktopMainEventRightShort,
+    DesktopMainEventOpenPassport, /**< Broken, don't use it */
 
     DesktopLockedEventUnlocked,
     DesktopLockedEventUpdate,

--- a/applications/desktop/views/desktop_view_main.c
+++ b/applications/desktop/views/desktop_view_main.c
@@ -46,7 +46,7 @@ bool desktop_main_input(InputEvent* event, void* context) {
         } else if(event->key == InputKeyLeft) {
             main_view->callback(DesktopMainEventOpenFavorite, main_view->context);
         } else if(event->key == InputKeyRight) {
-            main_view->callback(DesktopMainEventRightShort, main_view->context);
+            main_view->callback(DesktopMainEventOpenPassport, main_view->context);
         }
     } else if(event->type == InputTypeLong) {
         if(event->key == InputKeyDown) {


### PR DESCRIPTION
# What's new

- Desktop: use right button to open passport

# Verification 

- Compile and upload 
- Use right to open passport from main screen
- Check button behaviour in "edge" cases: new level and blocking animations

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
