### PR TITLE
[FL-2682] Allow spaces in file names

### DIFF
--- a/lib/toolbox/path.c
+++ b/lib/toolbox/path.c
@@ -102,7 +102,7 @@ bool path_contains_only_ascii(const char* path) {
         } else if((*name_pos >= 'a') && (*name_pos <= 'z')) {
             name_pos++;
             continue;
-        } else if(strchr(".!#\\$%&'()-@^_`{}~", *name_pos) != NULL) {
+        } else if(strchr(" .!#\\$%&'()-@^_`{}~", *name_pos) != NULL) {
             name_pos++;
             continue;
         }


### PR DESCRIPTION
# What's new

- Spaces in file and directory names are now allowed.

# Verification 

- Use qFlipper or any other companion app to create directories and files with names that contain a space.
- Said files and directories should be created and displayed without errors.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
