### PR TITLE
Fix Mifare DESFire Recognization

### DIFF
--- a/lib/nfc/protocols/mifare_common.c
+++ b/lib/nfc/protocols/mifare_common.c
@@ -9,7 +9,7 @@ MifareType mifare_common_get_type(uint8_t ATQA0, uint8_t ATQA1, uint8_t SAK) {
         ((ATQA0 == 0x44 || ATQA0 == 0x04) && (SAK == 0x08 || SAK == 0x88 || SAK == 0x09)) ||
         ((ATQA0 == 0x42 || ATQA0 == 0x02) && (SAK == 0x18))) {
         type = MifareTypeClassic;
-    } else if(ATQA0 == 0x44 && ATQA1 == 0x03 && SAK == 0x20) {
+    } else if((ATQA0 == 0x44 || ATQA1 == 0x03) && (SAK == 0x20)) {
         type = MifareTypeDesfire;
     }
 


### PR DESCRIPTION
# What's new

I made this PR because i was doing a fix for Skylanders futur PR (Reference: https://github.com/flipperdevices/flipperzero-firmware/pull/1497)

I noticed that the DESFire had the same syntax as skylanders before my change. After opening discord, i noticed an user that wasnt able to read is DESFire tag anymore with the newest update.

Maybe this change should fix, but i didn't have any DESFire stuff to test, i put this in your hand :P

# Verification 

- Look if DESFire is recognized and didnt display UID only

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
