### PR TITLE
Update docker-compose to add platform support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   dev:
+    platform: linux/x86_64
     image: flipperdevices/flipperzero-toolchain
     network_mode: host
     privileged: true


### PR DESCRIPTION
Trying to compile on Apple ARM without the platform information X86_64 in docker-compose result in an error:
`qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory `


# What's new

- Add platform parameter to be able for Apple ARM to compile with X86_64 library in Docker

# Verification 

- Test to compile on ARM device with the fix (tested and approved on my side)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
