### PR TITLE
[FL-2534] Change button text in format dialog and fix incorrect dialog_ex behavior when text is not set

### DIFF
--- a/applications/gui/modules/dialog_ex.c
+++ b/applications/gui/modules/dialog_ex.c
@@ -45,8 +45,8 @@ static void dialog_ex_view_draw_callback(Canvas* canvas, void* _model) {
     }
 
     // Draw header
+    canvas_set_font(canvas, FontPrimary);
     if(model->header.text != NULL) {
-        canvas_set_font(canvas, FontPrimary);
         elements_multiline_text_aligned(
             canvas,
             model->header.x,
@@ -57,8 +57,8 @@ static void dialog_ex_view_draw_callback(Canvas* canvas, void* _model) {
     }
 
     // Draw text
+    canvas_set_font(canvas, FontSecondary);
     if(model->text.text != NULL) {
-        canvas_set_font(canvas, FontSecondary);
         elements_multiline_text_aligned(
             canvas,
             model->text.x,

--- a/applications/storage_settings/scenes/storage_settings_scene_format_confirm.c
+++ b/applications/storage_settings/scenes/storage_settings_scene_format_confirm.c
@@ -11,7 +11,7 @@ void storage_settings_scene_format_confirm_on_enter(void* context) {
     StorageSettings* app = context;
     FS_Error sd_status = storage_sd_status(app->fs_api);
     DialogEx* dialog_ex = app->dialog_ex;
-    dialog_ex_set_left_button_text(dialog_ex, "Back");
+    dialog_ex_set_left_button_text(dialog_ex, "Cancel");
 
     if(sd_status == FSE_NOT_READY) {
         dialog_ex_set_header(dialog_ex, "SD card not mounted", 64, 10, AlignCenter, AlignCenter);


### PR DESCRIPTION
# What's new

- Change button text in format dialog and fix incorrect dialog_ex behavior when text is not set

# Verification 

- Compile and upload
- Check sd card format dialog, should be `Cancel` instead of `Back`

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
