### PR TITLE
Fix ./fbt flash FORCE=1

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -145,6 +145,8 @@ distenv.Alias("copro_dist", copro_dist)
 
 firmware_flash = distenv.AddOpenOCDFlashTarget(firmware_env)
 distenv.Alias("flash", firmware_flash)
+if distenv["FORCE"]:
+    distenv.AlwaysBuild(firmware_flash)
 
 firmware_bm_flash = distenv.PhonyTarget(
     "flash_blackmagic",


### PR DESCRIPTION
# What's new

- Now the "Target flash is up to date" message is not shown when force flashing, and the FW gets actually flashed.

# Verification 

- Try running `./fbt flash`, watch it refuse to flash the board a second time
- Run `./fbt flash FORCE=1` multiple times and confirm it always flashes

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
