### PR TITLE
NFC: fix exit from Classic emulation

### DIFF
--- a/firmware/targets/f7/furi_hal/furi_hal_nfc.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_nfc.c
@@ -286,7 +286,8 @@ bool furi_hal_nfc_listen_rx(FuriHalNfcTxRxContext* tx_rx, uint32_t timeout_ms) {
             continue;
         }
         if(osKernelGetTickCount() - start > timeout_ms) {
-            FURI_LOG_D(TAG, "Interrupt waiting timeout");
+            FURI_LOG_T(TAG, "Interrupt waiting timeout");
+            osDelay(1);
             break;
         }
     }


### PR DESCRIPTION
# What's new

- Flipper don't freeze if many buttons are pressed during emulation

# Verification 

- Verify emulation exits correctly
- Verify emulation still works

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
