### PR TITLE
MusicPlayer: set default volume in worker thread to 1.0f and fix issue with leaking memory

### DIFF
--- a/applications/music_player/music_player.c
+++ b/applications/music_player/music_player.c
@@ -298,7 +298,7 @@ int32_t music_player_app(void* p) {
         if(p) {
             string_cat_str(file_path, p);
         } else {
-            char* file_name = malloc(256);
+            char file_name[256] = {0};
             DialogsApp* dialogs = furi_record_open("dialogs");
             bool res = dialog_file_select_show(
                 dialogs,
@@ -315,7 +315,6 @@ int32_t music_player_app(void* p) {
             string_cat_str(file_path, MUSIC_PLAYER_APP_PATH_FOLDER);
             string_cat_str(file_path, "/");
             string_cat_str(file_path, file_name);
-            free(file_name);
         }
 
         if(!music_player_worker_load(music_player->worker, string_get_cstr(file_path))) {

--- a/applications/music_player/music_player_cli.c
+++ b/applications/music_player/music_player_cli.c
@@ -23,6 +23,7 @@ static void music_player_cli(Cli* cli, string_t args, void* context) {
         }
 
         printf("Press CTRL+C to stop\r\n");
+        music_player_worker_set_volume(music_player_worker, 1.0f);
         music_player_worker_start(music_player_worker);
         while(!cli_cmd_interrupt_received(cli)) {
             osDelay(50);

--- a/applications/music_player/music_player_worker.c
+++ b/applications/music_player/music_player_worker.c
@@ -102,6 +102,8 @@ MusicPlayerWorker* music_player_worker_alloc() {
     furi_thread_set_context(instance->thread, instance);
     furi_thread_set_callback(instance->thread, music_player_worker_thread_callback);
 
+    instance->volume = 1.0f;
+
     return instance;
 }
 


### PR DESCRIPTION
# What's new

- MusicPlayer: set default volume in worker thread to 1.0f and fix issue with leaking memory

# Verification 

- Compile and upload
- Open Music Player without opening file, now it's not leaking
- Open `music_player` in cli, now it's working

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
