### PR TITLE
[FL-2496] SubGhz: fix freezing of the interface when the transmission of the RAW signal is forcibly canceled

### DIFF
--- a/lib/subghz/subghz_file_encoder_worker.c
+++ b/lib/subghz/subghz_file_encoder_worker.c
@@ -167,7 +167,7 @@ static int32_t subghz_file_encoder_worker_thread(void* context) {
     }
     //waiting for the end of the transfer
     FURI_LOG_I(TAG, "End read file");
-    while(!furi_hal_subghz_is_async_tx_complete()) {
+    while(!furi_hal_subghz_is_async_tx_complete() && instance->worker_running) {
         osDelay(5);
     }
     FURI_LOG_I(TAG, "End transmission");


### PR DESCRIPTION
…W signal is forcibly canceled

# What's new

- SubGhz: fix freezing of the interface when the transmission of the RAW signal is forcibly canceled

# Verification 

- try to forcibly cancel RAW signal transmissions

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
