### PR TITLE
Fix SubGHz chat immediately closing

### DIFF
--- a/applications/subghz/subghz_cli.c
+++ b/applications/subghz/subghz_cli.c
@@ -676,7 +676,7 @@ static void subghz_cli_command_chat(Cli* cli, string_t args) {
                 break;
             }
         }
-        if(cli_is_connected(cli)) {
+        if(!cli_is_connected(cli)) {
             printf("\r\n");
             chat_event.event = SubGhzChatEventUserExit;
             subghz_chat_worker_put_event_chat(subghz_chat, &chat_event);


### PR DESCRIPTION
It was just an if condition which should've been inverted

# What's new

- Fix for #1439

# Verification 

- Open cli and execute `subghz chat`, the application should stay open and function as expected
- While the chat application is open, close and reopen your serial terminal, the chat application should now be closed.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
