### PR TITLE
[FL-2688] Fix incorrect remote renaming behaviour

### DIFF
--- a/applications/infrared/infrared.c
+++ b/applications/infrared/infrared.c
@@ -307,6 +307,7 @@ bool infrared_rename_current_remote(Infrared* infrared, const char* name) {
     FS_Error status = storage_common_rename(
         storage, infrared_remote_get_path(remote), string_get_cstr(new_path));
     infrared_remote_set_name(remote, string_get_cstr(new_name));
+    infrared_remote_set_path(remote, string_get_cstr(new_path));
 
     string_clear(new_name);
     string_clear(new_path);


### PR DESCRIPTION
# What's new

- Remotes are now renamed correctly (path updates along with name)

# Verification 

- Go to `Infrared->Saved Remotes` and open any remote 
**OR** 
Go to `Infrared->Learn New Remote` and save at least one button
- Go to `Edit->Rename Remote` and rename it
- Press `+`, learn a new button and save it
- Go back to `Saved Remotes` menu and see result
- There will be only one remote with new name containing all the buttons.
 (see Jira bug description for unfixed behaviour)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
