### PR TITLE
Fix typos in macOS Bad USB demo

### DIFF
--- a/assets/resources/Manifest
+++ b/assets/resources/Manifest
@@ -1,5 +1,5 @@
 V:0
-T:1654009290
+T:1655152832
 D:badusb
 D:dolphin
 D:infrared
@@ -7,7 +7,7 @@ D:music_player
 D:nfc
 D:subghz
 D:u2f
-F:bb8ffef2d052f171760ce3dc5220cbad:1591:badusb/demo_macos.txt
+F:0e41ba26498b7511d7c9e6e6b5e3b149:1592:badusb/demo_macos.txt
 F:e538ad2ce5a06ec45e1b5b24824901b1:1552:badusb/demo_windows.txt
 D:dolphin/L1_Boxing_128x64
 D:dolphin/L1_Cry_128x64

--- a/assets/resources/badusb/demo_macos.txt
+++ b/assets/resources/badusb/demo_macos.txt
@@ -13,7 +13,7 @@ DELAY 500
 ENTER
 DELAY 750
 
-REM Copy-Paste previuos string
+REM Copy-Paste previous string
 UP
 CTRL c
 
@@ -77,7 +77,7 @@ ENTER
 
 STRING Flipper Zero BadUSB feature is compatible with USB Rubber Ducky script format
 ENTER
-STRING More information about script synax can be found here:
+STRING More information about script syntax can be found here:
 ENTER
 STRING https://github.com/hak5darren/USB-Rubber-Ducky/wiki/Duckyscript
 ENTER


### PR DESCRIPTION
# What's new

- Fix typos in the macOS Bad USB demo script

# Verification 

- Changes may be verified by running the demo_macos Bad USB script while the Flipper is plugged into a macOS machine.  Changes are trivial, but the script was successfully tested on an Apple M1 MacBook Pro running macOS Monterey 12.4.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
