### PR TITLE
[FL-2706, FL-2709] SubGhz: checking saved key files for length

### DIFF
--- a/applications/subghz/subghz_i.c
+++ b/applications/subghz/subghz_i.c
@@ -331,8 +331,10 @@ bool subghz_key_load(SubGhz* subghz, const char* file_path, bool show_dialog) {
         subghz->txrx->decoder_result = subghz_receiver_search_decoder_base_by_name(
             subghz->txrx->receiver, string_get_cstr(temp_str));
         if(subghz->txrx->decoder_result) {
-            subghz_protocol_decoder_base_deserialize(
-                subghz->txrx->decoder_result, subghz->txrx->fff_data);
+            if(!subghz_protocol_decoder_base_deserialize(
+                   subghz->txrx->decoder_result, subghz->txrx->fff_data)) {
+                break;
+            }
         } else {
             FURI_LOG_E(TAG, "Protocol not found");
             break;

--- a/applications/subghz/views/subghz_read_raw.c
+++ b/applications/subghz/views/subghz_read_raw.c
@@ -216,8 +216,8 @@ void subghz_read_raw_draw(Canvas* canvas, SubGhzReadRAWModel* model) {
     uint8_t graphics_mode = 1;
     canvas_set_color(canvas, ColorBlack);
     canvas_set_font(canvas, FontSecondary);
-    canvas_draw_str(canvas, 5, 8, string_get_cstr(model->frequency_str));
-    canvas_draw_str(canvas, 40, 8, string_get_cstr(model->preset_str));
+    canvas_draw_str(canvas, 5, 7, string_get_cstr(model->frequency_str));
+    canvas_draw_str(canvas, 40, 7, string_get_cstr(model->preset_str));
     canvas_draw_str_aligned(
         canvas, 126, 0, AlignRight, AlignTop, string_get_cstr(model->sample_write));
 

--- a/lib/subghz/protocols/came.c
+++ b/lib/subghz/protocols/came.c
@@ -145,7 +145,13 @@ bool subghz_protocol_encoder_came_deserialize(void* context, FlipperFormat* flip
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-
+        if((instance->generic.data_count_bit !=
+            subghz_protocol_came_const.min_count_bit_for_found) &&
+           (instance->generic.data_count_bit !=
+            2 * subghz_protocol_came_const.min_count_bit_for_found)) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
         //optional parameter parameter
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
@@ -293,7 +299,21 @@ bool subghz_protocol_decoder_came_serialize(
 bool subghz_protocol_decoder_came_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderCame* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if((instance->generic.data_count_bit !=
+            subghz_protocol_came_const.min_count_bit_for_found) &&
+           (instance->generic.data_count_bit !=
+            2 * subghz_protocol_came_const.min_count_bit_for_found)) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_came_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/came_atomo.c
+++ b/lib/subghz/protocols/came_atomo.c
@@ -310,7 +310,19 @@ bool subghz_protocol_decoder_came_atomo_serialize(
 bool subghz_protocol_decoder_came_atomo_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderCameAtomo* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_came_atomo_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_came_atomo_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/came_twee.c
+++ b/lib/subghz/protocols/came_twee.c
@@ -250,7 +250,11 @@ bool subghz_protocol_encoder_came_twee_deserialize(void* context, FlipperFormat*
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_came_twee_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
         //optional parameter parameter
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
@@ -427,7 +431,19 @@ bool subghz_protocol_decoder_came_twee_serialize(
 bool subghz_protocol_decoder_came_twee_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderCameTwee* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_came_twee_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_came_twee_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/chamberlain_code.c
+++ b/lib/subghz/protocols/chamberlain_code.c
@@ -215,7 +215,11 @@ bool subghz_protocol_encoder_chamb_code_deserialize(void* context, FlipperFormat
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-
+        if(instance->generic.data_count_bit <
+           subghz_protocol_chamb_code_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
         //optional parameter parameter
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
@@ -432,7 +436,19 @@ bool subghz_protocol_decoder_chamb_code_serialize(
 bool subghz_protocol_decoder_chamb_code_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderChamb_Code* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if(instance->generic.data_count_bit <
+           subghz_protocol_chamb_code_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_chamb_code_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/faac_slh.c
+++ b/lib/subghz/protocols/faac_slh.c
@@ -115,7 +115,7 @@ void subghz_protocol_decoder_faac_slh_feed(void* context, bool level, uint32_t d
             if(duration >= ((uint32_t)subghz_protocol_faac_slh_const.te_short * 3 +
                             subghz_protocol_faac_slh_const.te_delta)) {
                 instance->decoder.parser_step = FaacSLHDecoderStepFoundPreambula;
-                if(instance->decoder.decode_count_bit >=
+                if(instance->decoder.decode_count_bit ==
                    subghz_protocol_faac_slh_const.min_count_bit_for_found) {
                     instance->generic.data = instance->decoder.decode_data;
                     instance->generic.data_count_bit = instance->decoder.decode_count_bit;
@@ -192,7 +192,19 @@ bool subghz_protocol_decoder_faac_slh_serialize(
 bool subghz_protocol_decoder_faac_slh_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderFaacSLH* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_faac_slh_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_faac_slh_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/gate_tx.c
+++ b/lib/subghz/protocols/gate_tx.c
@@ -138,7 +138,11 @@ bool subghz_protocol_encoder_gate_tx_deserialize(void* context, FlipperFormat* f
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_gate_tx_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
         //optional parameter parameter
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
@@ -298,7 +302,19 @@ bool subghz_protocol_decoder_gate_tx_serialize(
 bool subghz_protocol_decoder_gate_tx_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderGateTx* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_gate_tx_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_gate_tx_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/holtek.c
+++ b/lib/subghz/protocols/holtek.c
@@ -151,7 +151,11 @@ bool subghz_protocol_encoder_holtek_deserialize(void* context, FlipperFormat* fl
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_holtek_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
         //optional parameter parameter
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
@@ -331,7 +335,19 @@ bool subghz_protocol_decoder_holtek_serialize(
 bool subghz_protocol_decoder_holtek_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderHoltek* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_holtek_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_holtek_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/hormann.c
+++ b/lib/subghz/protocols/hormann.c
@@ -154,7 +154,11 @@ bool subghz_protocol_encoder_hormann_deserialize(void* context, FlipperFormat* f
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_hormann_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
         //optional parameter parameter
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
@@ -319,7 +323,19 @@ bool subghz_protocol_decoder_hormann_serialize(
 bool subghz_protocol_decoder_hormann_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderHormann* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_hormann_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_hormann_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/ido.c
+++ b/lib/subghz/protocols/ido.c
@@ -191,7 +191,18 @@ bool subghz_protocol_decoder_ido_serialize(
 bool subghz_protocol_decoder_ido_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderIDo* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if(instance->generic.data_count_bit != subghz_protocol_ido_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_ido_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/keeloq.c
+++ b/lib/subghz/protocols/keeloq.c
@@ -264,7 +264,11 @@ bool subghz_protocol_encoder_keeloq_deserialize(void* context, FlipperFormat* fl
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_keeloq_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
         subghz_protocol_keeloq_check_remote_controller(
             &instance->generic, instance->keystore, &instance->manufacture_name);
 
@@ -654,6 +658,11 @@ bool subghz_protocol_decoder_keeloq_deserialize(void* context, FlipperFormat* fl
     do {
         if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
             FURI_LOG_E(TAG, "Deserialize error");
+            break;
+        }
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_keeloq_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
             break;
         }
         res = true;

--- a/lib/subghz/protocols/kia.c
+++ b/lib/subghz/protocols/kia.c
@@ -12,7 +12,7 @@ static const SubGhzBlockConst subghz_protocol_kia_const = {
     .te_short = 250,
     .te_long = 500,
     .te_delta = 100,
-    .min_count_bit_for_found = 60,
+    .min_count_bit_for_found = 61,
 };
 
 struct SubGhzProtocolDecoderKIA {
@@ -145,7 +145,7 @@ void subghz_protocol_decoder_kia_feed(void* context, bool level, uint32_t durati
                (uint32_t)(subghz_protocol_kia_const.te_long + subghz_protocol_kia_const.te_delta * 2)) {
                 //Found stop bit
                 instance->decoder.parser_step = KIADecoderStepReset;
-                if(instance->decoder.decode_count_bit >=
+                if(instance->decoder.decode_count_bit ==
                    subghz_protocol_kia_const.min_count_bit_for_found) {
                     instance->generic.data = instance->decoder.decode_data;
                     instance->generic.data_count_bit = instance->decoder.decode_count_bit;
@@ -242,7 +242,18 @@ bool subghz_protocol_decoder_kia_serialize(
 bool subghz_protocol_decoder_kia_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderKIA* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if(instance->generic.data_count_bit != subghz_protocol_kia_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_kia_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/linear.c
+++ b/lib/subghz/protocols/linear.c
@@ -156,7 +156,11 @@ bool subghz_protocol_encoder_linear_deserialize(void* context, FlipperFormat* fl
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_linear_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
         //optional parameter parameter
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
@@ -308,7 +312,19 @@ bool subghz_protocol_decoder_linear_serialize(
 bool subghz_protocol_decoder_linear_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderLinear* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_linear_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_linear_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/megacode.c
+++ b/lib/subghz/protocols/megacode.c
@@ -184,7 +184,11 @@ bool subghz_protocol_encoder_megacode_deserialize(void* context, FlipperFormat* 
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_megacode_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
         //optional parameter parameter
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
@@ -270,7 +274,7 @@ void subghz_protocol_decoder_megacode_feed(void* context, bool level, uint32_t d
         if(!level) { //save interval
             if(duration >= (subghz_protocol_megacode_const.te_short * 10)) {
                 instance->decoder.parser_step = MegaCodeDecoderStepReset;
-                if(instance->decoder.decode_count_bit >=
+                if(instance->decoder.decode_count_bit ==
                    subghz_protocol_megacode_const.min_count_bit_for_found) {
                     instance->generic.data = instance->decoder.decode_data;
                     instance->generic.data_count_bit = instance->decoder.decode_count_bit;
@@ -389,7 +393,19 @@ bool subghz_protocol_decoder_megacode_serialize(
 bool subghz_protocol_decoder_megacode_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderMegaCode* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_megacode_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_megacode_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/nero_radio.c
+++ b/lib/subghz/protocols/nero_radio.c
@@ -163,7 +163,11 @@ bool subghz_protocol_encoder_nero_radio_deserialize(void* context, FlipperFormat
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_nero_radio_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
         //optional parameter parameter
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
@@ -294,7 +298,7 @@ void subghz_protocol_decoder_nero_radio_feed(void* context, bool level, uint32_t
                     subghz_protocol_blocks_add_bit(&instance->decoder, 1);
                 }
                 instance->decoder.parser_step = NeroRadioDecoderStepReset;
-                if(instance->decoder.decode_count_bit >=
+                if(instance->decoder.decode_count_bit ==
                    subghz_protocol_nero_radio_const.min_count_bit_for_found) {
                     instance->generic.data = instance->decoder.decode_data;
                     instance->generic.data_count_bit = instance->decoder.decode_count_bit;
@@ -351,7 +355,19 @@ bool subghz_protocol_decoder_nero_radio_serialize(
 bool subghz_protocol_decoder_nero_radio_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderNeroRadio* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_nero_radio_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_nero_radio_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/nero_sketch.c
+++ b/lib/subghz/protocols/nero_sketch.c
@@ -157,7 +157,11 @@ bool subghz_protocol_encoder_nero_sketch_deserialize(void* context, FlipperForma
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_nero_sketch_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
         //optional parameter parameter
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
@@ -271,7 +275,7 @@ void subghz_protocol_decoder_nero_sketch_feed(void* context, bool level, uint32_
                             subghz_protocol_nero_sketch_const.te_delta * 2)) {
                 //Found stop bit
                 instance->decoder.parser_step = NeroSketchDecoderStepReset;
-                if(instance->decoder.decode_count_bit >=
+                if(instance->decoder.decode_count_bit ==
                    subghz_protocol_nero_sketch_const.min_count_bit_for_found) {
                     instance->generic.data = instance->decoder.decode_data;
                     instance->generic.data_count_bit = instance->decoder.decode_count_bit;
@@ -336,7 +340,19 @@ bool subghz_protocol_decoder_nero_sketch_serialize(
 bool subghz_protocol_decoder_nero_sketch_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderNeroSketch* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_nero_sketch_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_nero_sketch_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/nice_flo.c
+++ b/lib/subghz/protocols/nice_flo.c
@@ -138,7 +138,13 @@ bool subghz_protocol_encoder_nice_flo_deserialize(void* context, FlipperFormat* 
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-
+        if((instance->generic.data_count_bit !=
+            subghz_protocol_nice_flo_const.min_count_bit_for_found) &&
+           (instance->generic.data_count_bit !=
+            2 * subghz_protocol_nice_flo_const.min_count_bit_for_found)) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
         //optional parameter parameter
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
@@ -286,7 +292,21 @@ bool subghz_protocol_decoder_nice_flo_serialize(
 bool subghz_protocol_decoder_nice_flo_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderNiceFlo* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if((instance->generic.data_count_bit !=
+            subghz_protocol_nice_flo_const.min_count_bit_for_found) &&
+           (instance->generic.data_count_bit !=
+            2 * subghz_protocol_nice_flo_const.min_count_bit_for_found)) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_nice_flo_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/nice_flor_s.c
+++ b/lib/subghz/protocols/nice_flor_s.c
@@ -339,7 +339,7 @@ bool subghz_protocol_decoder_nice_flor_s_serialize(
 bool subghz_protocol_decoder_nice_flor_s_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderNiceFlorS* instance = context;
-   bool ret = false;
+    bool ret = false;
     do {
         if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
             break;

--- a/lib/subghz/protocols/nice_flor_s.c
+++ b/lib/subghz/protocols/nice_flor_s.c
@@ -237,7 +237,7 @@ void subghz_protocol_decoder_nice_flor_s_feed(void* context, bool level, uint32_
                subghz_protocol_nice_flor_s_const.te_delta) {
                 //Found STOP bit
                 instance->decoder.parser_step = NiceFlorSDecoderStepReset;
-                if(instance->decoder.decode_count_bit >=
+                if(instance->decoder.decode_count_bit ==
                    subghz_protocol_nice_flor_s_const.min_count_bit_for_found) {
                     instance->generic.data = instance->decoder.decode_data;
                     instance->generic.data_count_bit = instance->decoder.decode_count_bit;
@@ -339,7 +339,19 @@ bool subghz_protocol_decoder_nice_flor_s_serialize(
 bool subghz_protocol_decoder_nice_flor_s_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderNiceFlorS* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+   bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_nice_flor_s_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_nice_flor_s_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/power_smart.c
+++ b/lib/subghz/protocols/power_smart.c
@@ -201,7 +201,11 @@ bool subghz_protocol_encoder_power_smart_deserialize(void* context, FlipperForma
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_power_smart_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
         //optional parameter parameter
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
@@ -354,7 +358,19 @@ bool subghz_protocol_decoder_power_smart_serialize(
 bool subghz_protocol_decoder_power_smart_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderPowerSmart* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_power_smart_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_power_smart_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/princeton.c
+++ b/lib/subghz/protocols/princeton.c
@@ -158,6 +158,11 @@ bool subghz_protocol_encoder_princeton_deserialize(void* context, FlipperFormat*
             FURI_LOG_E(TAG, "Missing TE");
             break;
         }
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_princeton_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
         //optional parameter parameter
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
@@ -318,6 +323,11 @@ bool subghz_protocol_decoder_princeton_deserialize(void* context, FlipperFormat*
     do {
         if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
             FURI_LOG_E(TAG, "Deserialize error");
+            break;
+        }
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_princeton_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
             break;
         }
         if(!flipper_format_rewind(flipper_format)) {

--- a/lib/subghz/protocols/raw.c
+++ b/lib/subghz/protocols/raw.c
@@ -57,6 +57,7 @@ const SubGhzProtocolDecoder subghz_protocol_raw_decoder = {
 
     .get_hash_data = NULL,
     .serialize = NULL,
+    .deserialize = subghz_protocol_decoder_raw_deserialize,
     .get_string = subghz_protocol_decoder_raw_get_string,
 };
 
@@ -246,9 +247,18 @@ void subghz_protocol_decoder_raw_feed(void* context, bool level, uint32_t durati
     }
 }
 
+bool subghz_protocol_decoder_raw_deserialize(void* context, FlipperFormat* flipper_format) {
+    furi_assert(context);
+    UNUSED(context);
+    UNUSED(flipper_format);
+    //ToDo stub, for backwards compatibility
+    return true;
+}
+
 void subghz_protocol_decoder_raw_get_string(void* context, string_t output) {
     furi_assert(context);
     //SubGhzProtocolDecoderRAW* instance = context;
+    UNUSED(context);
     //ToDo no use
     string_cat_printf(output, "RAW Date");
 }

--- a/lib/subghz/protocols/raw.h
+++ b/lib/subghz/protocols/raw.h
@@ -66,6 +66,14 @@ void subghz_protocol_decoder_raw_reset(void* context);
 void subghz_protocol_decoder_raw_feed(void* context, bool level, uint32_t duration);
 
 /**
+ * Deserialize data SubGhzProtocolDecoderRAW.
+ * @param context Pointer to a SubGhzProtocolDecoderRAW instance
+ * @param flipper_format Pointer to a FlipperFormat instance
+ * @return true On success
+ */
+bool subghz_protocol_decoder_raw_deserialize(void* context, FlipperFormat* flipper_format);
+
+/**
  * Getting a textual representation of the received data.
  * @param context Pointer to a SubGhzProtocolDecoderRAW instance
  * @param output Resulting text

--- a/lib/subghz/protocols/secplus_v1.c
+++ b/lib/subghz/protocols/secplus_v1.c
@@ -273,7 +273,11 @@ bool subghz_protocol_encoder_secplus_v1_deserialize(void* context, FlipperFormat
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-
+        if(instance->generic.data_count_bit !=
+           2 * subghz_protocol_secplus_v1_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
         //optional parameter parameter
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
@@ -524,7 +528,19 @@ bool subghz_protocol_decoder_secplus_v1_serialize(
 bool subghz_protocol_decoder_secplus_v1_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderSecPlus_v1* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if(instance->generic.data_count_bit !=
+           2 * subghz_protocol_secplus_v1_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 bool subghz_protocol_secplus_v1_check_fixed(uint32_t fixed) {

--- a/lib/subghz/protocols/secplus_v2.c
+++ b/lib/subghz/protocols/secplus_v2.c
@@ -514,7 +514,11 @@ bool subghz_protocol_encoder_secplus_v2_deserialize(void* context, FlipperFormat
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_secplus_v2_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
         uint8_t key_data[sizeof(uint64_t)] = {0};
         if(!flipper_format_read_hex(
                flipper_format, "Secplus_packet_1", key_data, sizeof(uint64_t))) {
@@ -689,7 +693,7 @@ void subghz_protocol_decoder_secplus_v2_feed(void* context, bool level, uint32_t
             } else if(
                 duration >= (uint32_t)(subghz_protocol_secplus_v2_const.te_long * 2 +
                              subghz_protocol_secplus_v2_const.te_delta)) {
-                if(instance->decoder.decode_count_bit >=
+                if(instance->decoder.decode_count_bit ==
                    subghz_protocol_secplus_v2_const.min_count_bit_for_found) {
                     instance->generic.data = instance->decoder.decode_data;
                     instance->generic.data_count_bit = instance->decoder.decode_count_bit;
@@ -780,6 +784,11 @@ bool subghz_protocol_decoder_secplus_v2_deserialize(void* context, FlipperFormat
     do {
         if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
             FURI_LOG_E(TAG, "Deserialize error");
+            break;
+        }
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_secplus_v2_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
             break;
         }
         if(!flipper_format_rewind(flipper_format)) {

--- a/lib/subghz/protocols/somfy_keytis.c
+++ b/lib/subghz/protocols/somfy_keytis.c
@@ -403,7 +403,7 @@ bool subghz_protocol_decoder_somfy_keytis_deserialize(void* context, FlipperForm
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-         if(instance->generic.data_count_bit !=
+        if(instance->generic.data_count_bit !=
            subghz_protocol_somfy_keytis_const.min_count_bit_for_found) {
             FURI_LOG_E(TAG, "Wrong number of bits in key");
             break;

--- a/lib/subghz/protocols/somfy_keytis.c
+++ b/lib/subghz/protocols/somfy_keytis.c
@@ -403,6 +403,11 @@ bool subghz_protocol_decoder_somfy_keytis_deserialize(void* context, FlipperForm
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
+         if(instance->generic.data_count_bit !=
+           subghz_protocol_somfy_keytis_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
         if(!flipper_format_rewind(flipper_format)) {
             FURI_LOG_E(TAG, "Rewind error");
             break;

--- a/lib/subghz/protocols/somfy_telis.c
+++ b/lib/subghz/protocols/somfy_telis.c
@@ -348,7 +348,19 @@ bool subghz_protocol_decoder_somfy_telis_serialize(
 bool subghz_protocol_decoder_somfy_telis_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderSomfyTelis* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    bool ret = false;
+    do {
+        if(!subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+            break;
+        }
+        if(instance->generic.data_count_bit !=
+           subghz_protocol_somfy_telis_const.min_count_bit_for_found) {
+            FURI_LOG_E(TAG, "Wrong number of bits in key");
+            break;
+        }
+        ret = true;
+    } while(false);
+    return ret;
 }
 
 void subghz_protocol_decoder_somfy_telis_get_string(void* context, string_t output) {

--- a/lib/subghz/protocols/star_line.c
+++ b/lib/subghz/protocols/star_line.c
@@ -332,6 +332,11 @@ bool subghz_protocol_decoder_star_line_serialize(
         FURI_LOG_E(TAG, "Unable to add manufacture name");
         res = false;
     }
+    if(res && instance->generic.data_count_bit !=
+                  subghz_protocol_star_line_const.min_count_bit_for_found) {
+        FURI_LOG_E(TAG, "Wrong number of bits in key");
+        res = false;
+    }
     return res;
 }
 


### PR DESCRIPTION
# What's new

- [FL-2706] SubGhz: checking saved key files for length
- [FL-2709] GubGhz: RAW screen fix

# Verification 

- create a custom remote in "Add Manually" and cut the bit: field to the wrong value. and try to play it, a window should appear that it is not possible to parse the file

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-2706]: https://flipperzero.atlassian.net/browse/FL-2706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FL-2709]: https://flipperzero.atlassian.net/browse/FL-2709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ