### PR TITLE
[FL-2512] Archive favourites fixes

### DIFF
--- a/applications/archive/helpers/archive_browser.c
+++ b/applications/archive/helpers/archive_browser.c
@@ -397,8 +397,6 @@ void archive_enter_dir(ArchiveBrowserView* browser, string_t name) {
         return;
     }
 
-    archive_dir_count_items(browser, string_get_cstr(name));
-
     if(string_cmp(browser->path, name) != 0) {
         with_view_model(
             browser->view, (ArchiveBrowserViewModel * model) {
@@ -411,6 +409,7 @@ void archive_enter_dir(ArchiveBrowserView* browser, string_t name) {
         string_set(browser->path, name);
     }
 
+    archive_dir_count_items(browser, string_get_cstr(name));
     archive_switch_dir(browser, string_get_cstr(browser->path));
 }
 

--- a/applications/archive/helpers/archive_browser.c
+++ b/applications/archive/helpers/archive_browser.c
@@ -80,6 +80,7 @@ void archive_set_item_count(ArchiveBrowserView* browser, uint32_t count) {
             model->item_idx = CLAMP(model->item_idx, model->item_cnt - 1, 0);
             return false;
         });
+    archive_update_offset(browser);
 }
 
 void archive_file_array_rm_selected(ArchiveBrowserView* browser) {

--- a/applications/archive/scenes/archive_scene_browser.c
+++ b/applications/archive/scenes/archive_scene_browser.c
@@ -95,6 +95,7 @@ bool archive_scene_browser_on_event(void* context, SceneManagerEvent event) {
             if(known_app) {
                 archive_run_in_app(browser, selected);
             }
+            archive_show_file_menu(browser, false);
             consumed = true;
             break;
         case ArchiveBrowserEventFileMenuPin:


### PR DESCRIPTION
# What's new

- Archive favorites: update list offset and close file menu on app run

# Verification 

- Compile and upload
- Open any file in archive and then close app: no more file menu
- Remove file, ensure cursor position is updated?

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
