### PR TITLE
[FL-2493] Infrared: fix crash on invalid name. Input: cancel info in dump command.

### DIFF
--- a/applications/infrared/infrared_app.cpp
+++ b/applications/infrared/infrared_app.cpp
@@ -14,14 +14,17 @@ int32_t InfraredApp::run(void* args) {
     if(args) {
         std::string path = static_cast<const char*>(args);
         std::string remote_name(path, path.find_last_of('/') + 1, path.size());
-        remote_name.erase(remote_name.find_last_of('.'));
-        path.erase(path.find_last_of('/'));
-        bool result = remote_manager.load(path, remote_name);
-        if(result) {
-            current_scene = InfraredApp::Scene::Remote;
-        } else {
-            printf("Failed to load remote \'%s\'\r\n", remote_name.c_str());
-            return -1;
+        auto last_dot = remote_name.find_last_of('.');
+        if(last_dot != std::string::npos) {
+            remote_name.erase(last_dot);
+            path.erase(path.find_last_of('/'));
+            bool result = remote_manager.load(path, remote_name);
+            if(result) {
+                current_scene = InfraredApp::Scene::Remote;
+            } else {
+                printf("Failed to load remote \'%s\'\r\n", remote_name.c_str());
+                return -1;
+            }
         }
     }
 

--- a/applications/input/input_cli.c
+++ b/applications/input/input_cli.c
@@ -24,18 +24,14 @@ static void input_cli_dump(Cli* cli, string_t args, Input* input) {
     FuriPubSubSubscription* input_subscription =
         furi_pubsub_subscribe(input->event_pubsub, input_cli_dump_events_callback, input_queue);
 
-    bool stop = false;
     InputEvent input_event;
-    while(!stop) {
+    printf("Press CTRL+C to stop\r\n");
+    while(!cli_cmd_interrupt_received(cli)) {
         if(osMessageQueueGet(input_queue, &input_event, NULL, 100) == osOK) {
             printf(
                 "key: %s type: %s\r\n",
                 input_get_key_name(input_event.key),
                 input_get_type_name(input_event.type));
-        }
-
-        if(cli_cmd_interrupt_received(cli)) {
-            stop = true;
         }
     }
 

--- a/firmware/targets/f7/Src/main.c
+++ b/firmware/targets/f7/Src/main.c
@@ -65,6 +65,10 @@ void Error_Handler(void) {
     furi_crash("ErrorHandler");
 }
 
+void abort() {
+    furi_crash("AbortHandler");
+}
+
 #ifdef USE_FULL_ASSERT
 /**
     * @brief  Reports the name of the source file and the source line number


### PR DESCRIPTION
# What's new

- Infrared: fix crash on invalid name.
- Input: cancel info in dump command.
- FuriHal: custom abort handler (reduce firmware size)

# Verification 

- Compile and upload
- `loader open Infrared Monitor` command is not causing system crash anymore
- Use `input dump` cli command, now it tells you how to exit

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
