### PR TITLE
Change "FuriHalNfc Current state" trace to only log on change of state

### DIFF
--- a/firmware/targets/f7/furi_hal/furi_hal_nfc.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_nfc.c
@@ -60,6 +60,7 @@ bool furi_hal_nfc_detect(FuriHalNfcDevData* nfc_data, uint32_t timeout) {
 
     rfalLowPowerModeStop();
     rfalNfcState state = rfalNfcGetState();
+    rfalNfcState state_old = 0;
     if(state == RFAL_NFC_STATE_NOTINIT) {
         rfalNfcInitialize();
     }
@@ -82,11 +83,14 @@ bool furi_hal_nfc_detect(FuriHalNfcDevData* nfc_data, uint32_t timeout) {
     while(true) {
         rfalNfcWorker();
         state = rfalNfcGetState();
+        if(state != state_old) {
+            FURI_LOG_T(TAG, "State change %d -> %d", state_old, state);
+        }
+        state_old = state;
         if(state == RFAL_NFC_STATE_ACTIVATED) {
             detected = true;
             break;
         }
-        FURI_LOG_T(TAG, "Current state %d", state);
         if(state == RFAL_NFC_STATE_POLL_ACTIVATION) {
             start = DWT->CYCCNT;
             continue;


### PR DESCRIPTION
# What's new

- Reduces the volume of _FuriHalNfc "Current state"_ logging by only logging when the state changes instead of at every iteration of the loop.

 Old log (repeated every 2 to 5 ms):
 ```
159565 [T][FuriHalNfc]: Current state 10
```

 New log:
```160826 [T][FuriHalNfc]: State change 0 -> 10
160956 [T][FuriHalNfc]: State change 10 -> 11
160990 [T][FuriHalNfc]: State change 11 -> 13
160995 [T][FuriHalNfc]: State change 13 -> 30
```

# Verification 

- run _log_ from CLI with _trace_ enabled and scan any NFC device.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
