### PR TITLE
[FL-2602] Infrared: Fix crash when messing with SD card

### DIFF
--- a/applications/infrared/infrared_brute_force.c
+++ b/applications/infrared/infrared_brute_force.c
@@ -99,6 +99,7 @@ bool infrared_brute_force_start(
         success = flipper_format_file_open_existing(brute_force->ff, brute_force->db_filename);
         if(!success) {
             flipper_format_free(brute_force->ff);
+            brute_force->ff = NULL;
             furi_record_close("storage");
         }
     }

--- a/applications/infrared/scenes/common/infrared_scene_universal_common.c
+++ b/applications/infrared/scenes/common/infrared_scene_universal_common.c
@@ -74,7 +74,7 @@ bool infrared_scene_universal_common_on_event(void* context, SceneManagerEvent e
                     infrared_play_notification_message(
                         infrared, InfraredNotificationMessageBlinkSend);
                 } else {
-                    scene_manager_previous_scene(scene_manager);
+                    scene_manager_next_scene(scene_manager, InfraredSceneErrorDatabases);
                 }
                 consumed = true;
             }


### PR DESCRIPTION
# What's new

- Do not crash on Infrared app exit if SD card was removed

# Verification 

1. Go to `Infrared -> Universal Remotes -> TVs`, wait for it to load
2. Remove SD card
3. Press any button. An error message will be displayed.
4. Exit the application. No crashes should occur.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
