### PR TITLE
SubGhz: bugfix  0.60.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,8 +56,33 @@
 /firmware/ @skotopes @DrZlo13 @hedger
 
 # Lib
-/lib/ST25RFAL002/** @skotopes @DrZlo13 @hedger @gornekich
-/lib/drivers/** @skotopes @DrZlo13 @hedger @gornekich
+/lib/FreeRTOS-Kernel/ @skotopes @DrZlo13 @hedger
+/lib/FreeRTOS-glue/ @skotopes @DrZlo13 @hedger
+/lib/ST25RFAL002/ @skotopes @DrZlo13 @hedger @gornekich
+/lib/STM32CubeWB/ @skotopes @DrZlo13 @hedger @gornekich
+/lib/app-scened-template/ @skotopes @DrZlo13 @hedger
+/lib/callback-connector/ @skotopes @DrZlo13 @hedger
+/lib/digital_signal/ @skotopes @DrZlo13 @hedger @gornekich
+/lib/drivers/ @skotopes @DrZlo13 @hedger
+/lib/fatfs/ @skotopes @DrZlo13 @hedger
+/lib/flipper_format/ @skotopes @DrZlo13 @hedger
+/lib/fnv1a-hash/ @skotopes @DrZlo13 @hedger
+/lib/heatshrink/ @skotopes @DrZlo13 @hedger
+/lib/infrared/ @skotopes @DrZlo13 @hedger @gsurkov
+/lib/libusb_stm32/ @skotopes @DrZlo13 @hedger @nminaylov
+/lib/littlefs/ @skotopes @DrZlo13 @hedger
+/lib/lfs_config.h @skotopes @DrZlo13 @hedger
+/lib/micro-ecc/ @skotopes @DrZlo13 @hedger @nminaylov
+/lib/microtar/ @skotopes @DrZlo13 @hedger
+/lib/mlib/ @skotopes @DrZlo13 @hedger
+/lib/nanopb/ @skotopes @DrZlo13 @hedger
+/lib/nfc_protocols/ @skotopes @DrZlo13 @hedger @gornekich
+/lib/one_wire/ @skotopes @DrZlo13 @hedger
+/lib/qrcode/ @skotopes @DrZlo13 @hedger
+/lib/subghz/ @skotopes @DrZlo13 @hedger @Skorpionm
+/lib/toolbox/ @skotopes @DrZlo13 @hedger
+/lib/u8g2/ @skotopes @DrZlo13 @hedger
+/lib/update_util/ @skotopes @DrZlo13 @hedger
 
 # Make tools
 /make/ @skotopes @DrZlo13 @hedger @aprosvetova

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,7 +47,7 @@
 
 # Docker
 /docker/ @skotopes @DrZlo13 @hedger @aprosvetova
-docker-compose.yml @skotopes @DrZlo13 @hedger @aprosvetova
+/docker-compose.yml @skotopes @DrZlo13 @hedger @aprosvetova
 
 # Documentation
 /documentation/ @skotopes @DrZlo13 @hedger @aprosvetova

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,63 +1,66 @@
 # Who owns all the fish by default
+* @skotopes @DrZlo13 @hedger
 
-* @skotopes @DrZlo13
+# Apps
+/applications/about/ @skotopes @DrZlo13 @hedger
+/applications/accessor/ @skotopes @DrZlo13 @hedger
+/applications/archive/ @skotopes @DrZlo13 @hedger @nminaylov
+/applications/bad_usb/ @skotopes @DrZlo13 @hedger @nminaylov
+/applications/bt/ @skotopes @DrZlo13 @hedger @gornekich
+/applications/cli/ @skotopes @DrZlo13 @hedger @nminaylov
+/applications/crypto/ @skotopes @DrZlo13 @hedger @nminaylov
+/applications/debug_tools/ @skotopes @DrZlo13 @hedger
+/applications/desktop/ @skotopes @DrZlo13 @hedger @nminaylov
+/applications/dialogs/ @skotopes @DrZlo13 @hedger
+/applications/dolphin/ @skotopes @DrZlo13 @hedger
+/applications/gpio/ @skotopes @DrZlo13 @hedger @nminaylov
+/applications/gui/ @skotopes @DrZlo13 @hedger
+/applications/ibutton/ @skotopes @DrZlo13 @hedger @gsurkov
+/applications/infrared/ @skotopes @DrZlo13 @hedger @gsurkov
+/applications/infrared_monitor/ @skotopes @DrZlo13 @hedger @gsurkov
+/applications/input/ @skotopes @DrZlo13 @hedger
+/applications/lfrfid/ @skotopes @DrZlo13 @hedger
+/applications/lfrfid_debug/ @skotopes @DrZlo13 @hedger
+/applications/loader/ @skotopes @DrZlo13 @hedger
+/applications/music_player/ @skotopes @DrZlo13 @hedger
+/applications/nfc/ @skotopes @DrZlo13 @hedger @gornekich
+/applications/notification/ @skotopes @DrZlo13 @hedger
+/applications/power/ @skotopes @DrZlo13 @hedger
+/applications/rpc/ @skotopes @DrZlo13 @hedger @nminaylov
+/applications/snake_game/ @skotopes @DrZlo13 @hedger
+/applications/storage/ @skotopes @DrZlo13 @hedger
+/applications/storage_settings/ @skotopes @DrZlo13 @hedger
+/applications/subghz/ @skotopes @DrZlo13 @hedger @Skorpionm
+/applications/system/ @skotopes @DrZlo13 @hedger
+/applications/u2f/ @skotopes @DrZlo13 @hedger @nminaylov
+/applications/unit_tests/ @skotopes @DrZlo13 @hedger
+/applications/updater/ @skotopes @DrZlo13 @hedger
 
-# Applications
-applications/** @skotopes @DrZlo13
-applications/accessor/** @skotopes @DrZlo13
-applications/loader/** @skotopes @DrZlo13 @gornekich
-applications/bt/** @skotopes @DrZlo13
-applications/cli/** @skotopes @DrZlo13
-applications/dolphin/** @skotopes @DrZlo13
-applications/gpio-tester/** @skotopes @DrZlo13
-applications/gui/** @skotopes @DrZlo13
-applications/gui-test/** @skotopes @DrZlo13
-applications/ibutton/** @skotopes @DrZlo13
-applications/input/** @skotopes @DrZlo13
-applications/infrared/** @skotopes @DrZlo13
-applications/lf-rfid/** @skotopes @DrZlo13
-applications/menu/** @skotopes @DrZlo13
-applications/music-player/** @skotopes @DrZlo13
-applications/nfc/** @skotopes @DrZlo13 @gornekich
-applications/power/** @skotopes @DrZlo13
-applications/sd-card-test/** @skotopes @DrZlo13
-applications/sd-filesystem/** @skotopes @DrZlo13
-applications/subghz/** @skotopes @DrZlo13
-applications/template/** @skotopes @DrZlo13
-applications/tests/** @skotopes @DrZlo13
-applications/updater/** @skotopes @DrZlo13 @hedger
+# Assets
+/assets/ @skotopes @DrZlo13 @hedger
 
-# Assets and asset generator
-assets/** @skotopes @DrZlo13
+# Furi Core
+/core/ @skotopes @DrZlo13 @hedger
 
-# Bootloader
-bootloader/** @skotopes @DrZlo13
+# Debug tools and plugins
+/debug/ @skotopes @DrZlo13 @hedger
 
-# Core, HAL and applocation loader
-core/** @skotopes @DrZlo13
+# Docker
+/docker/ @skotopes @DrZlo13 @hedger @aprosvetova
+docker-compose.yml @skotopes @DrZlo13 @hedger @aprosvetova
 
-# Debug tools
-debug/** @skotopes @DrZlo13
+# Documentation
+/documentation/ @skotopes @DrZlo13 @hedger @aprosvetova
 
-# Firmware
-firmware/** @skotopes @DrZlo13
+# Firmware targets
+/firmware/ @skotopes @DrZlo13 @hedger
 
 # Lib
-lib/app-template/** @skotopes @DrZlo13
-lib/callback-connector/** @skotopes @DrZlo13
-lib/common-api/** @skotopes @DrZlo13
-lib/cyfral/** @skotopes @DrZlo13
-lib/drivers/** @skotopes @DrZlo13 @gornekich
-lib/fatfs/** @skotopes @DrZlo13
-lib/fnv1a-hash/** @skotopes @DrZlo13
-lib/littlefs/** @skotopes @DrZlo13
-lib/mlib/** @skotopes @DrZlo13
-lib/onewire/** @skotopes @DrZlo13
-lib/qrcode/** @skotopes @DrZlo13
-lib/ST25RFAL002/** @skotopes @DrZlo13 @gornekich
-lib/STM32CubeWB/** @skotopes @DrZlo13
-lib/u8g2/** @skotopes @DrZlo13
-lib/version/** @skotopes @DrZlo13
+/lib/ST25RFAL002/** @skotopes @DrZlo13 @hedger @gornekich
+/lib/drivers/** @skotopes @DrZlo13 @hedger @gornekich
 
-# Make
-make/** @skotopes @DrZlo13
+# Make tools
+/make/ @skotopes @DrZlo13 @hedger @aprosvetova
+
+# Helper scripts
+/scripts/ @skotopes @DrZlo13 @hedger

--- a/applications/subghz/scenes/subghz_scene_read_raw.c
+++ b/applications/subghz/scenes/subghz_scene_read_raw.c
@@ -200,8 +200,6 @@ bool subghz_scene_read_raw_on_event(void* context, SceneManagerEvent event) {
                 }
                 if((subghz->txrx->txrx_state == SubGhzTxRxStateIDLE) ||
                    (subghz->txrx->txrx_state == SubGhzTxRxStateSleep)) {
-                    //ToDo FIX
-
                     if(!subghz_tx_start(subghz, subghz->txrx->fff_data)) {
                         scene_manager_next_scene(subghz->scene_manager, SubGhzSceneShowOnlyRx);
                     } else {

--- a/applications/subghz/scenes/subghz_scene_save_name.c
+++ b/applications/subghz/scenes/subghz_scene_save_name.c
@@ -39,12 +39,12 @@ void subghz_scene_save_name_on_enter(void* context) {
         path_extract_filename(subghz->file_path, file_name, true);
         if(scene_manager_get_scene_state(subghz->scene_manager, SubGhzSceneReadRAW) !=
            SubGhzCustomEventManagerNoSet) {
-            subghz_get_next_name_file(subghz, SUBGHZ_MAX_LEN_NAME);
-            path_extract_filename(subghz->file_path, file_name, true);
             if(scene_manager_get_scene_state(subghz->scene_manager, SubGhzSceneReadRAW) ==
                SubGhzCustomEventManagerSetRAW) {
                 dev_name_empty = true;
-            }
+                subghz_get_next_name_file(subghz, SUBGHZ_MAX_LEN_NAME);
+            } 
+            path_extract_filename(subghz->file_path, file_name, true);
         }
         string_set(subghz->file_path, dir_name);
     }

--- a/applications/subghz/scenes/subghz_scene_save_name.c
+++ b/applications/subghz/scenes/subghz_scene_save_name.c
@@ -43,7 +43,7 @@ void subghz_scene_save_name_on_enter(void* context) {
                SubGhzCustomEventManagerSetRAW) {
                 dev_name_empty = true;
                 subghz_get_next_name_file(subghz, SUBGHZ_MAX_LEN_NAME);
-            } 
+            }
             path_extract_filename(subghz->file_path, file_name, true);
         }
         string_set(subghz->file_path, dir_name);
@@ -72,7 +72,11 @@ void subghz_scene_save_name_on_enter(void* context) {
 bool subghz_scene_save_name_on_event(void* context, SceneManagerEvent event) {
     SubGhz* subghz = context;
     if(event.type == SceneManagerEventTypeBack) {
-        string_set(subghz->file_path, subghz->file_path_tmp);
+        if(!strcmp(subghz->file_name_tmp, "") ||
+           scene_manager_get_scene_state(subghz->scene_manager, SubGhzSceneReadRAW) !=
+               SubGhzCustomEventManagerNoSet) {
+            string_set(subghz->file_path, subghz->file_path_tmp);
+        }
         scene_manager_previous_scene(subghz->scene_manager);
         return true;
     } else if(event.type == SceneManagerEventTypeCustom) {


### PR DESCRIPTION
# What's new

- Sub-Ghz: With an empty subghz folder, go to AddManually select any key and press back on the name entry screen. Now if you go to saved, we open the root of the flash drive, and not the subghz folder
- Sub-Ghz: When renaming a RAW signal, a “1” always appears at the end

# Verification 

- Conduct validation testing of SubGhz

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
