### PR TITLE
[FL-2603] Infrared: exit app properly if ran from outside the launcher

### DIFF
--- a/applications/infrared/scenes/infrared_scene_remote.c
+++ b/applications/infrared/scenes/infrared_scene_remote.c
@@ -79,13 +79,8 @@ bool infrared_scene_remote_on_event(void* context, SceneManagerEvent event) {
 
     if(event.type == SceneManagerEventTypeBack) {
         const uint32_t possible_scenes[] = {InfraredSceneRemoteList, InfraredSceneStart};
-        const bool is_scene_found = scene_manager_search_and_switch_to_previous_scene_one_of(
+        consumed = scene_manager_search_and_switch_to_previous_scene_one_of(
             scene_manager, possible_scenes, sizeof(possible_scenes) / sizeof(uint32_t));
-        if(!is_scene_found) {
-            // Exit application if it was not run from launcher
-            view_dispatcher_stop(infrared->view_dispatcher);
-        }
-        consumed = true;
     } else if(event.type == SceneManagerEventTypeCustom) {
         const uint16_t custom_type = infrared_custom_event_get_type(event.event);
         const int16_t button_index = infrared_custom_event_get_value(event.event);

--- a/applications/infrared/scenes/infrared_scene_remote.c
+++ b/applications/infrared/scenes/infrared_scene_remote.c
@@ -79,8 +79,12 @@ bool infrared_scene_remote_on_event(void* context, SceneManagerEvent event) {
 
     if(event.type == SceneManagerEventTypeBack) {
         const uint32_t possible_scenes[] = {InfraredSceneRemoteList, InfraredSceneStart};
-        scene_manager_search_and_switch_to_previous_scene_one_of(
+        const bool is_scene_found = scene_manager_search_and_switch_to_previous_scene_one_of(
             scene_manager, possible_scenes, sizeof(possible_scenes) / sizeof(uint32_t));
+        if(!is_scene_found) {
+            // Exit application if it was not run from launcher
+            view_dispatcher_stop(infrared->view_dispatcher);
+        }
         consumed = true;
     } else if(event.type == SceneManagerEventTypeCustom) {
         const uint16_t custom_type = infrared_custom_event_get_type(event.event);


### PR DESCRIPTION
# What's new

- Make exiting the app possible if ran not from the launcher (e.g. from favourites)

# Verification 

1. Go to Favourites/Browser
2. Open an Infrared remote from it
3. When it loads, press Back button
4. The application should exit normally.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
