### PR TITLE
Desktop: Secondary favorite app

### DIFF
--- a/applications/desktop/desktop_settings/desktop_settings.h
+++ b/applications/desktop/desktop_settings/desktop_settings.h
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 #include <toolbox/saved_struct.h>
 
-#define DESKTOP_SETTINGS_VER (3)
+#define DESKTOP_SETTINGS_VER (4)
 #define DESKTOP_SETTINGS_PATH "/int/desktop.settings"
 #define DESKTOP_SETTINGS_MAGIC (0x17)
 #define PIN_MAX_LENGTH 12
@@ -37,7 +37,8 @@ typedef struct {
 } PinCode;
 
 typedef struct {
-    uint16_t favorite;
+    uint16_t favorite_primary;
+    uint16_t favorite_secondary;
     PinCode pin_code;
     uint8_t is_locked;
     uint32_t auto_lock_delay_ms;

--- a/applications/desktop/desktop_settings/desktop_settings_app.h
+++ b/applications/desktop/desktop_settings/desktop_settings_app.h
@@ -39,4 +39,6 @@ typedef struct {
 
     uint8_t menu_idx;
 
+    bool setting_primary_favorite;
+
 } DesktopSettingsApp;

--- a/applications/desktop/desktop_settings/scenes/desktop_settings_scene_favorite.c
+++ b/applications/desktop/desktop_settings/scenes/desktop_settings_scene_favorite.c
@@ -21,8 +21,12 @@ void desktop_settings_scene_favorite_on_enter(void* context) {
             app);
     }
 
-    submenu_set_header(app->submenu, "Quick access app:");
-    submenu_set_selected_item(app->submenu, app->settings.favorite);
+    submenu_set_header(app->submenu, app->setting_primary_favorite ? "Primary favorite app:" : "Secondary favorite app:");
+    if(app->setting_primary_favorite) {
+        submenu_set_selected_item(app->submenu, app->settings.favorite_primary);
+    } else {
+        submenu_set_selected_item(app->submenu, app->settings.favorite_secondary);
+    }
     view_dispatcher_switch_to_view(app->view_dispatcher, DesktopSettingsAppViewMenu);
 }
 
@@ -33,7 +37,11 @@ bool desktop_settings_scene_favorite_on_event(void* context, SceneManagerEvent e
     if(event.type == SceneManagerEventTypeCustom) {
         switch(event.event) {
         default:
-            app->settings.favorite = event.event;
+            if(app->setting_primary_favorite) {
+                app->settings.favorite_primary = event.event;
+            } else {
+                app->settings.favorite_secondary = event.event;
+            }
             scene_manager_previous_scene(app->scene_manager);
             consumed = true;
             break;

--- a/applications/desktop/desktop_settings/scenes/desktop_settings_scene_favorite.c
+++ b/applications/desktop/desktop_settings/scenes/desktop_settings_scene_favorite.c
@@ -21,7 +21,9 @@ void desktop_settings_scene_favorite_on_enter(void* context) {
             app);
     }
 
-    submenu_set_header(app->submenu, app->setting_primary_favorite ? "Primary favorite app:" : "Secondary favorite app:");
+    submenu_set_header(
+        app->submenu,
+        app->setting_primary_favorite ? "Primary favorite app:" : "Secondary favorite app:");
     if(app->setting_primary_favorite) {
         submenu_set_selected_item(app->submenu, app->settings.favorite_primary);
     } else {

--- a/applications/desktop/desktop_settings/scenes/desktop_settings_scene_start.c
+++ b/applications/desktop/desktop_settings/scenes/desktop_settings_scene_start.c
@@ -4,9 +4,10 @@
 #include "../desktop_settings_app.h"
 #include "desktop_settings_scene.h"
 
-#define SCENE_EVENT_SELECT_FAVORITE 0
-#define SCENE_EVENT_SELECT_PIN_SETUP 1
-#define SCENE_EVENT_SELECT_AUTO_LOCK_DELAY 2
+#define SCENE_EVENT_SELECT_FAVORITE_PRIMARY 0
+#define SCENE_EVENT_SELECT_FAVORITE_SECONDARY 1
+#define SCENE_EVENT_SELECT_PIN_SETUP 2
+#define SCENE_EVENT_SELECT_AUTO_LOCK_DELAY 3
 
 #define AUTO_LOCK_DELAY_COUNT 6
 const char* const auto_lock_delay_text[AUTO_LOCK_DELAY_COUNT] = {
@@ -41,7 +42,9 @@ void desktop_settings_scene_start_on_enter(void* context) {
     VariableItem* item;
     uint8_t value_index;
 
-    variable_item_list_add(variable_item_list, "Favorite App", 1, NULL, NULL);
+    variable_item_list_add(variable_item_list, "Primary Favorite App", 1, NULL, NULL);
+
+    variable_item_list_add(variable_item_list, "Secondary Favorite App", 1, NULL, NULL);
 
     variable_item_list_add(variable_item_list, "PIN Setup", 1, NULL, NULL);
 
@@ -68,7 +71,13 @@ bool desktop_settings_scene_start_on_event(void* context, SceneManagerEvent even
 
     if(event.type == SceneManagerEventTypeCustom) {
         switch(event.event) {
-        case SCENE_EVENT_SELECT_FAVORITE:
+        case SCENE_EVENT_SELECT_FAVORITE_PRIMARY:
+            app->setting_primary_favorite = true;
+            scene_manager_next_scene(app->scene_manager, DesktopSettingsAppSceneFavorite);
+            consumed = true;
+            break;
+        case SCENE_EVENT_SELECT_FAVORITE_SECONDARY:
+            app->setting_primary_favorite = false;
             scene_manager_next_scene(app->scene_manager, DesktopSettingsAppSceneFavorite);
             consumed = true;
             break;

--- a/applications/desktop/scenes/desktop_scene_main.c
+++ b/applications/desktop/scenes/desktop_scene_main.c
@@ -120,7 +120,9 @@ bool desktop_scene_main_on_event(void* context, SceneManagerEvent event) {
             LOAD_DESKTOP_SETTINGS(&desktop->settings);
             if(desktop->settings.favorite_secondary < FLIPPER_APPS_COUNT) {
                 LoaderStatus status = loader_start(
-                    desktop->loader, FLIPPER_APPS[desktop->settings.favorite_secondary].name, NULL);
+                    desktop->loader,
+                    FLIPPER_APPS[desktop->settings.favorite_secondary].name,
+                    NULL);
                 if(status != LoaderStatusOk) {
                     FURI_LOG_E(TAG, "loader_start failed: %d", status);
                 }

--- a/applications/desktop/scenes/desktop_scene_main.c
+++ b/applications/desktop/scenes/desktop_scene_main.c
@@ -103,16 +103,29 @@ bool desktop_scene_main_on_event(void* context, SceneManagerEvent event) {
             consumed = true;
             break;
 
-        case DesktopMainEventOpenFavorite:
+        case DesktopMainEventOpenFavoritePrimary:
             LOAD_DESKTOP_SETTINGS(&desktop->settings);
-            if(desktop->settings.favorite < FLIPPER_APPS_COUNT) {
+            if(desktop->settings.favorite_primary < FLIPPER_APPS_COUNT) {
                 LoaderStatus status = loader_start(
-                    desktop->loader, FLIPPER_APPS[desktop->settings.favorite].name, NULL);
+                    desktop->loader, FLIPPER_APPS[desktop->settings.favorite_primary].name, NULL);
                 if(status != LoaderStatusOk) {
                     FURI_LOG_E(TAG, "loader_start failed: %d", status);
                 }
             } else {
-                FURI_LOG_E(TAG, "Can't find favorite application");
+                FURI_LOG_E(TAG, "Can't find primary favorite application");
+            }
+            consumed = true;
+            break;
+        case DesktopMainEventOpenFavoriteSecondary:
+            LOAD_DESKTOP_SETTINGS(&desktop->settings);
+            if(desktop->settings.favorite_secondary < FLIPPER_APPS_COUNT) {
+                LoaderStatus status = loader_start(
+                    desktop->loader, FLIPPER_APPS[desktop->settings.favorite_secondary].name, NULL);
+                if(status != LoaderStatusOk) {
+                    FURI_LOG_E(TAG, "loader_start failed: %d", status);
+                }
+            } else {
+                FURI_LOG_E(TAG, "Can't find secondary favorite application");
             }
             consumed = true;
             break;

--- a/applications/desktop/views/desktop_events.h
+++ b/applications/desktop/views/desktop_events.h
@@ -3,7 +3,8 @@
 typedef enum {
     DesktopMainEventOpenLockMenu,
     DesktopMainEventOpenArchive,
-    DesktopMainEventOpenFavorite,
+    DesktopMainEventOpenFavoritePrimary,
+    DesktopMainEventOpenFavoriteSecondary,
     DesktopMainEventOpenMenu,
     DesktopMainEventOpenDebug,
     DesktopMainEventOpenPassport, /**< Broken, don't use it */

--- a/applications/desktop/views/desktop_view_main.c
+++ b/applications/desktop/views/desktop_view_main.c
@@ -44,13 +44,15 @@ bool desktop_main_input(InputEvent* event, void* context) {
         } else if(event->key == InputKeyDown) {
             main_view->callback(DesktopMainEventOpenArchive, main_view->context);
         } else if(event->key == InputKeyLeft) {
-            main_view->callback(DesktopMainEventOpenFavorite, main_view->context);
+            main_view->callback(DesktopMainEventOpenFavoritePrimary, main_view->context);
         } else if(event->key == InputKeyRight) {
             main_view->callback(DesktopMainEventOpenPassport, main_view->context);
         }
     } else if(event->type == InputTypeLong) {
         if(event->key == InputKeyDown) {
             main_view->callback(DesktopMainEventOpenDebug, main_view->context);
+        } else if(event->key == InputKeyLeft) {
+            main_view->callback(DesktopMainEventOpenFavoriteSecondary, main_view->context);
         }
     }
 


### PR DESCRIPTION
# What's new

- A secondary favorite app can be opened from the desktop by long-pressing left.
- Corresponding settings have been renamed to "Primary" and "Secondary."

# Verification 

- Compiled & Uploaded to device.
- Tested in video below.

https://user-images.githubusercontent.com/8518150/172910126-7daed345-203a-4b92-95b3-0cb581fdfaa8.mp4

_(I'm aware this might cause a merge conflict with #1279 and/or invalidate existing desktop settings)_ 

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
