### PR TITLE
nfc: track progress through dictionary

### DIFF
--- a/applications/nfc/helpers/nfc_mf_classic_dict.c
+++ b/applications/nfc/helpers/nfc_mf_classic_dict.c
@@ -47,6 +47,16 @@ bool nfc_mf_classic_dict_get_next_key(Stream* stream, uint64_t* key) {
     return next_key_read;
 }
 
+uint32_t nfc_mf_classic_dict_get_key_count(Stream* stream) {
+    uint32_t count = 0;
+    uint64_t unused;
+    while (nfc_mf_classic_dict_get_next_key(stream, &unused)) {
+        count++;
+    }
+    nfc_mf_classic_dict_reset(stream);
+    return count;
+}
+
 void nfc_mf_classic_dict_reset(Stream* stream) {
     furi_assert(stream);
     stream_rewind(stream);

--- a/applications/nfc/helpers/nfc_mf_classic_dict.h
+++ b/applications/nfc/helpers/nfc_mf_classic_dict.h
@@ -12,4 +12,6 @@ void nfc_mf_classic_dict_close_file(Stream* stream);
 
 bool nfc_mf_classic_dict_get_next_key(Stream* stream, uint64_t* key);
 
+uint32_t nfc_mf_classic_dict_get_key_count(Stream* stream);
+
 void nfc_mf_classic_dict_reset(Stream* stream);

--- a/applications/nfc/nfc_device.h
+++ b/applications/nfc/nfc_device.h
@@ -44,7 +44,10 @@ typedef struct {
 typedef struct {
     FuriHalNfcDevData nfc_data;
     NfcProtocol protocol;
-    NfcReaderRequestData reader_data;
+    union {
+        NfcReaderRequestData reader_data;
+        uint32_t key_dict_size;
+    };
     union {
         EmvData emv_data;
         MfUltralightData mf_ul_data;

--- a/applications/nfc/nfc_worker.h
+++ b/applications/nfc/nfc_worker.h
@@ -35,6 +35,7 @@ typedef enum {
     NfcWorkerEventNoCardDetected,
     // Mifare Classic events
     NfcWorkerEventNoDictFound,
+    NfcWorkerEventDictProgress,
     NfcWorkerEventDetectedClassic1k,
     NfcWorkerEventDetectedClassic4k,
     NfcWorkerEventNewSector,

--- a/applications/nfc/scenes/nfc_scene_read_mifare_classic.c
+++ b/applications/nfc/scenes/nfc_scene_read_mifare_classic.c
@@ -22,6 +22,7 @@ void nfc_scene_read_mifare_classic_on_enter(void* context) {
 
     // Setup and start worker
     memset(&nfc->dev->dev_data.mf_classic_data, 0, sizeof(MfClassicData));
+    nfc->dev->dev_data.key_dict_size = 0;
     dict_attack_set_result_callback(
         nfc->dict_attack, nfc_read_mifare_classic_dict_attack_result_callback, nfc);
     scene_manager_set_scene_state(
@@ -54,7 +55,10 @@ bool nfc_scene_read_mifare_classic_on_event(void* context, SceneManagerEvent eve
             dict_attack_card_detected(nfc->dict_attack, MfClassicType4k);
             consumed = true;
         } else if(event.event == NfcWorkerEventNewSector) {
-            dict_attack_inc_curr_sector(nfc->dict_attack);
+            dict_attack_inc_curr_sector(nfc->dict_attack, nfc->dev->dev_data.key_dict_size);
+            consumed = true;
+        } else if(event.event == NfcWorkerEventDictProgress) {
+            dict_attack_inc_dict_index(nfc->dict_attack);
             consumed = true;
         } else if(event.event == NfcWorkerEventFoundKeyA) {
             dict_attack_inc_found_key(nfc->dict_attack, MfClassicKeyA);

--- a/applications/nfc/views/dict_attack.h
+++ b/applications/nfc/views/dict_attack.h
@@ -26,7 +26,9 @@ void dict_attack_card_detected(DictAttack* dict_attack, MfClassicType type);
 
 void dict_attack_card_removed(DictAttack* dict_attack);
 
-void dict_attack_inc_curr_sector(DictAttack* dict_attack);
+void dict_attack_inc_dict_index(DictAttack* dict_attack);
+
+void dict_attack_inc_curr_sector(DictAttack* dict_attack, uint32_t dict_size);
 
 void dict_attack_inc_found_key(DictAttack* dict_attack, MfClassicKey key);
 


### PR DESCRIPTION
# What's new

- Make mifare classic progressbar more interactive by taking number of keys in the dictionary into account

# Verification 

- Scan a mifare classic key for which the decryption key is not known and see that the progressbar moves even though the sector number doesn't change

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
