### PR TITLE
SubGhz: fix Princeton duration

### DIFF
--- a/lib/subghz/protocols/princeton.c
+++ b/lib/subghz/protocols/princeton.c
@@ -17,7 +17,7 @@
 static const SubGhzBlockConst subghz_protocol_princeton_const = {
     .te_short = 400,
     .te_long = 1200,
-    .te_delta = 250,
+    .te_delta = 300,
     .min_count_bit_for_found = 24,
 };
 


### PR DESCRIPTION
# What's new

- SubGhz: fix Princeton duration

# Verification 

- check Princeton reception with durations less than 180 us

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
