### PR TITLE
Added Javacard Emulated mifare classic 1K compatibility

### DIFF
--- a/lib/nfc_protocols/mifare_classic.c
+++ b/lib/nfc_protocols/mifare_classic.c
@@ -198,7 +198,7 @@ static bool mf_classic_is_allowed_access(
 
 bool mf_classic_check_card_type(uint8_t ATQA0, uint8_t ATQA1, uint8_t SAK) {
     UNUSED(ATQA1);
-    if((ATQA0 == 0x44 || ATQA0 == 0x04) && (SAK == 0x08 || SAK == 0x88)) {
+    if((ATQA0 == 0x44 || ATQA0 == 0x04) && (SAK == 0x08 || SAK == 0x88 || SAK == 0x09)) {
         return true;
     } else if((ATQA0 == 0x42 || ATQA0 == 0x02) && (SAK == 0x18)) {
         return true;
@@ -219,7 +219,7 @@ bool mf_classic_get_type(
     furi_assert(reader);
     memset(reader, 0, sizeof(MfClassicReader));
 
-    if((ATQA0 == 0x44 || ATQA0 == 0x04) && (SAK == 0x08 || SAK == 0x88)) {
+    if((ATQA0 == 0x44 || ATQA0 == 0x04) && (SAK == 0x08 || SAK == 0x88 || SAK == 0x09)) {
         reader->type = MfClassicType1k;
     } else if((ATQA0 == 0x42 || ATQA0 == 0x02) && (SAK == 0x18)) {
         reader->type = MfClassicType4k;

--- a/lib/nfc_protocols/mifare_common.c
+++ b/lib/nfc_protocols/mifare_common.c
@@ -6,7 +6,7 @@ MifareType mifare_common_get_type(uint8_t ATQA0, uint8_t ATQA1, uint8_t SAK) {
     if((ATQA0 == 0x44) && (ATQA1 == 0x00) && (SAK == 0x00)) {
         type = MifareTypeUltralight;
     } else if(
-        ((ATQA0 == 0x44 || ATQA0 == 0x04) && (SAK == 0x08 || SAK == 0x88)) ||
+        ((ATQA0 == 0x44 || ATQA0 == 0x04) && (SAK == 0x08 || SAK == 0x88 || SAK == 0x09)) ||
         ((ATQA0 == 0x42 || ATQA0 == 0x02) && (SAK == 0x18))) {
         type = MifareTypeClassic;
     } else if(ATQA0 == 0x44 && ATQA1 == 0x03 && SAK == 0x20) {


### PR DESCRIPTION
# What's new

- Added support for reading mifare classic 1ks that have been emulated on java cards that have the non-standard SAK of 0x09

# Verification 

- Scan a Javacard emulated mifare classic (SmartMX etc)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
