### PR TITLE
Preserve dotted note timing on subsequent loops

### DIFF
--- a/applications/music_player/music_player_worker.c
+++ b/applications/music_player/music_player_worker.c
@@ -59,9 +59,10 @@ static int32_t music_player_worker_thread_callback(void* context) {
             float frequency = NOTE_C4 * powf(TWO_POW_TWELTH_ROOT, note_from_a4);
             float duration =
                 60.0 * osKernelGetTickFreq() * 4 / instance->bpm / note_block->duration;
-            while(note_block->dots > 0) {
+            uint32_t dots = note_block->dots;
+            while(dots > 0) {
                 duration += duration / 2;
-                note_block->dots--;
+                dots--;
             }
             uint32_t next_tick = furi_hal_get_tick() + duration;
             float volume = instance->volume;


### PR DESCRIPTION
# What's new

- Dotted note lengths in the music player are preserved on subsequent loops

# Verification 

1. Make a short .fmf file like the following (content warning: this is literally the first two bars from Never Gonna Give You Up by Rick Astley; I just want to rick roll my friends, not you). Upload it into the `music_player` folder on the SD Card (I did this via qFlipper).

```txt
Filetype: Flipper Music Format
Version: 0
BPM: 120
Duration: 16
Octave: 5
Notes: C, D, F, D, 8A., 8A., 4G., 1P
```

2. Before the patch: dotted notes (e.g., `8A.`) get played like regular eighths (e.g., `8A`) on the second and subsequent loops because the `->dots` field was being modified in the first loop. After the patch: plays correctly every loop. This music player is never gonna give you up, let you down, or run around and desert you (on subsequent loops).

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
