### PR TITLE
[FL-2502] Properly closing directory on free

### DIFF
--- a/applications/storage/filesystem_api_internal.h
+++ b/applications/storage/filesystem_api_internal.h
@@ -6,9 +6,17 @@
 extern "C" {
 #endif
 
+/** File type */
+typedef enum {
+    FileTypeClosed, /**< Closed file */
+    FileTypeOpenDir, /**< Open dir */
+    FileTypeOpenFile, /**< Open file */
+} FileType;
+
 /** Structure that hold file index and returned api errors */
 struct File {
     uint32_t file_id; /**< File ID for internal references */
+    FileType type;
     FS_Error error_id; /**< Standart API error from FS_Error enum */
     int32_t internal_error_id; /**< Internal API error value */
     void* storage;

--- a/applications/storage/storage_external_api.c
+++ b/applications/storage/storage_external_api.c
@@ -112,7 +112,7 @@ bool storage_file_open(
     furi_pubsub_unsubscribe(storage_get_pubsub(file->storage), subscription);
     osEventFlagsDelete(event);
 
-    FURI_LOG_D(
+    FURI_LOG_T(
         TAG, "File %p - %p open (%s)", (uint32_t)file - SRAM_BASE, file->file_id - SRAM_BASE, path);
 
     return result;
@@ -126,7 +126,7 @@ bool storage_file_close(File* file) {
     S_API_MESSAGE(StorageCommandFileClose);
     S_API_EPILOGUE;
 
-    FURI_LOG_D(TAG, "File %p - %p closed", (uint32_t)file - SRAM_BASE, file->file_id - SRAM_BASE);
+    FURI_LOG_T(TAG, "File %p - %p closed", (uint32_t)file - SRAM_BASE, file->file_id - SRAM_BASE);
     file->type = FileTypeClosed;
 
     return S_RETURN_BOOL;
@@ -263,7 +263,7 @@ bool storage_dir_open(File* file, const char* path) {
     furi_pubsub_unsubscribe(storage_get_pubsub(file->storage), subscription);
     osEventFlagsDelete(event);
 
-    FURI_LOG_D(
+    FURI_LOG_T(
         TAG, "Dir %p - %p open (%s)", (uint32_t)file - SRAM_BASE, file->file_id - SRAM_BASE, path);
 
     return result;
@@ -276,7 +276,7 @@ bool storage_dir_close(File* file) {
     S_API_MESSAGE(StorageCommandDirClose);
     S_API_EPILOGUE;
 
-    FURI_LOG_D(TAG, "Dir %p - %p closed", (uint32_t)file - SRAM_BASE, file->file_id - SRAM_BASE);
+    FURI_LOG_T(TAG, "Dir %p - %p closed", (uint32_t)file - SRAM_BASE, file->file_id - SRAM_BASE);
 
     file->type = FileTypeClosed;
 
@@ -460,7 +460,7 @@ File* storage_file_alloc(Storage* storage) {
     file->type = FileTypeClosed;
     file->storage = storage;
 
-    FURI_LOG_D(TAG, "File/Dir %p alloc", (uint32_t)file - SRAM_BASE);
+    FURI_LOG_T(TAG, "File/Dir %p alloc", (uint32_t)file - SRAM_BASE);
 
     return file;
 }
@@ -482,7 +482,7 @@ void storage_file_free(File* file) {
         }
     }
 
-    FURI_LOG_D(TAG, "File/Dir %p free", (uint32_t)file - SRAM_BASE);
+    FURI_LOG_T(TAG, "File/Dir %p free", (uint32_t)file - SRAM_BASE);
     free(file);
 }
 

--- a/applications/storage/storage_external_api.c
+++ b/applications/storage/storage_external_api.c
@@ -47,10 +47,6 @@
 #define S_RETURN_ERROR (return_data.error_value);
 #define S_RETURN_CSTRING (return_data.cstring_value);
 
-#define FILE_OPENED_FILE 1
-#define FILE_OPENED_DIR 2
-#define FILE_CLOSED 0
-
 typedef enum {
     StorageEventFlagFileClose = (1 << 0),
 } StorageEventFlag;
@@ -72,7 +68,7 @@ static bool storage_file_open_internal(
             .open_mode = open_mode,
         }};
 
-    file->file_id = FILE_OPENED_FILE;
+    file->type = FileTypeOpenFile;
 
     S_API_MESSAGE(StorageCommandFileOpen);
     S_API_EPILOGUE;
@@ -124,7 +120,7 @@ bool storage_file_close(File* file) {
     S_API_MESSAGE(StorageCommandFileClose);
     S_API_EPILOGUE;
 
-    file->file_id = FILE_CLOSED;
+    file->type = FileTypeClosed;
 
     return S_RETURN_BOOL;
 }
@@ -234,7 +230,7 @@ static bool storage_dir_open_internal(File* file, const char* path) {
             .path = path,
         }};
 
-    file->file_id = FILE_OPENED_DIR;
+    file->type = FileTypeOpenDir;
 
     S_API_MESSAGE(StorageCommandDirOpen);
     S_API_EPILOGUE;
@@ -269,7 +265,7 @@ bool storage_dir_close(File* file) {
     S_API_MESSAGE(StorageCommandDirClose);
     S_API_EPILOGUE;
 
-    file->file_id = FILE_CLOSED;
+    file->type = FileTypeClosed;
 
     return S_RETURN_BOOL;
 }
@@ -448,18 +444,18 @@ FS_Error storage_sd_status(Storage* storage) {
 
 File* storage_file_alloc(Storage* storage) {
     File* file = malloc(sizeof(File));
-    file->file_id = FILE_CLOSED;
+    file->type = FileTypeClosed;
     file->storage = storage;
 
     return file;
 }
 
 bool storage_file_is_open(File* file) {
-    return (file->file_id != FILE_CLOSED);
+    return (file->type != FileTypeClosed);
 }
 
 bool storage_file_is_dir(File* file) {
-    return (file->file_id == FILE_OPENED_DIR);
+    return (file->type == FileTypeOpenDir);
 }
 
 void storage_file_free(File* file) {

--- a/applications/storage/storage_external_api.c
+++ b/applications/storage/storage_external_api.c
@@ -112,7 +112,8 @@ bool storage_file_open(
     furi_pubsub_unsubscribe(storage_get_pubsub(file->storage), subscription);
     osEventFlagsDelete(event);
 
-    FURI_LOG_D(TAG, "File %p[%u] open", file, file->file_id);
+    FURI_LOG_D(
+        TAG, "File %p - %p open (%s)", (uint32_t)file - SRAM_BASE, file->file_id - SRAM_BASE, path);
 
     return result;
 }
@@ -125,7 +126,7 @@ bool storage_file_close(File* file) {
     S_API_MESSAGE(StorageCommandFileClose);
     S_API_EPILOGUE;
 
-    FURI_LOG_D(TAG, "File %p[%u] closed", file, file->file_id);
+    FURI_LOG_D(TAG, "File %p - %p closed", (uint32_t)file - SRAM_BASE, file->file_id - SRAM_BASE);
     file->type = FileTypeClosed;
 
     return S_RETURN_BOOL;
@@ -262,7 +263,8 @@ bool storage_dir_open(File* file, const char* path) {
     furi_pubsub_unsubscribe(storage_get_pubsub(file->storage), subscription);
     osEventFlagsDelete(event);
 
-    FURI_LOG_D(TAG, "Dir %p[%u] open", file, file->file_id);
+    FURI_LOG_D(
+        TAG, "Dir %p - %p open (%s)", (uint32_t)file - SRAM_BASE, file->file_id - SRAM_BASE, path);
 
     return result;
 }
@@ -274,7 +276,7 @@ bool storage_dir_close(File* file) {
     S_API_MESSAGE(StorageCommandDirClose);
     S_API_EPILOGUE;
 
-    FURI_LOG_D(TAG, "Dir %p[%u] closed", file, file->file_id);
+    FURI_LOG_D(TAG, "Dir %p - %p closed", (uint32_t)file - SRAM_BASE, file->file_id - SRAM_BASE);
 
     file->type = FileTypeClosed;
 
@@ -458,7 +460,7 @@ File* storage_file_alloc(Storage* storage) {
     file->type = FileTypeClosed;
     file->storage = storage;
 
-    FURI_LOG_D(TAG, "File/Dir %p alloc", file);
+    FURI_LOG_D(TAG, "File/Dir %p alloc", (uint32_t)file - SRAM_BASE);
 
     return file;
 }
@@ -480,7 +482,7 @@ void storage_file_free(File* file) {
         }
     }
 
-    FURI_LOG_D(TAG, "File/Dir %p free", file);
+    FURI_LOG_D(TAG, "File/Dir %p free", (uint32_t)file - SRAM_BASE);
     free(file);
 }
 

--- a/applications/storage/storage_external_api.c
+++ b/applications/storage/storage_external_api.c
@@ -7,6 +7,8 @@
 
 #define MAX_NAME_LENGTH 256
 
+#define TAG "StorageAPI"
+
 #define S_API_PROLOGUE                                      \
     osSemaphoreId_t semaphore = osSemaphoreNew(1, 0, NULL); \
     furi_check(semaphore != NULL);
@@ -109,6 +111,9 @@ bool storage_file_open(
 
     furi_pubsub_unsubscribe(storage_get_pubsub(file->storage), subscription);
     osEventFlagsDelete(event);
+
+    FURI_LOG_D(TAG, "File %p[%u] open", file, file->file_id);
+
     return result;
 }
 
@@ -120,6 +125,7 @@ bool storage_file_close(File* file) {
     S_API_MESSAGE(StorageCommandFileClose);
     S_API_EPILOGUE;
 
+    FURI_LOG_D(TAG, "File %p[%u] closed", file, file->file_id);
     file->type = FileTypeClosed;
 
     return S_RETURN_BOOL;
@@ -255,6 +261,9 @@ bool storage_dir_open(File* file, const char* path) {
 
     furi_pubsub_unsubscribe(storage_get_pubsub(file->storage), subscription);
     osEventFlagsDelete(event);
+
+    FURI_LOG_D(TAG, "Dir %p[%u] open", file, file->file_id);
+
     return result;
 }
 
@@ -264,6 +273,8 @@ bool storage_dir_close(File* file) {
     S_API_DATA_FILE;
     S_API_MESSAGE(StorageCommandDirClose);
     S_API_EPILOGUE;
+
+    FURI_LOG_D(TAG, "Dir %p[%u] closed", file, file->file_id);
 
     file->type = FileTypeClosed;
 
@@ -447,6 +458,8 @@ File* storage_file_alloc(Storage* storage) {
     file->type = FileTypeClosed;
     file->storage = storage;
 
+    FURI_LOG_D(TAG, "File/Dir %p alloc", file);
+
     return file;
 }
 
@@ -467,6 +480,7 @@ void storage_file_free(File* file) {
         }
     }
 
+    FURI_LOG_D(TAG, "File/Dir %p free", file);
     free(file);
 }
 

--- a/lib/toolbox/tar/tar_archive.c
+++ b/lib/toolbox/tar/tar_archive.c
@@ -94,6 +94,7 @@ void tar_archive_free(TarArchive* archive) {
     if(mtar_is_open(&archive->tar)) {
         mtar_close(&archive->tar);
     }
+    free(archive);
 }
 
 void tar_archive_set_file_callback(TarArchive* archive, tar_unpack_file_cb callback, void* context) {

--- a/lib/toolbox/tar/tar_archive.c
+++ b/lib/toolbox/tar/tar_archive.c
@@ -38,6 +38,7 @@ static int mtar_storage_file_seek(void* stream, unsigned offset) {
 static int mtar_storage_file_close(void* stream) {
     if(stream) {
         storage_file_close(stream);
+        storage_file_free(stream);
     }
     return MTAR_ESUCCESS;
 }


### PR DESCRIPTION
# What's new

- Storage: debug logs
- Fixed misc memleaks
- storage_file_free on opened dir no longer causes fault

# Verification 

- Cli: update backup /ext/testb.tar no longer causes random faults

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
