### PR TITLE
nfc: Add support for saved files in subdirectories

### DIFF
--- a/applications/nfc/nfc_device.c
+++ b/applications/nfc/nfc_device.c
@@ -11,6 +11,7 @@ NfcDevice* nfc_device_alloc() {
     NfcDevice* nfc_dev = malloc(sizeof(NfcDevice));
     nfc_dev->storage = furi_record_open("storage");
     nfc_dev->dialogs = furi_record_open("dialogs");
+    string_init(nfc_dev->load_path);
     return nfc_dev;
 }
 
@@ -19,6 +20,7 @@ void nfc_device_free(NfcDevice* nfc_dev) {
     nfc_device_clear(nfc_dev);
     furi_record_close("storage");
     furi_record_close("dialogs");
+    string_clear(nfc_dev->load_path);
     free(nfc_dev);
 }
 
@@ -693,11 +695,24 @@ void nfc_device_set_name(NfcDevice* dev, const char* name) {
     strlcpy(dev->dev_name, name, NFC_DEV_NAME_MAX_LEN);
 }
 
+static void nfc_device_get_path_without_ext(string_t orig_path, string_t shadow_path) {
+    // TODO: this won't work if there is ".nfc" anywhere in the path other than
+    // at the end
+    size_t ext_start = string_search_str(orig_path, NFC_APP_EXTENSION);
+    string_set_n(shadow_path, orig_path, 0, ext_start);
+}
+
+static void nfc_device_get_shadow_path(string_t orig_path, string_t shadow_path) {
+    nfc_device_get_path_without_ext(orig_path, shadow_path);
+    string_cat_printf(shadow_path, "%s", NFC_APP_SHADOW_EXTENSION);
+}
+
 static bool nfc_device_save_file(
     NfcDevice* dev,
     const char* dev_name,
     const char* folder,
-    const char* extension) {
+    const char* extension,
+    bool use_load_path) {
     furi_assert(dev);
 
     bool saved = false;
@@ -707,10 +722,20 @@ static bool nfc_device_save_file(
     string_init(temp_str);
 
     do {
-        // Create nfc directory if necessary
-        if(!storage_simply_mkdir(dev->storage, NFC_APP_FOLDER)) break;
-        // First remove nfc device file if it was saved
-        string_printf(temp_str, "%s/%s%s", folder, dev_name, extension);
+        if(use_load_path && !string_empty_p(dev->load_path)) {
+            // Get directory name
+            path_extract_dirname(string_get_cstr(dev->load_path), temp_str);
+            // Create nfc directory if necessary
+            if(!storage_simply_mkdir(dev->storage, string_get_cstr(temp_str))) break;
+            // Make path to file to save
+            nfc_device_get_path_without_ext(dev->load_path, temp_str);
+            string_cat_str(temp_str, extension);
+        } else {
+            // Create nfc directory if necessary
+            if(!storage_simply_mkdir(dev->storage, NFC_APP_FOLDER)) break;
+            // First remove nfc device file if it was saved
+            string_printf(temp_str, "%s/%s%s", folder, dev_name, extension);
+        }
         // Open file
         if(!flipper_format_file_open_always(file, string_get_cstr(temp_str))) break;
         // Write header
@@ -749,12 +774,12 @@ static bool nfc_device_save_file(
 }
 
 bool nfc_device_save(NfcDevice* dev, const char* dev_name) {
-    return nfc_device_save_file(dev, dev_name, NFC_APP_FOLDER, NFC_APP_EXTENSION);
+    return nfc_device_save_file(dev, dev_name, NFC_APP_FOLDER, NFC_APP_EXTENSION, true);
 }
 
 bool nfc_device_save_shadow(NfcDevice* dev, const char* dev_name) {
     dev->shadow_file_exist = true;
-    return nfc_device_save_file(dev, dev_name, NFC_APP_FOLDER, NFC_APP_SHADOW_EXTENSION);
+    return nfc_device_save_file(dev, dev_name, NFC_APP_FOLDER, NFC_APP_SHADOW_EXTENSION, true);
 }
 
 static bool nfc_device_load_data(NfcDevice* dev, string_t path) {
@@ -827,15 +852,16 @@ bool nfc_device_load(NfcDevice* dev, const char* file_path) {
     furi_assert(file_path);
 
     // Load device data
-    string_t path;
-    string_init_set_str(path, file_path);
-    bool dev_load = nfc_device_load_data(dev, path);
+    string_set_str(dev->load_path, file_path);
+    bool dev_load = nfc_device_load_data(dev, dev->load_path);
     if(dev_load) {
         // Set device name
-        path_extract_filename_no_ext(file_path, path);
-        nfc_device_set_name(dev, string_get_cstr(path));
+        string_t filename;
+        string_init(filename);
+        path_extract_filename_no_ext(file_path, filename);
+        nfc_device_set_name(dev, string_get_cstr(filename));
+        string_clear(filename);
     }
-    string_clear(path);
 
     return dev_load;
 }
@@ -877,9 +903,10 @@ void nfc_device_clear(NfcDevice* dev) {
     nfc_device_data_clear(&dev->dev_data);
     memset(&dev->dev_data, 0, sizeof(dev->dev_data));
     dev->format = NfcDeviceSaveFormatUid;
+    string_set_str(dev->load_path, "");
 }
 
-bool nfc_device_delete(NfcDevice* dev) {
+bool nfc_device_delete(NfcDevice* dev, bool use_load_path) {
     furi_assert(dev);
 
     bool deleted = false;
@@ -888,12 +915,20 @@ bool nfc_device_delete(NfcDevice* dev) {
 
     do {
         // Delete original file
-        string_init_printf(file_path, "%s/%s%s", NFC_APP_FOLDER, dev->dev_name, NFC_APP_EXTENSION);
+        if(use_load_path && !string_empty_p(dev->load_path)) {
+            string_set(file_path, dev->load_path);
+        } else {
+            string_printf(file_path, "%s/%s%s", NFC_APP_FOLDER, dev->dev_name, NFC_APP_EXTENSION);
+        }
         if(!storage_simply_remove(dev->storage, string_get_cstr(file_path))) break;
         // Delete shadow file if it exists
         if(dev->shadow_file_exist) {
-            string_printf(
-                file_path, "%s/%s%s", NFC_APP_FOLDER, dev->dev_name, NFC_APP_SHADOW_EXTENSION);
+            if(use_load_path && !string_empty_p(dev->load_path)) {
+                nfc_device_get_shadow_path(dev->load_path, file_path);
+            } else {
+                string_printf(
+                    file_path, "%s/%s%s", NFC_APP_FOLDER, dev->dev_name, NFC_APP_SHADOW_EXTENSION);
+            }
             if(!storage_simply_remove(dev->storage, string_get_cstr(file_path))) break;
         }
         deleted = true;
@@ -907,19 +942,29 @@ bool nfc_device_delete(NfcDevice* dev) {
     return deleted;
 }
 
-bool nfc_device_restore(NfcDevice* dev) {
+bool nfc_device_restore(NfcDevice* dev, bool use_load_path) {
     furi_assert(dev);
     furi_assert(dev->shadow_file_exist);
 
     bool restored = false;
     string_t path;
 
+    string_init(path);
+
     do {
-        string_init_printf(
-            path, "%s/%s%s", NFC_APP_FOLDER, dev->dev_name, NFC_APP_SHADOW_EXTENSION);
+        if(use_load_path && !string_empty_p(dev->load_path)) {
+            nfc_device_get_shadow_path(dev->load_path, path);
+        } else {
+            string_printf(
+                path, "%s/%s%s", NFC_APP_FOLDER, dev->dev_name, NFC_APP_SHADOW_EXTENSION);
+        }
         if(!storage_simply_remove(dev->storage, string_get_cstr(path))) break;
         dev->shadow_file_exist = false;
-        string_printf(path, "%s/%s%s", NFC_APP_FOLDER, dev->dev_name, NFC_APP_EXTENSION);
+        if(use_load_path && !string_empty_p(dev->load_path)) {
+            string_set(path, dev->load_path);
+        } else {
+            string_printf(path, "%s/%s%s", NFC_APP_FOLDER, dev->dev_name, NFC_APP_EXTENSION);
+        }
         if(!nfc_device_load_data(dev, path)) break;
         restored = true;
     } while(0);

--- a/applications/nfc/nfc_device.c
+++ b/applications/nfc/nfc_device.c
@@ -793,9 +793,7 @@ static bool nfc_device_load_data(NfcDevice* dev, string_t path) {
 
     do {
         // Check existance of shadow file
-        size_t ext_start = string_search_str(path, NFC_APP_EXTENSION);
-        string_set_n(temp_str, path, 0, ext_start);
-        string_cat_printf(temp_str, "%s", NFC_APP_SHADOW_EXTENSION);
+        nfc_device_get_shadow_path(path, temp_str);
         dev->shadow_file_exist =
             storage_common_stat(dev->storage, string_get_cstr(temp_str), NULL) == FSE_OK;
         // Open shadow file if it exists. If not - open original

--- a/applications/nfc/nfc_device.h
+++ b/applications/nfc/nfc_device.h
@@ -58,6 +58,7 @@ typedef struct {
     NfcDeviceData dev_data;
     char dev_name[NFC_DEV_NAME_MAX_LEN + 1];
     char file_name[NFC_FILE_NAME_MAX_LEN];
+    string_t load_path;
     NfcDeviceSaveFormat format;
     bool shadow_file_exist;
 } NfcDevice;
@@ -80,6 +81,6 @@ void nfc_device_data_clear(NfcDeviceData* dev);
 
 void nfc_device_clear(NfcDevice* dev);
 
-bool nfc_device_delete(NfcDevice* dev);
+bool nfc_device_delete(NfcDevice* dev, bool use_load_path);
 
-bool nfc_device_restore(NfcDevice* dev);
+bool nfc_device_restore(NfcDevice* dev, bool use_load_path);

--- a/applications/nfc/scenes/nfc_scene_delete.c
+++ b/applications/nfc/scenes/nfc_scene_delete.c
@@ -73,7 +73,7 @@ bool nfc_scene_delete_on_event(void* context, SceneManagerEvent event) {
         if(event.event == GuiButtonTypeLeft) {
             return scene_manager_previous_scene(nfc->scene_manager);
         } else if(event.event == GuiButtonTypeRight) {
-            if(nfc_device_delete(nfc->dev)) {
+            if(nfc_device_delete(nfc->dev, true)) {
                 scene_manager_next_scene(nfc->scene_manager, NfcSceneDeleteSuccess);
             } else {
                 scene_manager_search_and_switch_to_previous_scene(

--- a/applications/nfc/scenes/nfc_scene_save_name.c
+++ b/applications/nfc/scenes/nfc_scene_save_name.c
@@ -43,7 +43,7 @@ bool nfc_scene_save_name_on_event(void* context, SceneManagerEvent event) {
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == NfcCustomEventTextInputDone) {
             if(strcmp(nfc->dev->dev_name, "")) {
-                nfc_device_delete(nfc->dev);
+                nfc_device_delete(nfc->dev, true);
             }
             if(scene_manager_has_previous_scene(nfc->scene_manager, NfcSceneSetUid)) {
                 nfc->dev->dev_data.nfc_data = nfc->dev_edit_data;

--- a/applications/nfc/scenes/nfc_scene_saved_menu.c
+++ b/applications/nfc/scenes/nfc_scene_saved_menu.c
@@ -78,7 +78,7 @@ bool nfc_scene_saved_menu_on_event(void* context, SceneManagerEvent event) {
             scene_manager_next_scene(nfc->scene_manager, NfcSceneDeviceInfo);
             consumed = true;
         } else if(event.event == SubmenuIndexRestoreOriginal) {
-            if(!nfc_device_restore(nfc->dev)) {
+            if(!nfc_device_restore(nfc->dev, true)) {
                 scene_manager_search_and_switch_to_previous_scene(
                     nfc->scene_manager, NfcSceneStart);
             } else {


### PR DESCRIPTION
# What's new

This PR corrects the saving, restoring, and deleting of saved NFC tags that reside in a directory, loaded from archive.

# Verification 

- From NFC menu
  - Ensure that a newly read tag can be saved to the nfc directory
  - Ensure that a tag can be loaded from the saved menu
  - Write back to an emulated tag loaded from the saved menu, and after a reload from the saved menu, ensure it contains the same data as written
  - Ensure that a tag loaded from the saved menu, when restored, read as the original data when emulated
  - Delete a saved tag with modified data loaded from the saved menu, and ensure that both original and shadow files have been deleted
- From archive
  - Ensure that a saved tag can be loaded
  - Write back to an emulated tag loaded from archive, and after a reload from archive, ensure it contains the same data as written
- Emulated Amiibo should retain saved data when reloaded

Note: deleting shadow file together with main file from archive has not been considered, since it's not originally implemented.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
