### PR TITLE
Enable building without Git

### DIFF
--- a/scripts/version.py
+++ b/scripts/version.py
@@ -6,6 +6,24 @@ import subprocess
 import os
 import json
 from datetime import date
+import os.path
+
+
+_version_info_keys = [
+    "GIT_COMMIT",
+    "GIT_BRANCH",
+    "GIT_BRANCH_NUM",
+    "VERSION",
+    "BUILD_DIRTY"
+]
+
+
+class EnvVersion:
+    def get_version_info(self):
+        return {
+            k: os.environ.get(k, "" if k != "BUILD_DIRTY" else 0)
+            for k in _version_info_keys
+        }
 
 
 class GitVersion:
@@ -76,7 +94,10 @@ class Main(App):
         self.parser_generate.set_defaults(func=self.generate)
 
     def generate(self):
-        current_info = GitVersion(self.args.sourcedir).get_version_info()
+        if os.path.exists(os.path.join(self.args.sourcedir, ".git")):
+            current_info = GitVersion(self.args.sourcedir).get_version_info()
+        else:
+            current_info = EnvVersion().get_version_info()
         current_info.update(
             {
                 "BUILD_DATE": date.today().strftime("%d-%m-%Y"),


### PR DESCRIPTION
# What's new
I want to build my Flipper firmware inside the [Nix](https://nixos.org/) build sandbox.

In this case the .git directory has been discarded by Nix for reproducibility reasons which currently causes the build to fail since
it cannot extract version information.

This can also be useful when building from source dumps such as automatically created Git archives.

The fallback when the Git repository is not available is to allow setting this information via environment variables.

# Verification 

- Verification will be contained in upcoming PR with Nix expressions.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
