### PR TITLE
[FL-2526] SubGhz: fixed receiver list scrolling

### DIFF
--- a/applications/subghz/views/receiver.c
+++ b/applications/subghz/views/receiver.c
@@ -68,14 +68,13 @@ static void subghz_view_receiver_update_offset(SubGhzViewReceiver* subghz_receiv
             size_t history_item = model->history_item;
             uint16_t bounds = history_item > 3 ? 2 : history_item;
 
-            if(history_item > 3 && model->idx >= history_item - 1) {
+            if(history_item > 3 && model->idx >= (int16_t)(history_item - 1)) {
                 model->list_offset = model->idx - 3;
             } else if(model->list_offset < model->idx - bounds) {
-                model->list_offset = CLAMP(
-                    (uint16_t)(model->list_offset + 1), (uint16_t)(history_item - bounds), 0);
-            } else if(model->list_offset > model->idx - bounds) {
                 model->list_offset =
-                    CLAMP((uint16_t)(model->idx - 1), (uint16_t)(history_item - bounds), 0);
+                    CLAMP(model->list_offset + 1, (int16_t)(history_item - bounds), 0);
+            } else if(model->list_offset > model->idx - bounds) {
+                model->list_offset = CLAMP(model->idx - 1, (int16_t)(history_item - bounds), 0);
             }
             return true;
         });


### PR DESCRIPTION
# What's new

- [FL-2526] Fixed receiver view scrolling broken by invalid casts introduced by warning suppression

# Verification 

- Build, receive 8+ keys, scroll list in all directions and validate that it does not behave erratically

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-2526]: https://flipperzero.atlassian.net/browse/FL-2526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ