### PR TITLE
ci: Change GH-Actions comment to DFU download link

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,7 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            [Click here](https://update.flipperzero.one/?url=https://update.flipperzero.one/builds/firmware/${{steps.names.outputs.artifacts-path}}/flipper-z-${{steps.names.outputs.default-target}}-full-${{steps.names.outputs.suffix}}.dfu&channel=${{steps.names.outputs.artifacts-path}}&version=${{steps.names.outputs.short-hash}}&target=${{steps.names.outputs.default-target}}) to flash the `${{steps.names.outputs.short-hash}}` version of this branch via WebUSB.
+            [Click here](https://update.flipperzero.one/builds/firmware/${{steps.names.outputs.artifacts-path}}/flipper-z-${{steps.names.outputs.default-target}}-full-${{steps.names.outputs.suffix}}.dfu) for the DFU file to flash the `${{steps.names.outputs.short-hash}}` version of this branch with the [`Install from file` option in qFlipper](https://docs.flipperzero.one/basics/firmware-update).
           edit-mode: replace
 
   compact:


### PR DESCRIPTION
# What's new

- Change the GitHub Actions bot comment to directly link to the DFU download
- Add a pointer to the qFlipper firmware update documentation
- Remove WebUSB flashing link since [the WebUSB updater is no longer supported](https://forum.flipperzero.one/t/no-database-found-after-firmware-update/1761/6 )

# Verification 

- Open a pull request and observe the GitHub Actions bot comment
- Ensure the DFU download link works
- Push to the pull request branch, and ensure the comment is correctly edited

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
   - **Not applicable: This change only impacts the GitHub Actions comment.**
