### PR TITLE
[FL-2507]  Fix NTAG21x emulation fix

### DIFF
--- a/lib/nfc_protocols/emv.c
+++ b/lib/nfc_protocols/emv.c
@@ -58,6 +58,16 @@ static const uint8_t pdol_ans[] = {0x77, 0x40, 0x82, 0x02, 0x20, 0x00, 0x57, 0x1
                                    0xC9, 0x85, 0x9F, 0x27, 0x01, 0x00, 0x9F, 0x36, 0x02, 0x06,
                                    0x0C, 0x9F, 0x6C, 0x02, 0x10, 0x00, 0x90, 0x00};
 
+static void emv_trace(FuriHalNfcTxRxContext* tx_rx, const char* message) {
+    if(furi_log_get_level() == FuriLogLevelTrace) {
+        FURI_LOG_T(TAG, "%s", message);
+        for(size_t i = 0; i < tx_rx->rx_bits / 8; i++) {
+            printf("%02X ", tx_rx->rx_data[i]);
+        }
+        printf("\r\n");
+    }
+}
+
 static uint16_t emv_parse_TLV(uint8_t* dest, uint8_t* src, uint16_t* idx) {
     uint8_t len = src[*idx + 1];
     memcpy(dest, &src[*idx + 2], len);
@@ -113,6 +123,7 @@ bool emv_select_ppse(FuriHalNfcTxRxContext* tx_rx, EmvApplication* app) {
 
     FURI_LOG_D(TAG, "Send select PPSE");
     if(furi_hal_nfc_tx_rx(tx_rx, 300)) {
+        emv_trace(tx_rx, "Select PPSE answer:");
         if(emv_decode_ppse_response(tx_rx->rx_data, tx_rx->rx_bits / 8, app)) {
             app_aid_found = true;
         } else {
@@ -169,6 +180,7 @@ bool emv_select_app(FuriHalNfcTxRxContext* tx_rx, EmvApplication* app) {
 
     FURI_LOG_D(TAG, "Start application");
     if(furi_hal_nfc_tx_rx(tx_rx, 300)) {
+        emv_trace(tx_rx, "Start application answer:");
         if(emv_decode_select_app_response(tx_rx->rx_data, tx_rx->rx_bits / 8, app)) {
             select_app_success = true;
         } else {
@@ -251,6 +263,7 @@ static bool emv_get_processing_options(FuriHalNfcTxRxContext* tx_rx, EmvApplicat
 
     FURI_LOG_D(TAG, "Get proccessing options");
     if(furi_hal_nfc_tx_rx(tx_rx, 300)) {
+        emv_trace(tx_rx, "Get processing options answer:");
         if(emv_decode_get_proc_opt(tx_rx->rx_data, tx_rx->rx_bits / 8, app)) {
             card_num_read = true;
         }
@@ -306,6 +319,7 @@ static bool emv_read_sfi_record(
     tx_rx->tx_rx_type = FuriHalNfcTxRxTypeDefault;
 
     if(furi_hal_nfc_tx_rx(tx_rx, 300)) {
+        emv_trace(tx_rx, "SFI record:");
         if(emv_decode_read_sfi_record(tx_rx->rx_data, tx_rx->rx_bits / 8, app)) {
             card_num_read = true;
         }

--- a/lib/nfc_protocols/mifare_ultralight.c
+++ b/lib/nfc_protocols/mifare_ultralight.c
@@ -14,6 +14,8 @@ static void mf_ul_set_default_version(MfUltralightReader* reader, MfUltralightDa
     data->type = MfUltralightTypeUnknown;
     reader->pages_to_read = 16;
     reader->support_fast_read = false;
+    reader->support_tearing_flags = false;
+    reader->support_counters = false;
 }
 
 bool mf_ultralight_read_version(
@@ -40,22 +42,32 @@ bool mf_ultralight_read_version(
             data->type = MfUltralightTypeUL11;
             reader->pages_to_read = 20;
             reader->support_fast_read = true;
+            reader->support_tearing_flags = true;
+            reader->support_counters = true;
         } else if(version->storage_size == 0x0E) {
             data->type = MfUltralightTypeUL21;
             reader->pages_to_read = 41;
             reader->support_fast_read = true;
+            reader->support_tearing_flags = true;
+            reader->support_counters = true;
         } else if(version->storage_size == 0x0F) {
             data->type = MfUltralightTypeNTAG213;
             reader->pages_to_read = 45;
-            reader->support_fast_read = false;
+            reader->support_fast_read = true;
+            reader->support_tearing_flags = false;
+            reader->support_counters = false;
         } else if(version->storage_size == 0x11) {
             data->type = MfUltralightTypeNTAG215;
             reader->pages_to_read = 135;
-            reader->support_fast_read = false;
+            reader->support_fast_read = true;
+            reader->support_tearing_flags = false;
+            reader->support_counters = false;
         } else if(version->storage_size == 0x13) {
             data->type = MfUltralightTypeNTAG216;
             reader->pages_to_read = 231;
-            reader->support_fast_read = false;
+            reader->support_fast_read = true;
+            reader->support_tearing_flags = false;
+            reader->support_counters = false;
         } else {
             mf_ul_set_default_version(reader, data);
             break;
@@ -190,9 +202,10 @@ bool mf_ul_read_card(
         // Read Signature
         mf_ultralight_read_signature(tx_rx, data);
     }
-    // Read data blocks
-    if(reader->support_fast_read) {
+    if(reader->support_counters) {
         mf_ultralight_read_counters(tx_rx, data);
+    }
+    if(reader->support_tearing_flags) {
         mf_ultralight_read_tearing_flags(tx_rx, data);
     }
     card_read = mf_ultralight_read_pages(tx_rx, reader, data);
@@ -230,11 +243,11 @@ void mf_ul_prepare_emulation(MfUltralightEmulator* emulator, MfUltralightData* d
     } else if(data->type == MfUltralightTypeUL21) {
         emulator->support_fast_read = true;
     } else if(data->type == MfUltralightTypeNTAG213) {
-        emulator->support_fast_read = false;
+        emulator->support_fast_read = true;
     } else if(data->type == MfUltralightTypeNTAG215) {
-        emulator->support_fast_read = false;
+        emulator->support_fast_read = true;
     } else if(data->type == MfUltralightTypeNTAG216) {
-        emulator->support_fast_read = false;
+        emulator->support_fast_read = true;
     }
 
     if(data->type >= MfUltralightTypeNTAG213) {

--- a/lib/nfc_protocols/mifare_ultralight.h
+++ b/lib/nfc_protocols/mifare_ultralight.h
@@ -74,6 +74,8 @@ typedef struct {
     uint8_t pages_to_read;
     uint8_t pages_read;
     bool support_fast_read;
+    bool support_tearing_flags;
+    bool support_counters;
 } MfUltralightReader;
 
 typedef struct {


### PR DESCRIPTION
# What's new

- Add NTAG21x fast read support
- Add trace logs for EMV reading

# Verification 

- Test NTAG emulation

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
