### PR TITLE
BadUSB Speedup

### DIFF
--- a/firmware/targets/f7/furi_hal/furi_hal_usb_hid.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_usb_hid.c
@@ -9,6 +9,7 @@
 #include "hid_usage_desktop.h"
 #include "hid_usage_button.h"
 #include "hid_usage_keyboard.h"
+#include "hid_usage_consumer.h"
 #include "hid_usage_led.h"
 
 #define HID_EP_IN 0x81
@@ -18,8 +19,7 @@
 #define HID_KB_MAX_KEYS 6
 #define HID_CONSUMER_MAX_KEYS 2
 
-#define HID_PAGE_CONSUMER 0x0C
-#define HID_CONSUMER_CONTROL 0x01
+#define HID_INTERVAL 2
 
 #define HID_VID_DEFAULT 0x046D
 #define HID_PID_DEFAULT 0xC529
@@ -190,7 +190,7 @@ static const struct HidConfigDescriptor hid_cfg_desc = {
                     .bEndpointAddress = HID_EP_IN,
                     .bmAttributes = USB_EPTYPE_INTERRUPT,
                     .wMaxPacketSize = HID_EP_SZ,
-                    .bInterval = 10,
+                    .bInterval = HID_INTERVAL,
                 },
             .hid_ep_out =
                 {
@@ -199,7 +199,7 @@ static const struct HidConfigDescriptor hid_cfg_desc = {
                     .bEndpointAddress = HID_EP_OUT,
                     .bmAttributes = USB_EPTYPE_INTERRUPT,
                     .wMaxPacketSize = HID_EP_SZ,
-                    .bInterval = 10,
+                    .bInterval = HID_INTERVAL,
                 },
         },
 };


### PR DESCRIPTION
# What's new

- USB HID polling interval set to 2ms instead of 10

# Verification 

- Check BadUSB demo scripts

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
