### PR TITLE
Desktop: poweroff timer and 5 seconds delay and other improvements

### DIFF
--- a/applications/desktop/desktop_settings/desktop_settings_app.h
+++ b/applications/desktop/desktop_settings/desktop_settings_app.h
@@ -38,7 +38,4 @@ typedef struct {
     bool pincode_buffer_filled;
 
     uint8_t menu_idx;
-
-    bool setting_primary_favorite;
-
 } DesktopSettingsApp;

--- a/applications/desktop/desktop_settings/scenes/desktop_settings_scene_favorite.c
+++ b/applications/desktop/desktop_settings/scenes/desktop_settings_scene_favorite.c
@@ -21,10 +21,13 @@ void desktop_settings_scene_favorite_on_enter(void* context) {
             app);
     }
 
+    uint32_t primary_favorite =
+        scene_manager_get_scene_state(app->scene_manager, DesktopSettingsAppSceneFavorite);
+
     submenu_set_header(
-        app->submenu,
-        app->setting_primary_favorite ? "Primary favorite app:" : "Secondary favorite app:");
-    if(app->setting_primary_favorite) {
+        app->submenu, primary_favorite ? "Primary favorite app:" : "Secondary favorite app:");
+
+    if(primary_favorite) {
         submenu_set_selected_item(app->submenu, app->settings.favorite_primary);
     } else {
         submenu_set_selected_item(app->submenu, app->settings.favorite_secondary);
@@ -36,18 +39,17 @@ bool desktop_settings_scene_favorite_on_event(void* context, SceneManagerEvent e
     DesktopSettingsApp* app = context;
     bool consumed = false;
 
+    uint32_t primary_favorite =
+        scene_manager_get_scene_state(app->scene_manager, DesktopSettingsAppSceneFavorite);
+
     if(event.type == SceneManagerEventTypeCustom) {
-        switch(event.event) {
-        default:
-            if(app->setting_primary_favorite) {
-                app->settings.favorite_primary = event.event;
-            } else {
-                app->settings.favorite_secondary = event.event;
-            }
-            scene_manager_previous_scene(app->scene_manager);
-            consumed = true;
-            break;
+        if(primary_favorite) {
+            app->settings.favorite_primary = event.event;
+        } else {
+            app->settings.favorite_secondary = event.event;
         }
+        scene_manager_previous_scene(app->scene_manager);
+        consumed = true;
     }
     return consumed;
 }

--- a/applications/desktop/desktop_settings/scenes/desktop_settings_scene_start.c
+++ b/applications/desktop/desktop_settings/scenes/desktop_settings_scene_start.c
@@ -72,12 +72,12 @@ bool desktop_settings_scene_start_on_event(void* context, SceneManagerEvent even
     if(event.type == SceneManagerEventTypeCustom) {
         switch(event.event) {
         case SCENE_EVENT_SELECT_FAVORITE_PRIMARY:
-            app->setting_primary_favorite = true;
+            scene_manager_set_scene_state(app->scene_manager, DesktopSettingsAppSceneFavorite, 1);
             scene_manager_next_scene(app->scene_manager, DesktopSettingsAppSceneFavorite);
             consumed = true;
             break;
         case SCENE_EVENT_SELECT_FAVORITE_SECONDARY:
-            app->setting_primary_favorite = false;
+            scene_manager_set_scene_state(app->scene_manager, DesktopSettingsAppSceneFavorite, 0);
             scene_manager_next_scene(app->scene_manager, DesktopSettingsAppSceneFavorite);
             consumed = true;
             break;

--- a/applications/desktop/views/desktop_view_main.c
+++ b/applications/desktop/views/desktop_view_main.c
@@ -13,7 +13,15 @@ struct DesktopMainView {
     View* view;
     DesktopMainViewCallback callback;
     void* context;
+    TimerHandle_t poweroff_timer;
 };
+
+#define DESKTOP_MAIN_VIEW_POWEROFF_TIMEOUT 5000
+
+static void desktop_main_poweroff_timer_callback(TimerHandle_t timer) {
+    DesktopMainView* main_view = pvTimerGetTimerID(timer);
+    main_view->callback(DesktopMainEventOpenPowerOff, main_view->context);
+}
 
 void desktop_main_set_callback(
     DesktopMainView* main_view,
@@ -53,8 +61,17 @@ bool desktop_main_input(InputEvent* event, void* context) {
             main_view->callback(DesktopMainEventOpenDebug, main_view->context);
         } else if(event->key == InputKeyLeft) {
             main_view->callback(DesktopMainEventOpenFavoriteSecondary, main_view->context);
-        } else if(event->key == InputKeyBack) {
-            main_view->callback(DesktopMainEventOpenPowerOff, main_view->context);
+        }
+    }
+
+    if(event->key == InputKeyBack) {
+        if(event->type == InputTypePress) {
+            xTimerChangePeriod(
+                main_view->poweroff_timer,
+                pdMS_TO_TICKS(DESKTOP_MAIN_VIEW_POWEROFF_TIMEOUT),
+                portMAX_DELAY);
+        } else if(event->type == InputTypeRelease) {
+            xTimerStop(main_view->poweroff_timer, portMAX_DELAY);
         }
     }
 
@@ -69,11 +86,19 @@ DesktopMainView* desktop_main_alloc() {
     view_set_context(main_view->view, main_view);
     view_set_input_callback(main_view->view, desktop_main_input);
 
+    main_view->poweroff_timer = xTimerCreate(
+        NULL,
+        pdMS_TO_TICKS(DESKTOP_MAIN_VIEW_POWEROFF_TIMEOUT),
+        pdFALSE,
+        main_view,
+        desktop_main_poweroff_timer_callback);
+
     return main_view;
 }
 
 void desktop_main_free(DesktopMainView* main_view) {
     furi_assert(main_view);
     view_free(main_view->view);
+    osTimerDelete(main_view->poweroff_timer);
     free(main_view);
 }


### PR DESCRIPTION
# What's new

- Desktop: poweroff timer and 5 seconds delay
- Desktop: cleanup logic in settings application

# Verification 

- Compile and upload
- Check back button poweoff delay on main screen
- Check desktop settings: primary and secondary favorite app

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
