### PR TITLE
Infrared.c: Dont Close GUI 2 times

### DIFF
--- a/applications/infrared/infrared.c
+++ b/applications/infrared/infrared.c
@@ -242,9 +242,6 @@ static void infrared_free(Infrared* infrared) {
     infrared_remote_free(infrared->remote);
     infrared_worker_free(infrared->worker);
 
-    furi_record_close(RECORD_GUI);
-    infrared->gui = NULL;
-
     furi_record_close(RECORD_NOTIFICATION);
     infrared->notifications = NULL;
 


### PR DESCRIPTION
# What's new

- GUI was being closed 2 times upon exit, this PR fixes that by removing 1 of those cases

# Verification 

- Test Infrared app

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
