### PR TITLE
Correct the typo in EMV app's code from "cad" to "card"

### DIFF
--- a/applications/nfc/scenes/nfc_scene_read_emv_data_success.c
+++ b/applications/nfc/scenes/nfc_scene_read_emv_data_success.c
@@ -37,7 +37,7 @@ void nfc_scene_read_emv_data_success_on_enter(void* context) {
     // Add card name
     widget_add_string_element(
         nfc->widget, 64, 3, AlignCenter, AlignTop, FontSecondary, nfc->dev->dev_data.emv_data.name);
-    // Add cad number
+    // Add card number
     string_t pan_str;
     string_init(pan_str);
     for(uint8_t i = 0; i < emv_data->number_len; i += 2) {


### PR DESCRIPTION
# What's new

- Comment on line 39 in the EMV data scene now says "card" as it should

# Verification 

- Look at the only edited line and confirm that it says "card" now :)

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
