### PR TITLE
Fix a race condition

### DIFF
--- a/lib/subghz/subghz_tx_rx_worker.c
+++ b/lib/subghz/subghz_tx_rx_worker.c
@@ -237,12 +237,12 @@ bool subghz_tx_rx_worker_start(SubGhzTxRxWorker* instance, uint32_t frequency) {
 
     instance->worker_running = true;
 
-    furi_thread_start(instance->thread);
-
     if(furi_hal_subghz_is_tx_allowed(frequency)) {
         instance->frequency = frequency;
         res = true;
     }
+
+    furi_thread_start(instance->thread);
 
     return res;
 }


### PR DESCRIPTION
# What's new

- Fixes a race condition that may cause the frequency variable to become 0 and break `furi_hal_subghz_set_frequency_and_path()`.

# Verification 

- Try repeatedly calling the worker and see if it crashes. 

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
