### PR TITLE
Loader autostart fix

### DIFF
--- a/applications/loader/loader.c
+++ b/applications/loader/loader.c
@@ -92,7 +92,7 @@ const FlipperApplication* loader_find_application_by_name(const char* name) {
         application = loader_find_application_by_name_in_list(
             name, FLIPPER_SYSTEM_APPS, FLIPPER_SYSTEM_APPS_COUNT);
     }
-    if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagDebug) && !application) {
+    if(!application) {
         application = loader_find_application_by_name_in_list(
             name, FLIPPER_DEBUG_APPS, FLIPPER_DEBUG_APPS_COUNT);
     }


### PR DESCRIPTION
# What's new

- Loader always search application in debug apps list

# Verification 

- Switch off Debug. Build firmware with `APP_BATTERY_TEST=1 LOADER_AUTOSTART="Battery Test"  make`. Verify debug app Battery Test is loaded after restart

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
