### PR TITLE
[FL-2510] Fixed BT startup while backing up LFS

### DIFF
--- a/lib/toolbox/tar/tar_archive.c
+++ b/lib/toolbox/tar/tar_archive.c
@@ -212,6 +212,7 @@ static int archive_extract_foreach_cb(mtar_t* tar, const mtar_header_t* header, 
                 break;
             }
             FURI_LOG_W(TAG, "Failed to open '%s', reties: %d", string_get_cstr(fname), n_tries);
+            storage_file_close(out_file);
             osDelay(FILE_OPEN_RETRY_DELAY);
         }
 
@@ -263,6 +264,7 @@ bool tar_archive_add_file(
                 break;
             }
             FURI_LOG_W(TAG, "Failed to open '%s', reties: %d", fs_file_path, n_tries);
+            storage_file_close(src_file);
             osDelay(FILE_OPEN_RETRY_DELAY);
         }
 

--- a/lib/toolbox/tar/tar_archive.c
+++ b/lib/toolbox/tar/tar_archive.c
@@ -206,12 +206,13 @@ static int archive_extract_foreach_cb(mtar_t* tar, const mtar_header_t* header, 
     bool failed = false;
     uint8_t n_tries = FILE_OPEN_NTRIES;
     do {
-        while(
-            (n_tries-- > 0) &&
-            !storage_file_open(out_file, string_get_cstr(fname), FSAM_WRITE, FSOM_CREATE_ALWAYS)) {
+        while(n_tries-- > 0) {
+            if(storage_file_open(
+                   out_file, string_get_cstr(fname), FSAM_WRITE, FSOM_CREATE_ALWAYS)) {
+                break;
+            }
             FURI_LOG_W(TAG, "Failed to open '%s', reties: %d", string_get_cstr(fname), n_tries);
             osDelay(FILE_OPEN_RETRY_DELAY);
-            continue;
         }
 
         if(!storage_file_is_open(out_file)) {
@@ -257,11 +258,12 @@ bool tar_archive_add_file(
     File* src_file = storage_file_alloc(archive->storage);
     uint8_t n_tries = FILE_OPEN_NTRIES;
     do {
-        while((n_tries-- > 0) &&
-              !storage_file_open(src_file, fs_file_path, FSAM_READ, FSOM_OPEN_EXISTING)) {
+        while(n_tries-- > 0) {
+            if(storage_file_open(src_file, fs_file_path, FSAM_READ, FSOM_OPEN_EXISTING)) {
+                break;
+            }
             FURI_LOG_W(TAG, "Failed to open '%s', reties: %d", fs_file_path, n_tries);
             osDelay(FILE_OPEN_RETRY_DELAY);
-            continue;
         }
 
         if(!storage_file_is_open(src_file) ||


### PR DESCRIPTION
# What's new

- [FL-2510] Fixed race with BT thread on LFS ops
- Cleaner file open retry on backup/restore

# Verification 

- Build update package
- Enable BT
- Install it; reinstall 
- Verify that BT doesn't start on pre-post update 

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-2510]: https://flipperzero.atlassian.net/browse/FL-2510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ