### PR TITLE
fbt: building `core` with respect for debug flag

### DIFF
--- a/applications/infrared/infrared_cli.c
+++ b/applications/infrared/infrared_cli.c
@@ -97,6 +97,7 @@ static bool infrared_cli_parse_message(const char* str, InfraredSignal* signal) 
         return false;
     }
 
+    message.protocol = infrared_get_protocol_by_name(protocol_name);
     message.repeat = false;
     infrared_signal_set_message(signal, &message);
     return infrared_signal_is_valid(signal);

--- a/firmware.scons
+++ b/firmware.scons
@@ -39,7 +39,17 @@ env = ENV.Clone(
             ],
             # You can add other entries named after libraries
             # If they are present, they have precedence over Default
-        }
+        },
+        # for furi_check to respect build type
+        "core": {
+            "CCFLAGS": [
+                "-Os",
+            ],
+            "CPPDEFINES": [
+                "NDEBUG",
+                "FURI_DEBUG" if ENV["DEBUG"] else "FURI_NDEBUG",
+            ],
+        },
     },
 )
 

--- a/firmware.scons
+++ b/firmware.scons
@@ -201,6 +201,7 @@ fwelf = fwenv["FW_ELF"] = fwenv.Program(
 # Make it depend on everything child builders returned
 Depends(fwelf, lib_targets)
 AddPostAction(fwelf, fwenv["APPBUILD_DUMP"])
+AddPostAction(fwelf, Action("@$SIZECOM"))
 
 
 fwhex = fwenv["FW_HEX"] = fwenv.HEXBuilder("${FIRMWARE_BUILD_CFG}")

--- a/site_scons/site_tools/crosscc.py
+++ b/site_scons/site_tools/crosscc.py
@@ -6,6 +6,7 @@ from SCons.Tool import gnulink
 import strip
 import gdb
 import objdump
+import size
 
 from SCons.Action import _subproc
 import subprocess
@@ -36,7 +37,7 @@ def _get_tool_version(env, tool):
 
 
 def generate(env, **kw):
-    for orig_tool in (asm, gcc, gxx, ar, gnulink, strip, gdb, objdump):
+    for orig_tool in (asm, gcc, gxx, ar, gnulink, strip, gdb, objdump, size):
         orig_tool.generate(env)
     env.SetDefault(
         TOOLCHAIN_PREFIX=kw.get("toolchain_prefix"),
@@ -55,6 +56,7 @@ def generate(env, **kw):
             "GDB",
             "GDBPY",
             "OBJDUMP",
+            "SIZE",
         ],
     )
     # Call CC to check version

--- a/site_scons/site_tools/fbt_dist.py
+++ b/site_scons/site_tools/fbt_dist.py
@@ -77,8 +77,7 @@ def generate(env):
         BUILDERS={
             "DistBuilder": Builder(
                 action=Action(
-                    '${PYTHON3} ${ROOT_DIR.abspath}/scripts/sconsdist.py copy -p ${DIST_PROJECTS} -s "${DIST_SUFFIX}" ${DIST_EXTRA}',
-                    "${DISTCOMSTR}",
+                    '@${PYTHON3} ${ROOT_DIR.abspath}/scripts/sconsdist.py copy -p ${DIST_PROJECTS} -s "${DIST_SUFFIX}" ${DIST_EXTRA}',
                 ),
             ),
             "CoproBuilder": Builder(

--- a/site_scons/site_tools/size.py
+++ b/site_scons/site_tools/size.py
@@ -1,0 +1,24 @@
+from SCons.Builder import Builder
+from SCons.Action import Action
+
+
+def generate(env):
+    env.SetDefault(
+        SIZE="size",
+        SIZEFLAGS=[],
+        SIZECOM="$SIZE $SIZEFLAGS $TARGETS",
+    )
+    env.Append(
+        BUILDERS={
+            "ELFSize": Builder(
+                action=Action(
+                    "${SIZECOM}",
+                    "${SIZECOMSTR}",
+                ),
+            ),
+        }
+    )
+
+
+def exists(env):
+    return True


### PR DESCRIPTION
# What's new

- furi_check now respects build type. Previously it always rebooted on assertion fail

# Verification 

- Put `    *(int*)(12345676) = 3;` anywhere in app startup code
- Build firmware in release and debug configurations
- Verify that debug build doesn't automatically reboot Flipper

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
