### PR TITLE
[FL-2528] Fix iButton crash on successful emulation

### DIFF
--- a/lib/one_wire/ibutton/ibutton_worker_i.h
+++ b/lib/one_wire/ibutton/ibutton_worker_i.h
@@ -73,6 +73,7 @@ struct iButtonWorker {
 extern const iButtonWorkerModeType ibutton_worker_modes[];
 
 void ibutton_worker_switch_mode(iButtonWorker* worker, iButtonWorkerMode mode);
+void ibutton_worker_notify_emulate(iButtonWorker* worker);
 
 #ifdef __cplusplus
 }

--- a/lib/one_wire/ibutton/ibutton_worker_modes.c
+++ b/lib/one_wire/ibutton/ibutton_worker_modes.c
@@ -184,9 +184,7 @@ void ibutton_worker_mode_read_stop(iButtonWorker* worker) {
 static void onewire_slave_callback(void* context) {
     furi_assert(context);
     iButtonWorker* worker = context;
-    if(worker->emulate_cb != NULL) {
-        worker->emulate_cb(worker->cb_ctx, true);
-    }
+    ibutton_worker_notify_emulate(worker);
 }
 
 void ibutton_worker_emulate_dallas_start(iButtonWorker* worker) {


### PR DESCRIPTION
# What's new
No more crashy-crashy!
(calling emulate callback from iButtonWorker thread now)

# Verification 
Emulate any iButton key against a real lock or a reader.
Everything should work without crashes.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
