### PR TITLE
Fixes long note decay and sounds MUCH better

### DIFF
--- a/applications/music_player/music_player_worker.c
+++ b/applications/music_player/music_player_worker.c
@@ -80,7 +80,7 @@ static int32_t music_player_worker_thread_callback(void* context) {
             while(instance->should_work && furi_hal_get_tick() < next_tick) {
                 volume *= 0.9945679;
                 furi_hal_speaker_set_volume(volume);
-                furi_hal_delay_ms(2);
+                furi_hal_delay_ms(100);
             }
             NoteBlockArray_next(it);
         }


### PR DESCRIPTION
Discussion - https://discord.com/channels/740930220399525928/954430078882816021/974727845840576512

# What's new

- Fixes the issue of long note decay by allowing it to play longer
- Sounds more like the "8-bit beeps" that it should

# Verification 

- Video in the linked thread (too big to upload here)

# Checklist (For Reviewer)

- [ X ] PR has a description of feature/bug or link to Confluence/Jira task
- [ X ] Description contains actions to verify feature/bugfix
- [ X ] I've built this code, uploaded it to the device, and verified the feature/bugfix
