### PR TITLE
Fix typo in nfc_device ("depricated")

### DIFF
--- a/applications/nfc/nfc_device.c
+++ b/applications/nfc/nfc_device.c
@@ -764,7 +764,7 @@ static bool nfc_device_load_data(NfcDevice* dev, string_t path) {
     uint32_t data_cnt = 0;
     string_t temp_str;
     string_init(temp_str);
-    bool depricated_version = false;
+    bool deprecated_version = false;
 
     do {
         // Check existance of shadow file
@@ -783,7 +783,7 @@ static bool nfc_device_load_data(NfcDevice* dev, string_t path) {
         uint32_t version = 0;
         if(!flipper_format_read_header(file, temp_str, &version)) break;
         if(string_cmp_str(temp_str, nfc_file_header) || (version != nfc_file_version)) {
-            depricated_version = true;
+            deprecated_version = true;
             break;
         }
         // Read Nfc device type
@@ -810,8 +810,8 @@ static bool nfc_device_load_data(NfcDevice* dev, string_t path) {
     } while(false);
 
     if(!parsed) {
-        if(depricated_version) {
-            dialog_message_show_storage_error(dev->dialogs, "File format depricated");
+        if(deprecated_version) {
+            dialog_message_show_storage_error(dev->dialogs, "File format deprecated");
         } else {
             dialog_message_show_storage_error(dev->dialogs, "Can not parse\nfile");
         }


### PR DESCRIPTION
# What's new

- Fix typo in user-visible message and in variable name.

# Verification 

1. Go into the Browser.
2. Open the `nfc` folder, then `assets`.
3. Open `aid` and then choose `Run in app`.
4. Look at the error message (*File format depricated* should now be *File format is deprecated*).

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix