### PR TITLE
Added condition to cli "log" command to end if serial terminal is disconnected.

### DIFF
--- a/applications/cli/cli.c
+++ b/applications/cli/cli.c
@@ -69,21 +69,24 @@ size_t cli_read_timeout(Cli* cli, uint8_t* buffer, size_t size, uint32_t timeout
     }
 }
 
-bool cli_cmd_interrupt_received(Cli* cli) {
-    furi_assert(cli);
-    char c = '\0';
-    if(cli->session != NULL) {
-        if(cli->session->rx((uint8_t*)&c, 1, 0) == 1) {
-            return c == CliSymbolAsciiETX;
-        }
-    }
-    return false;
-}
-
 bool cli_is_connected(Cli* cli) {
     furi_assert(cli);
     if(cli->session != NULL) {
         return (cli->session->is_connected());
+    }
+    return false;
+}
+
+bool cli_cmd_interrupt_received(Cli* cli) {
+    furi_assert(cli);
+    char c = '\0';
+    if(cli_is_connected(cli)) {
+        if(cli->session->rx((uint8_t*)&c, 1, 0) == 1) {
+            return c == CliSymbolAsciiETX;
+        }
+    }
+    else {
+        return true;
     }
     return false;
 }

--- a/applications/cli/cli.c
+++ b/applications/cli/cli.c
@@ -84,7 +84,8 @@ bool cli_cmd_interrupt_received(Cli* cli) {
         if(cli->session->rx((uint8_t*)&c, 1, 0) == 1) {
             return c == CliSymbolAsciiETX;
         }
-    } else {
+    }
+    else {
         return true;
     }
     return false;

--- a/applications/cli/cli.c
+++ b/applications/cli/cli.c
@@ -84,8 +84,7 @@ bool cli_cmd_interrupt_received(Cli* cli) {
         if(cli->session->rx((uint8_t*)&c, 1, 0) == 1) {
             return c == CliSymbolAsciiETX;
         }
-    }
-    else {
+    } else {
         return true;
     }
     return false;

--- a/applications/cli/cli_commands.c
+++ b/applications/cli/cli_commands.c
@@ -152,7 +152,7 @@ void cli_command_log(Cli* cli, string_t args, void* context) {
     furi_hal_console_set_tx_callback(cli_command_log_tx_callback, ring);
 
     printf("Press CTRL+C to stop...\r\n");
-    while(!cli_cmd_interrupt_received(cli)) {
+    while(!cli_cmd_interrupt_received(cli) && cli_is_connected(cli)) {
         size_t ret = xStreamBufferReceive(ring, buffer, CLI_COMMAND_LOG_BUFFER_SIZE, 50);
         cli_write(cli, buffer, ret);
     }

--- a/applications/cli/cli_commands.c
+++ b/applications/cli/cli_commands.c
@@ -152,7 +152,7 @@ void cli_command_log(Cli* cli, string_t args, void* context) {
     furi_hal_console_set_tx_callback(cli_command_log_tx_callback, ring);
 
     printf("Press CTRL+C to stop...\r\n");
-    while(!cli_cmd_interrupt_received(cli) && cli_is_connected(cli)) {
+    while(!cli_cmd_interrupt_received(cli)) {
         size_t ret = xStreamBufferReceive(ring, buffer, CLI_COMMAND_LOG_BUFFER_SIZE, 50);
         cli_write(cli, buffer, ret);
     }

--- a/applications/subghz/subghz_cli.c
+++ b/applications/subghz/subghz_cli.c
@@ -676,6 +676,11 @@ static void subghz_cli_command_chat(Cli* cli, string_t args) {
                 break;
             }
         }
+        if(cli_is_connected(cli)) {
+            printf("\r\n");
+            chat_event.event = SubGhzChatEventUserExit;
+            subghz_chat_worker_put_event_chat(subghz_chat, &chat_event);
+        }
     }
 
     string_clear(input);


### PR DESCRIPTION
# What's new

- If USB is disconnected while "log" command is running, it will end the command. This is a change in cli_commands.c under cli_command_log function.

# Verification 

One way to verify:
- Connect to cli using serial terminal over USB
- Run log cli command
- Disconnect USB while log is still running
- Reconnect USB and reconnect to serial terminal over USB
- User should be prompted with normal cli prompt instead of a running log command.

Second way to verify
- Connect to cli using serial terminal over USB
- Run log cli command
- Disconnect from serial terminal while log is still running
- Reconnect to serial terminal over USB
- User should be prompted with normal cli prompt instead of a running log command.

Additional Verification:
- User should still be able to end log command using Ctrl+C break.

Note:
- If the original functionality of cli_command_log is to keep running while the serial terminal is disconnected, please feel free to decline this PR.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
