### PR TITLE
[FL-2470],[FL-2385],[FL-2411] NFC fixes

### DIFF
--- a/applications/nfc/nfc.c
+++ b/applications/nfc/nfc.c
@@ -169,11 +169,16 @@ int32_t nfc_app(void* p) {
     char* args = p;
 
     // Check argument and run corresponding scene
-    if((*args != '\0') && nfc_device_load(nfc->dev, p)) {
-        if(nfc->dev->format == NfcDeviceSaveFormatMifareUl) {
-            scene_manager_next_scene(nfc->scene_manager, NfcSceneEmulateMifareUl);
+    if((*args != '\0')) {
+        if(nfc_device_load(nfc->dev, p)) {
+            if(nfc->dev->format == NfcDeviceSaveFormatMifareUl) {
+                scene_manager_next_scene(nfc->scene_manager, NfcSceneEmulateMifareUl);
+            } else {
+                scene_manager_next_scene(nfc->scene_manager, NfcSceneEmulateUid);
+            }
         } else {
-            scene_manager_next_scene(nfc->scene_manager, NfcSceneEmulateUid);
+            // Exit app
+            view_dispatcher_stop(nfc->view_dispatcher);
         }
     } else {
         scene_manager_next_scene(nfc->scene_manager, NfcSceneStart);

--- a/firmware/targets/f7/furi_hal/furi_hal_nfc.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_nfc.c
@@ -96,7 +96,7 @@ bool furi_hal_nfc_detect(FuriHalNfcDevData* nfc_data, uint32_t timeout) {
             FURI_LOG_T(TAG, "Timeout");
             break;
         }
-        osThreadYield();
+        osDelay(1);
     }
     rfalNfcGetDevicesFound(&dev_list, &dev_cnt);
     if(detected) {

--- a/lib/nfc_protocols/mifare_classic.c
+++ b/lib/nfc_protocols/mifare_classic.c
@@ -118,7 +118,7 @@ static bool mf_classic_auth(
         tx_rx->tx_data[1] = block;
         tx_rx->tx_rx_type = FuriHalNfcTxRxTypeRxNoCrc;
         tx_rx->tx_bits = 2 * 8;
-        if(!furi_hal_nfc_tx_rx(tx_rx, 4)) break;
+        if(!furi_hal_nfc_tx_rx(tx_rx, 5)) break;
 
         uint32_t nt = (uint32_t)nfc_util_bytes2num(tx_rx->rx_data, 4);
         crypto1_init(crypto, key);
@@ -140,7 +140,7 @@ static bool mf_classic_auth(
         }
         tx_rx->tx_rx_type = FuriHalNfcTxRxTypeRaw;
         tx_rx->tx_bits = 8 * 8;
-        if(!furi_hal_nfc_tx_rx(tx_rx, 4)) break;
+        if(!furi_hal_nfc_tx_rx(tx_rx, 5)) break;
         if(tx_rx->rx_bits == 32) {
             crypto1_word(crypto, 0, 0);
             auth_success = true;
@@ -220,7 +220,7 @@ bool mf_classic_read_block(
     tx_rx->tx_bits = 4 * 9;
     tx_rx->tx_rx_type = FuriHalNfcTxRxTypeRaw;
 
-    if(furi_hal_nfc_tx_rx(tx_rx, 4)) {
+    if(furi_hal_nfc_tx_rx(tx_rx, 5)) {
         if(tx_rx->rx_bits == 8 * 18) {
             for(uint8_t i = 0; i < 18; i++) {
                 block->value[i] = crypto1_byte(crypto, 0, 0) ^ tx_rx->rx_data[i];


### PR DESCRIPTION
# What's new

- Increase timeout for Mifare Classic authentication process
- Exit NFC app after launch incorrect card file from archive
- Allow to switch context during nfc detection

# Verification 

- Flipper reads Mifare Classic cards with all FFFFFFFF keys quickly
- NFC exits after launch incorrect key from archive
- No freeze after launching nfc detect CLI command

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
