### PR TITLE
Add NotificationSequence to be able to set for same colors as blink

### DIFF
--- a/applications/notification/notification_messages.c
+++ b/applications/notification/notification_messages.c
@@ -276,6 +276,35 @@ const NotificationSequence sequence_set_blue_255 = {
     NULL,
 };
 
+const NotificationSequence sequence_set_yellow_255 = {
+    &message_red_255,
+    &message_green_255,
+    &message_do_not_reset,
+    NULL,
+};
+
+const NotificationSequence sequence_set_cyan_255 = {
+    &message_blue_255,
+    &message_green_255,
+    &message_do_not_reset,
+    NULL,
+};
+
+const NotificationSequence sequence_set_magenta_255 = {
+    &message_blue_255,
+    &message_red_255,
+    &message_do_not_reset,
+    NULL,
+};
+
+const NotificationSequence sequence_set_white_255 = {
+    &message_red_255,
+    &message_green_255,
+    &message_blue_255,
+    &message_do_not_reset,
+    NULL,
+};
+
 // Blink
 const NotificationSequence sequence_blink_blue_10 = {
     &message_blue_255,


### PR DESCRIPTION
# What's new

- This PR adds 4 new NotificationSequence entries to notification_messages.c. While coding I noticed these colors had "blink" NotificationSequence definitions, but there was no way to call them to be "set." The added colors are yellow, cyan, magenta and white.

# Verification 

- Send the new NotificationSequence definition to the notification app. The LED light should turn that color. The code `notification_message(notifications, &sequence_reset_rgb);` must be used after the LED has been turned on to turn it off.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
