### PR TITLE
Add Nix expressions to build firmware with Nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ build/
 
 # openocd output file
 openocd.log
+
+# Nix result symlinks
+result*

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,82 @@
+{ pkgs ? import <nixpkgs> { }
+, lib ? pkgs.lib
+, src ? lib.cleanSource ./.
+, version ? "dev"
+, rev ? let
+    gitRepo = "${toString src.origSrc or ""}/.git";
+    isGitRepo = lib.pathIsGitRepo gitRepo;
+  in
+  if isGitRepo then builtins.substring 0 8 (lib.commitIdFromGitRepo gitRepo) else ""
+}:
+
+let
+  inherit (builtins) elem elemAt match filter split readFile typeOf;
+  inherit (pkgs) stdenv lib;
+  inherit (lib) toLower;
+
+  ignoredPythonDeps = [
+    "python3-protobuf" # Doesn't seem to actually be required?
+  ];
+
+  pythonDeps = (
+    filter
+      (x: ! elem x ignoredPythonDeps)
+      (map
+        (x: toLower (elemAt (match "([A-Za-z0-9._-]+).+" x) 0))
+        (filter (line: typeOf line == "string" && line != "") (split "\n" (readFile ./scripts/requirements.txt))))
+  );
+
+  python = pkgs.python3.override {
+    self = python;
+
+    packageOverrides = self: super: {
+
+      heatshrink2 =
+        let
+          pname = "heatshrink2";
+          version = "0.11.0";
+        in
+        self.buildPythonPackage {
+          inherit pname version;
+          src = self.fetchPypi {
+            inherit pname version;
+            sha256 = "sha256-xihtHUuS+664Ow/YtfgxyTUNzRBG53blqqg9G+Q4Nfc=";
+          };
+        };
+
+    };
+  };
+
+  pythonEnv = python.withPackages (ps: map (x: ps.${x}) pythonDeps);
+
+in
+stdenv.mkDerivation {
+  pname = "flipperzero-firmware";
+  inherit version src;
+
+  GIT_COMMIT = rev;
+
+  nativeBuildInputs = [
+    pythonEnv
+    pkgs.gcc-arm-embedded
+    pkgs.imagemagick
+  ];
+
+  FBT_NOENV = true;
+  FBT_NO_SYNC = true;
+
+  dontConfigure = true;
+  dontFixup = true;
+
+  buildPhase = ''
+    runHook preBuild
+    ./fbt
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mv dist $out
+    runHook postInstall
+  '';
+}

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -6,6 +6,24 @@ import subprocess
 import os
 import json
 from datetime import date
+import os.path
+
+
+_version_info_keys = [
+    "GIT_COMMIT",
+    "GIT_BRANCH",
+    "GIT_BRANCH_NUM",
+    "VERSION",
+    "BUILD_DIRTY"
+]
+
+
+class EnvVersion:
+    def get_version_info(self):
+        return {
+            k: os.environ.get(k, "" if k != "BUILD_DIRTY" else 0)
+            for k in _version_info_keys
+        }
 
 
 class GitVersion:
@@ -76,7 +94,10 @@ class Main(App):
         self.parser_generate.set_defaults(func=self.generate)
 
     def generate(self):
-        current_info = GitVersion(self.args.sourcedir).get_version_info()
+        if os.path.exists(os.path.join(self.args.sourcedir, ".git")):
+            current_info = GitVersion(self.args.sourcedir).get_version_info()
+        else:
+            current_info = EnvVersion().get_version_info()
         current_info.update(
             {
                 "BUILD_DATE": date.today().strftime("%d-%m-%Y"),

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+(pkgs.callPackage ./default.nix {
+  src = null;
+}).overrideAttrs (old: {
+  FBT_NO_SYNC = false;
+
+  nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
+    pkgs.openocd
+    pkgs.dfu-util
+  ];
+})


### PR DESCRIPTION
# What's new
[Nix](https://nixos.org/) is distro & language agnostic package manager that can also be seen
as a meta build system.
This can be used to build on any Linux distro as long as the Nix
package manager is installed, and possibly also on MacOS though I
haven't tested this myself.

This is intended to be used either purely for building the firmware.
Building like this runs the build inside a sandbox.
- `$ nix-build ./.`

Or interactively using nix-shell:
- `$ nix-shell`
- `$ ./fbt firmware_flash`

# Verification 

- Run above steps.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
