### PR TITLE
Fix git submodules update ignores FBT_NO_SYNC parameter

### DIFF
--- a/fbt.cmd
+++ b/fbt.cmd
@@ -11,7 +11,6 @@ if [%FBT_NO_SYNC%] == [] (
         exit /b 1
     )
 )
-git submodule update --init
 
 set "SCONS_DEFAULT_FLAGS=-Q --warn=target-not-built"
 python lib\scons\scripts\scons.py %SCONS_DEFAULT_FLAGS% %*


### PR DESCRIPTION
# What's new

- Fixes git submodules update ignores FBT_NO_SYNC parameter on Windows

# Verification 

- Run fbt.cmd on windows, then add env parameter FBT_NO_SYNC=1 and try again

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
