### PR TITLE
SubGhz: fix Princeton false positive on GateTx receive

### DIFF
--- a/applications/subghz/scenes/subghz_scene_receiver.c
+++ b/applications/subghz/scenes/subghz_scene_receiver.c
@@ -60,7 +60,6 @@ static void subghz_scene_add_to_history_callback(
 
     if(subghz_history_add_to_history(
            subghz->txrx->history, decoder_base, subghz->txrx->frequency, subghz->txrx->preset)) {
-        subghz_receiver_reset(receiver);
         string_reset(str_buff);
 
         subghz->state_notifications = SubGhzNotificationStateRxDone;
@@ -75,6 +74,7 @@ static void subghz_scene_add_to_history_callback(
 
         subghz_scene_receiver_update_statusbar(subghz);
     }
+    subghz_receiver_reset(receiver);
     string_clear(str_buff);
     subghz->txrx->rx_key_state = SubGhzRxKeyStateAddKey;
 }

--- a/lib/subghz/protocols/registry.c
+++ b/lib/subghz/protocols/registry.c
@@ -1,12 +1,12 @@
 #include "registry.h"
 
 const SubGhzProtocol* subghz_protocol_registry[] = {
-    &subghz_protocol_princeton,    &subghz_protocol_keeloq,     &subghz_protocol_star_line,
+    &subghz_protocol_gate_tx,      &subghz_protocol_keeloq,     &subghz_protocol_star_line,
     &subghz_protocol_nice_flo,     &subghz_protocol_came,       &subghz_protocol_faac_slh,
     &subghz_protocol_nice_flor_s,  &subghz_protocol_came_twee,  &subghz_protocol_came_atomo,
     &subghz_protocol_nero_sketch,  &subghz_protocol_ido,        &subghz_protocol_kia,
     &subghz_protocol_hormann,      &subghz_protocol_nero_radio, &subghz_protocol_somfy_telis,
-    &subghz_protocol_somfy_keytis, &subghz_protocol_scher_khan, &subghz_protocol_gate_tx,
+    &subghz_protocol_somfy_keytis, &subghz_protocol_scher_khan, &subghz_protocol_princeton,
     &subghz_protocol_raw,          &subghz_protocol_firefly,    &subghz_protocol_secplus_v2,
     &subghz_protocol_secplus_v1,   &subghz_protocol_megacode,   &subghz_protocol_holtek,
 


### PR DESCRIPTION
# What's new

- Change protocol order and reset receiver on valid payload arrival

# Verification 

- Compile and upload
- Run `unit_tests`
- Check GateTX and Princeton

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix