### PR TITLE
[FL-2343] IR: Rename the left button

### DIFF
--- a/applications/infrared/scene/infrared_app_scene_edit_delete.cpp
+++ b/applications/infrared/scene/infrared_app_scene_edit_delete.cpp
@@ -51,7 +51,7 @@ void InfraredAppSceneEditDelete::on_enter(InfraredApp* app) {
 
     dialog_ex_set_text(dialog_ex, app->get_text_store(0), 64, 31, AlignCenter, AlignCenter);
     dialog_ex_set_icon(dialog_ex, 0, 0, NULL);
-    dialog_ex_set_left_button_text(dialog_ex, "Back");
+    dialog_ex_set_left_button_text(dialog_ex, "Cancel");
     dialog_ex_set_right_button_text(dialog_ex, "Delete");
     dialog_ex_set_result_callback(dialog_ex, dialog_result_callback);
     dialog_ex_set_context(dialog_ex, app);


### PR DESCRIPTION
# What's new

- Renamed the left button to "Cancel" in deleting scene

# Verification 

- Try to delete button and IR remote: Left button should be named "Cancel"

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
