### PR TITLE
Revert "SubGhz: refactoring frequency analyzer and MegaCode display changes"

### DIFF
--- a/applications/subghz/helpers/subghz_frequency_analyzer_worker.c
+++ b/applications/subghz/helpers/subghz_frequency_analyzer_worker.c
@@ -1,22 +1,24 @@
 #include "subghz_frequency_analyzer_worker.h"
-#include <lib/drivers/cc1101.h>
+#include <lib/drivers/cc1101_regs.h>
 
 #include <furi.h>
 
 #include "../subghz_i.h"
 
-#define TAG "SubghzFrequencyAnalyzerWorker"
-
-#define SUBGHZ_FREQUENCY_ANALYZER_THRESHOLD -95.0f
-
 static const uint8_t subghz_preset_ook_58khz[][2] = {
-    {CC1101_MDMCFG4, 0b11110111}, // Rx BW filter is 58.035714kHz
+    {CC1101_FIFOTHR, 0x47}, // The only important bit is ADC_RETENTION, FIFO Tx=33 Rx=32
+    {CC1101_MDMCFG4, 0xF5}, // Rx BW filter is 58.035714kHz
+    {CC1101_TEST2, 0x81}, // FIFOTHR ADC_RETENTION=1 matched value
+    {CC1101_TEST1, 0x35}, // FIFOTHR ADC_RETENTION=1 matched value
     /* End  */
     {0, 0},
 };
 
 static const uint8_t subghz_preset_ook_650khz[][2] = {
-    {CC1101_MDMCFG4, 0b00010111}, // Rx BW filter is 650.000kHz
+    {CC1101_FIFOTHR, 0x07}, // The only important bit is ADC_RETENTION
+    {CC1101_MDMCFG4, 0x17}, // Rx BW filter is 650.000kHz
+    {CC1101_TEST2, 0x88},
+    {CC1101_TEST1, 0x31},
     /* End  */
     {0, 0},
 };
@@ -25,7 +27,7 @@ struct SubGhzFrequencyAnalyzerWorker {
     FuriThread* thread;
 
     volatile bool worker_running;
-    uint8_t sample_hold_counter;
+    uint8_t count_repet;
     FrequencyRSSI frequency_rssi_buf;
     SubGhzSetting* setting;
 
@@ -34,16 +36,6 @@ struct SubGhzFrequencyAnalyzerWorker {
     SubGhzFrequencyAnalyzerWorkerPairCallback pair_callback;
     void* context;
 };
-
-static void subghz_frequency_analyzer_worker_load_registers(const uint8_t data[][2]) {
-    furi_hal_spi_acquire(&furi_hal_spi_bus_handle_subghz);
-    size_t i = 0;
-    while(data[i][0]) {
-        cc1101_write_reg(&furi_hal_spi_bus_handle_subghz, data[i][0], data[i][1]);
-        i++;
-    }
-    furi_hal_spi_release(&furi_hal_spi_bus_handle_subghz);
-}
 
 // running average with adaptive coefficient
 static uint32_t subghz_frequency_analyzer_worker_expRunningAverageAdaptive(
@@ -70,75 +62,32 @@ static int32_t subghz_frequency_analyzer_worker_thread(void* context) {
     SubGhzFrequencyAnalyzerWorker* instance = context;
 
     FrequencyRSSI frequency_rssi = {.frequency = 0, .rssi = 0};
-    float rssi = 0;
-    uint32_t frequency = 0;
-    CC1101Status status;
+    float rssi;
+    uint32_t frequency;
+    uint32_t frequency_start;
 
     //Start CC1101
     furi_hal_subghz_reset();
-
-    furi_hal_spi_acquire(&furi_hal_spi_bus_handle_subghz);
-    cc1101_flush_rx(&furi_hal_spi_bus_handle_subghz);
-    cc1101_flush_tx(&furi_hal_spi_bus_handle_subghz);
-    cc1101_write_reg(&furi_hal_spi_bus_handle_subghz, CC1101_IOCFG0, CC1101IocfgHW);
-    cc1101_write_reg(&furi_hal_spi_bus_handle_subghz, CC1101_MDMCFG3,
-                     0b11111111); // symbol rate
-    cc1101_write_reg(
-        &furi_hal_spi_bus_handle_subghz,
-        CC1101_AGCCTRL2,
-        0b00000111); // 00 - DVGA all; 000 - MAX LNA+LNA2; 111 - MAGN_TARGET 42 dB
-    cc1101_write_reg(
-        &furi_hal_spi_bus_handle_subghz,
-        CC1101_AGCCTRL1,
-        0b00001000); // 0; 0 - LNA 2 gain is decreased to minimum before decreasing LNA gain; 00 - Relative carrier sense threshold disabled; 1000 - Absolute carrier sense threshold disabled
-    cc1101_write_reg(
-        &furi_hal_spi_bus_handle_subghz,
-        CC1101_AGCCTRL0,
-        0b00110000); // 00 - No hysteresis, medium asymmetric dead zone, medium gain ; 11 - 64 samples agc; 00 - Normal AGC, 00 - 4dB boundary
-
-    furi_hal_spi_release(&furi_hal_spi_bus_handle_subghz);
-
+    furi_hal_subghz_load_preset(FuriHalSubGhzPresetOok650Async);
+    furi_hal_subghz_set_frequency(433920000);
+    furi_hal_subghz_flush_rx();
     furi_hal_subghz_set_path(FuriHalSubGhzPathIsolate);
+    furi_hal_subghz_rx();
 
     while(instance->worker_running) {
         osDelay(10);
-
-        float rssi_min = 26.0f;
-        float rssi_avg = 0;
-        size_t rssi_avg_samples = 0;
-
         frequency_rssi.rssi = -127.0f;
         furi_hal_subghz_idle();
-        subghz_frequency_analyzer_worker_load_registers(subghz_preset_ook_650khz);
-
-        // First stage: coarse scan
+        furi_hal_subghz_load_registers(subghz_preset_ook_650khz);
         for(size_t i = 0; i < subghz_setting_get_frequency_count(instance->setting); i++) {
             if(furi_hal_subghz_is_frequency_valid(
                    subghz_setting_get_frequency(instance->setting, i))) {
-                furi_hal_spi_acquire(&furi_hal_spi_bus_handle_subghz);
-                cc1101_switch_to_idle(&furi_hal_spi_bus_handle_subghz);
-                frequency = cc1101_set_frequency(
-                    &furi_hal_spi_bus_handle_subghz,
+                furi_hal_subghz_idle();
+                frequency = furi_hal_subghz_set_frequency(
                     subghz_setting_get_frequency(instance->setting, i));
-
-                cc1101_calibrate(&furi_hal_spi_bus_handle_subghz);
-                do {
-                    status = cc1101_get_status(&furi_hal_spi_bus_handle_subghz);
-                } while(status.STATE != CC1101StateIDLE);
-
-                cc1101_switch_to_rx(&furi_hal_spi_bus_handle_subghz);
-                furi_hal_spi_release(&furi_hal_spi_bus_handle_subghz);
-
-                // delay will be in range between 1 and 2ms
-                osDelay(2);
-
+                furi_hal_subghz_rx();
+                osDelay(3);
                 rssi = furi_hal_subghz_get_rssi();
-
-                rssi_avg += rssi;
-                rssi_avg_samples++;
-
-                if(rssi < rssi_min) rssi_min = rssi;
-
                 if(frequency_rssi.rssi < rssi) {
                     frequency_rssi.rssi = rssi;
                     frequency_rssi.frequency = frequency;
@@ -146,41 +95,19 @@ static int32_t subghz_frequency_analyzer_worker_thread(void* context) {
             }
         }
 
-        FURI_LOG_T(
-            TAG,
-            "RSSI: avg %f, max %f at %u, min %f",
-            (double)(rssi_avg / rssi_avg_samples),
-            (double)frequency_rssi.rssi,
-            frequency_rssi.frequency,
-            (double)rssi_min);
-
-        // Second stage: fine scan
-        if(frequency_rssi.rssi > SUBGHZ_FREQUENCY_ANALYZER_THRESHOLD) {
-            FURI_LOG_D(TAG, "~:%u:%f", frequency_rssi.frequency, (double)frequency_rssi.rssi);
-
+        if(frequency_rssi.rssi > -90.0) {
+            //  -0.5 ... 433.92 ... +0.5
+            frequency_start = frequency_rssi.frequency - 250000;
+            //step 10KHz
             frequency_rssi.rssi = -127.0;
             furi_hal_subghz_idle();
-            subghz_frequency_analyzer_worker_load_registers(subghz_preset_ook_58khz);
-            //-0.3 ... 433.92 ... +0.3 step 10KHz
-            for(uint32_t i = frequency_rssi.frequency - 300000;
-                i < frequency_rssi.frequency + 300000;
-                i += 20000) {
+            furi_hal_subghz_load_registers(subghz_preset_ook_58khz);
+            for(uint32_t i = frequency_start; i < frequency_start + 500000; i += 10000) {
                 if(furi_hal_subghz_is_frequency_valid(i)) {
-                    furi_hal_spi_acquire(&furi_hal_spi_bus_handle_subghz);
-                    cc1101_switch_to_idle(&furi_hal_spi_bus_handle_subghz);
-                    frequency = cc1101_set_frequency(&furi_hal_spi_bus_handle_subghz, i);
-
-                    cc1101_calibrate(&furi_hal_spi_bus_handle_subghz);
-                    do {
-                        status = cc1101_get_status(&furi_hal_spi_bus_handle_subghz);
-                    } while(status.STATE != CC1101StateIDLE);
-
-                    cc1101_switch_to_rx(&furi_hal_spi_bus_handle_subghz);
-                    furi_hal_spi_release(&furi_hal_spi_bus_handle_subghz);
-
-                    // delay will be in range between 1 and 2ms
-                    osDelay(2);
-
+                    furi_hal_subghz_idle();
+                    frequency = furi_hal_subghz_set_frequency(i);
+                    furi_hal_subghz_rx();
+                    osDelay(3);
                     rssi = furi_hal_subghz_get_rssi();
                     if(frequency_rssi.rssi < rssi) {
                         frequency_rssi.rssi = rssi;
@@ -190,24 +117,20 @@ static int32_t subghz_frequency_analyzer_worker_thread(void* context) {
             }
         }
 
-        // Deliver results
-        if(frequency_rssi.rssi > SUBGHZ_FREQUENCY_ANALYZER_THRESHOLD) {
-            FURI_LOG_D(TAG, "=:%u:%f", frequency_rssi.frequency, (double)frequency_rssi.rssi);
-
-            instance->sample_hold_counter = 20;
+        if(frequency_rssi.rssi > -90.0) {
+            instance->count_repet = 20;
             if(instance->filVal) {
                 frequency_rssi.frequency =
                     subghz_frequency_analyzer_worker_expRunningAverageAdaptive(
                         instance, frequency_rssi.frequency);
             }
-            // Deliver callback
-            if(instance->pair_callback) {
+            if(instance->pair_callback)
                 instance->pair_callback(
                     instance->context, frequency_rssi.frequency, frequency_rssi.rssi);
-            }
+
         } else {
-            if(instance->sample_hold_counter > 0) {
-                instance->sample_hold_counter--;
+            if(instance->count_repet > 0) {
+                instance->count_repet--;
             } else {
                 instance->filVal = 0;
                 if(instance->pair_callback) instance->pair_callback(instance->context, 0, 0);

--- a/lib/subghz/protocols/megacode.c
+++ b/lib/subghz/protocols/megacode.c
@@ -401,14 +401,13 @@ void subghz_protocol_decoder_megacode_get_string(void* context, string_t output)
     string_cat_printf(
         output,
         "%s %dbit\r\n"
-        "Key:0x%06lX\r\n"
-        "Sn:0x%04lX - %d\r\n"
-        "Facility:%X Btn:%X\r\n",
+        "Key:%06lX\r\n"
+        "Sn:%04lX Btn:%X\r\n"
+        "Facility:%X\r\n",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)instance->generic.data,
         instance->generic.serial,
-        instance->generic.serial,
-        instance->generic.cnt,
-        instance->generic.btn);
+        instance->generic.btn,
+        instance->generic.cnt);
 }


### PR DESCRIPTION
Reverts flipperdevices/flipperzero-firmware#1221

These changes broke some detection since my car remote at 433.868 could not be read after this update.

Not sure if 315/318 works with this code, but without these changes 315/318 still can't be read. May need to be opened as a different issue. 

I will be able to provide debugging/logs Monday. If anyone wants to take a stab at it, I'll leave this here.