### PR TITLE
Fixing a typo in Bug Report Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -10,7 +10,7 @@ body:
 - type: textarea
   id: description
   attributes:
-    label: Desctibe the bug.
+    label: Describe the bug.
     description: "A clear and concise description of what the bug is."
   validations:
     required: true


### PR DESCRIPTION
# What's new

- Fixed a typo in description of a template. Was "desctibe" instead of "describe" 

# Verification 

- Create new issue and verify that it has correct spelling in template

# Checklist (For Reviewer)

- [x] Description contains actions to verify feature/bugfix
