### PR TITLE
Auto detect raw

### DIFF
--- a/applications/subghz/scenes/subghz_scene_read_raw.c
+++ b/applications/subghz/scenes/subghz_scene_read_raw.c
@@ -99,6 +99,12 @@ void subghz_scene_read_raw_on_enter(void* context) {
         subghz->txrx->receiver, SUBGHZ_PROTOCOL_RAW_NAME);
     furi_assert(subghz->txrx->decoder_result);
 
+    // make sure we're not in auto-detect mode, which is only meant for the Read app
+    subghz_protocol_decoder_raw_set_auto_mode(
+        subghz->txrx->decoder_result,
+        false
+    );
+
     //set filter RAW feed
     subghz_receiver_set_filter(subghz->txrx->receiver, SubGhzProtocolFlag_RAW);
     view_dispatcher_switch_to_view(subghz->view_dispatcher, SubGhzViewIdReadRAW);

--- a/applications/subghz/scenes/subghz_scene_receiver.c
+++ b/applications/subghz/scenes/subghz_scene_receiver.c
@@ -108,13 +108,6 @@ void subghz_scene_receiver_on_enter(void* context) {
         subghz->txrx->preset = FuriHalSubGhzPresetOok650Async;
         subghz_history_reset(subghz->txrx->history);
         subghz->txrx->rx_key_state = SubGhzRxKeyStateStart;
-
-        subghz_receiver_set_filter(subghz->txrx->receiver, SubGhzProtocolFlag_Decodable | SubGhzProtocolFlag_RAW);
-
-        subghz_protocol_decoder_raw_set_auto_mode(
-            subghz_receiver_search_decoder_base_by_name(subghz->txrx->receiver, SUBGHZ_PROTOCOL_RAW_NAME),
-            true
-        );
     }
 
     subghz_view_receiver_set_lock(subghz->subghz_receiver, subghz->lock);

--- a/applications/subghz/scenes/subghz_scene_receiver.c
+++ b/applications/subghz/scenes/subghz_scene_receiver.c
@@ -1,6 +1,5 @@
 #include "../subghz_i.h"
 #include "../views/receiver.h"
-#include <lib/subghz/protocols/raw.h>
 
 static const NotificationSequence subghs_sequence_rx = {
     &message_green_255,

--- a/applications/subghz/scenes/subghz_scene_receiver.c
+++ b/applications/subghz/scenes/subghz_scene_receiver.c
@@ -1,5 +1,6 @@
 #include "../subghz_i.h"
 #include "../views/receiver.h"
+#include <lib/subghz/protocols/raw.h>
 
 static const NotificationSequence subghs_sequence_rx = {
     &message_green_255,
@@ -107,6 +108,15 @@ void subghz_scene_receiver_on_enter(void* context) {
         subghz->txrx->preset = FuriHalSubGhzPresetOok650Async;
         subghz_history_reset(subghz->txrx->history);
         subghz->txrx->rx_key_state = SubGhzRxKeyStateStart;
+
+        subghz_receiver_set_filter(subghz->txrx->receiver, SubGhzProtocolFlag_Decodable | SubGhzProtocolFlag_RAW);
+
+        subghz_protocol_decoder_raw_set_auto_mode(
+            subghz_receiver_search_decoder_base_by_name(subghz->txrx->receiver, SUBGHZ_PROTOCOL_RAW_NAME),
+            true,
+            subghz->txrx->frequency,
+            subghz->txrx->preset
+        );
     }
 
     subghz_view_receiver_set_lock(subghz->subghz_receiver, subghz->lock);

--- a/applications/subghz/scenes/subghz_scene_receiver.c
+++ b/applications/subghz/scenes/subghz_scene_receiver.c
@@ -113,9 +113,7 @@ void subghz_scene_receiver_on_enter(void* context) {
 
         subghz_protocol_decoder_raw_set_auto_mode(
             subghz_receiver_search_decoder_base_by_name(subghz->txrx->receiver, SUBGHZ_PROTOCOL_RAW_NAME),
-            true,
-            subghz->txrx->frequency,
-            subghz->txrx->preset
+            true
         );
     }
 

--- a/applications/subghz/scenes/subghz_scene_receiver_config.c
+++ b/applications/subghz/scenes/subghz_scene_receiver_config.c
@@ -143,9 +143,7 @@ static void subghz_scene_receiver_config_set_detect_raw(VariableItem* item) {
     subghz_receiver_set_filter(subghz->txrx->receiver, detect_raw_value[index]);
     subghz_protocol_decoder_raw_set_auto_mode(
         subghz_receiver_search_decoder_base_by_name(subghz->txrx->receiver, SUBGHZ_PROTOCOL_RAW_NAME),
-        (index == 1),
-        subghz->txrx->frequency,
-        subghz->txrx->preset
+        (index == 1)
     );
 }
 

--- a/applications/subghz/scenes/subghz_scene_receiver_config.c
+++ b/applications/subghz/scenes/subghz_scene_receiver_config.c
@@ -6,6 +6,7 @@ enum SubGhzSettingIndex {
     SubGhzSettingIndexFrequency,
     SubGhzSettingIndexHopping,
     SubGhzSettingIndexModulation,
+    SubGhzSettingIndexDetectRaw,
     SubGhzSettingIndexLock,
 };
 

--- a/applications/subghz/scenes/subghz_scene_receiver_config.c
+++ b/applications/subghz/scenes/subghz_scene_receiver_config.c
@@ -1,5 +1,7 @@
 #include "../subghz_i.h"
 
+#include <lib/subghz/protocols/raw.h>
+
 enum SubGhzSettingIndex {
     SubGhzSettingIndexFrequency,
     SubGhzSettingIndexHopping,
@@ -29,6 +31,16 @@ const char* const hopping_text[HOPPING_COUNT] = {
 const uint32_t hopping_value[HOPPING_COUNT] = {
     SubGhzHopperStateOFF,
     SubGhzHopperStateRunnig,
+};
+
+#define DETECT_RAW_COUNT 2
+const char* const detect_raw_text[DETECT_RAW_COUNT] = {
+    "OFF",
+    "ON",
+};
+const SubGhzProtocolFlag detect_raw_value[DETECT_RAW_COUNT] = {
+    SubGhzProtocolFlag_Decodable,
+    SubGhzProtocolFlag_Decodable | SubGhzProtocolFlag_RAW,
 };
 
 uint8_t subghz_scene_receiver_config_uint32_value_index(
@@ -82,6 +94,20 @@ uint8_t subghz_scene_receiver_config_hopper_value_index(
     }
 }
 
+uint8_t subghz_scene_receiver_config_detect_raw_value_index(
+    const SubGhzProtocolFlag value,
+    const SubGhzProtocolFlag values[],
+    uint8_t values_count) {
+    uint8_t index = 0;
+    for(uint8_t i = 0; i < values_count; i++) {
+        if(value == values[i]) {
+            index = i;
+            break;
+        }
+    }
+    return index;
+}
+
 static void subghz_scene_receiver_config_set_frequency(VariableItem* item) {
     SubGhz* subghz = variable_item_get_context(item);
     uint8_t index = variable_item_get_current_value_index(item);
@@ -107,6 +133,20 @@ static void subghz_scene_receiver_config_set_preset(VariableItem* item) {
 
     variable_item_set_current_value_text(item, preset_text[index]);
     subghz->txrx->preset = preset_value[index];
+}
+
+static void subghz_scene_receiver_config_set_detect_raw(VariableItem* item) {
+    SubGhz* subghz = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+
+    variable_item_set_current_value_text(item, detect_raw_text[index]);
+    subghz_receiver_set_filter(subghz->txrx->receiver, detect_raw_value[index]);
+    subghz_protocol_decoder_raw_set_auto_mode(
+        subghz_receiver_search_decoder_base_by_name(subghz->txrx->receiver, SUBGHZ_PROTOCOL_RAW_NAME),
+        (index == 1),
+        subghz->txrx->frequency,
+        subghz->txrx->preset
+    );
 }
 
 static void subghz_scene_receiver_config_set_hopping_runing(VariableItem* item) {
@@ -200,6 +240,20 @@ void subghz_scene_receiver_config_on_enter(void* context) {
         subghz->txrx->preset, preset_value, PRESET_COUNT);
     variable_item_set_current_value_index(item, value_index);
     variable_item_set_current_value_text(item, preset_text[value_index]);
+
+    if(scene_manager_get_scene_state(subghz->scene_manager, SubGhzSceneReadRAW) !=
+        SubGhzCustomEventManagerSet) {
+        item = variable_item_list_add(
+            subghz->variable_item_list,
+            "Detect Raw:",
+            DETECT_RAW_COUNT,
+            subghz_scene_receiver_config_set_detect_raw,
+            subghz);
+        value_index = subghz_scene_receiver_config_detect_raw_value_index(
+            subghz_receiver_get_filter(subghz->txrx->receiver), detect_raw_value, DETECT_RAW_COUNT);
+        variable_item_set_current_value_index(item, value_index);
+        variable_item_set_current_value_text(item, detect_raw_text[value_index]);
+    }
 
     if(scene_manager_get_scene_state(subghz->scene_manager, SubGhzSceneReadRAW) !=
        SubGhzCustomEventManagerSet) {

--- a/applications/subghz/subghz_history.c
+++ b/applications/subghz/subghz_history.c
@@ -168,7 +168,20 @@ bool subghz_history_add_to_history(
             FURI_LOG_E(TAG, "Missing Protocol");
             break;
         }
-        if(!strcmp(string_get_cstr(instance->tmp_string), "KeeLoq")) {
+        if(!strcmp(string_get_cstr(instance->tmp_string), "RAW")) {
+            string_printf(
+                item->item_str,
+                "RAW %03ld.%02ld",
+                frequency / 1000000 % 1000,
+                frequency / 10000 % 100);
+
+            if(!flipper_format_rewind(item->flipper_string)) {
+                FURI_LOG_E(TAG, "Rewind error");
+            }
+
+            break;
+        }
+        else if(!strcmp(string_get_cstr(instance->tmp_string), "KeeLoq")) {
             string_set_str(instance->tmp_string, "KL ");
             if(!flipper_format_read_string(item->flipper_string, "Manufacture", text)) {
                 FURI_LOG_E(TAG, "Missing Protocol");

--- a/applications/subghz/views/receiver.c
+++ b/applications/subghz/views/receiver.c
@@ -33,6 +33,7 @@ static const Icon* ReceiverItemIcons[] = {
     [SubGhzProtocolTypeUnknown] = &I_Quest_7x8,
     [SubGhzProtocolTypeStatic] = &I_Unlock_7x8,
     [SubGhzProtocolTypeDynamic] = &I_Lock_7x8,
+    [SubGhzProtocolTypeRAW] = &I_Unlock_7x8,
 };
 
 typedef enum {

--- a/lib/subghz/protocols/raw.h
+++ b/lib/subghz/protocols/raw.h
@@ -2,6 +2,8 @@
 
 #include "base.h"
 
+#include <furi_hal.h>
+
 #define SUBGHZ_PROTOCOL_RAW_NAME "RAW"
 
 typedef void (*SubGhzProtocolEncoderRAWCallbackEnd)(void* context);
@@ -34,6 +36,15 @@ bool subghz_protocol_raw_save_to_file_init(
 void subghz_protocol_raw_save_to_file_stop(SubGhzProtocolDecoderRAW* instance);
 
 /**
+ * Set SubGhzProtocolDecoderRAW to auto mode, which allows subghz_scene_receiver to capture RAW.
+ * @param context Pointer to a SubGhzProtocolDecoderRAW instance
+ * @param auto_mode Whether or not to enable auto mode
+ * @param frequency The current frequency
+ * @param preset The current FuriHalSubGhzPreset
+ */
+void subghz_protocol_decoder_raw_set_auto_mode(void* context, bool auto_mode, uint32_t frequency, FuriHalSubGhzPreset preset);
+
+/**
  * Get the number of samples received SubGhzProtocolDecoderRAW.
  * @param instance Pointer to a SubGhzProtocolDecoderRAW instance
  * @return count of samples
@@ -60,12 +71,27 @@ void subghz_protocol_decoder_raw_free(void* context);
 void subghz_protocol_decoder_raw_reset(void* context);
 
 /**
+ * Write raw data to the instance's internal buffer.
+ * @param context Pointer to a SubGhzProtocolDecoderRAW instance
+ * @param level Signal level true-high false-low
+ * @param duration Duration of this level in, us
+ */
+void subghz_protocol_decoder_raw_write_data(void* context, bool level, uint32_t duration);
+
+/**
  * Parse a raw sequence of levels and durations received from the air.
  * @param context Pointer to a SubGhzProtocolDecoderRAW instance
  * @param level Signal level true-high false-low
  * @param duration Duration of this level in, us
  */
 void subghz_protocol_decoder_raw_feed(void* context, bool level, uint32_t duration);
+
+/**
+ * Getting the hash sum of the last randomly received parcel.
+ * @param context Pointer to a SubGhzProtocolDecoderRAW instance
+ * @return hash Hash sum
+ */
+uint8_t subghz_protocol_decoder_raw_get_hash_data(void* context);
 
 /**
  * Getting a textual representation of the received data.
@@ -118,6 +144,20 @@ void subghz_protocol_raw_file_encoder_worker_set_callback_end(
 void subghz_protocol_raw_gen_fff_data(FlipperFormat* flipper_format, const char* file_path);
 
 /**
+ * Serialize data SubGhzProtocolDecoderRAW.
+ * @param context Pointer to a SubGhzProtocolDecoderRAW instance
+ * @param flipper_format Pointer to a FlipperFormat instance
+ * @param frequency The frequency at which the signal was received, Hz
+ * @param preset The modulation on which the signal was received, FuriHalSubGhzPreset
+ * @return true On success
+ */
+bool subghz_protocol_decoder_raw_serialize(
+    void* context,
+    FlipperFormat* flipper_format,
+    uint32_t frequency,
+    FuriHalSubGhzPreset preset);
+
+/**
  * Deserialize and generating an upload to send.
  * @param context Pointer to a SubGhzProtocolEncoderRAW instance
  * @param flipper_format Pointer to a FlipperFormat instance
@@ -128,6 +168,6 @@ bool subghz_protocol_encoder_raw_deserialize(void* context, FlipperFormat* flipp
 /**
  * Getting the level and duration of the upload to be loaded into DMA.
  * @param context Pointer to a SubGhzProtocolEncoderRAW instance
- * @return LevelDuration 
+ * @return LevelDuration
  */
 LevelDuration subghz_protocol_encoder_raw_yield(void* context);

--- a/lib/subghz/protocols/raw.h
+++ b/lib/subghz/protocols/raw.h
@@ -39,10 +39,8 @@ void subghz_protocol_raw_save_to_file_stop(SubGhzProtocolDecoderRAW* instance);
  * Set SubGhzProtocolDecoderRAW to auto mode, which allows subghz_scene_receiver to capture RAW.
  * @param context Pointer to a SubGhzProtocolDecoderRAW instance
  * @param auto_mode Whether or not to enable auto mode
- * @param frequency The current frequency
- * @param preset The current FuriHalSubGhzPreset
  */
-void subghz_protocol_decoder_raw_set_auto_mode(void* context, bool auto_mode, uint32_t frequency, FuriHalSubGhzPreset preset);
+void subghz_protocol_decoder_raw_set_auto_mode(void* context, bool auto_mode);
 
 /**
  * Get the number of samples received SubGhzProtocolDecoderRAW.

--- a/lib/subghz/protocols/raw.h
+++ b/lib/subghz/protocols/raw.h
@@ -73,8 +73,9 @@ void subghz_protocol_decoder_raw_reset(void* context);
  * @param context Pointer to a SubGhzProtocolDecoderRAW instance
  * @param level Signal level true-high false-low
  * @param duration Duration of this level in, us
+ * @return whether or not data was written
  */
-void subghz_protocol_decoder_raw_write_data(void* context, bool level, uint32_t duration);
+bool subghz_protocol_decoder_raw_write_data(void* context, bool level, uint32_t duration);
 
 /**
  * Parse a raw sequence of levels and durations received from the air.

--- a/lib/subghz/receiver.c
+++ b/lib/subghz/receiver.c
@@ -61,7 +61,7 @@ void subghz_receiver_decode(SubGhzReceiver* instance, bool level, uint32_t durat
 
     for
         M_EACH(slot, instance->slots, SubGhzReceiverSlotArray_t) {
-            if((slot->base->protocol->flag & instance->filter) == instance->filter) {
+            if((slot->base->protocol->flag & instance->filter) != 0) {
                 slot->base->protocol->decoder->feed(slot->base, level, duration);
             }
         }
@@ -103,6 +103,11 @@ void subghz_receiver_set_rx_callback(
 void subghz_receiver_set_filter(SubGhzReceiver* instance, SubGhzProtocolFlag filter) {
     furi_assert(instance);
     instance->filter = filter;
+}
+
+SubGhzProtocolFlag subghz_receiver_get_filter(SubGhzReceiver* instance) {
+    furi_assert(instance);
+    return instance->filter;
 }
 
 SubGhzProtocolDecoderBase* subghz_receiver_search_decoder_base_by_name(

--- a/lib/subghz/receiver.h
+++ b/lib/subghz/receiver.h
@@ -56,6 +56,13 @@ void subghz_receiver_set_rx_callback(
 void subghz_receiver_set_filter(SubGhzReceiver* instance, SubGhzProtocolFlag filter);
 
 /**
+ * Get the filter of receivers that will work at the moment.
+ * @param instance Pointer to a SubGhzReceiver instance
+ * @return filter Filter, SubGhzProtocolFlag
+ */
+SubGhzProtocolFlag subghz_receiver_get_filter(SubGhzReceiver* instance);
+
+/**
  * Search for a cattery by his name.
  * @param instance Pointer to a SubGhzReceiver instance
  * @param decoder_name Receiver name


### PR DESCRIPTION
# What's new

- Added ability to auto-detect raw signals in Sub-GHz -> Read

# Verification 

- Visit SubGHz -> Read, go to Config, and set Detect Raw to On, then back out of the config screen.  Play a signal from another device that the Flipper doesn't know the protocol for.  The raw signal should be detected and listed (e.g. "Raw 433.92") and you should be able to be save it. 

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
