### PR TITLE
SubGhz: fix waiting for UPLOAD to be sent, for RAW file worker

### DIFF
--- a/lib/subghz/subghz_file_encoder_worker.c
+++ b/lib/subghz/subghz_file_encoder_worker.c
@@ -106,6 +106,7 @@ LevelDuration subghz_file_encoder_worker_get_level_duration(void* context) {
             FURI_LOG_I(TAG, "Stop transmission");
             instance->worker_stoping = true;
         }
+        FURI_LOG_I(TAG, "%d, %d", level_duration.level, level_duration.duration);
         return level_duration;
     } else {
         FURI_LOG_E(TAG, "Slow flash read");
@@ -167,7 +168,10 @@ static int32_t subghz_file_encoder_worker_thread(void* context) {
     }
     //waiting for the end of the transfer
     FURI_LOG_I(TAG, "End read file");
-
+    while(!furi_hal_subghz_is_async_tx_complete()) {
+        osDelay(5);
+    }
+    FURI_LOG_I(TAG, "End transmission");
     while(instance->worker_running) {
         if(instance->worker_stoping) {
             if(instance->callback_end) instance->callback_end(instance->context_end);

--- a/lib/subghz/subghz_file_encoder_worker.c
+++ b/lib/subghz/subghz_file_encoder_worker.c
@@ -106,7 +106,6 @@ LevelDuration subghz_file_encoder_worker_get_level_duration(void* context) {
             FURI_LOG_I(TAG, "Stop transmission");
             instance->worker_stoping = true;
         }
-        FURI_LOG_I(TAG, "%d, %d", level_duration.level, level_duration.duration);
         return level_duration;
     } else {
         FURI_LOG_E(TAG, "Slow flash read");


### PR DESCRIPTION
# What's new

- SubGhz: fix waiting for UPLOAD to be sent, for RAW file worker

# Verification 

- compile and download
- create file for RAW with short UPLOAD example:
Filetype: Flipper SubGhz RAW File
Version: 1
Frequency: 433800000
Preset: FuriHalSubGhzPresetOok650Async
Protocol: RAW
RAW_Data: 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -620 620 -1920 1860 -620 1860 -620 620 -1860 620 -1860 620 -1860 620 -1860 1860 -620 1860 -620 1860 -620 620 -1860 620 -1860 1860 -620 1860 -620 1860 -620 1860 -620 620 -9920 1860 -620 1860 -620 620 -1860 620 -1860 620 -1860 620 -1860 1860 -620 1860 -620 1860 -620 620 -1860 620 -1860 1860 -620 1860 -620 1860 -620 1860 -620 620 -9920

- reproduce the trace results either on HACKRF or logic analyzer on pin GO0 cc1101

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
