### PR TITLE
Core, logs: removed tag concatenation

### DIFF
--- a/furi/core/log.c
+++ b/furi/core/log.c
@@ -22,6 +22,63 @@ void furi_log_init() {
     furi_log.mutex = furi_mutex_alloc(FuriMutexTypeNormal);
 }
 
+void furi_log_print_format(FuriLogLevel level, const char* tag, const char* format, ...) {
+    if(level <= furi_log.log_level &&
+       furi_mutex_acquire(furi_log.mutex, FuriWaitForever) == FuriStatusOk) {
+        string_t string;
+
+        const char* color = FURI_LOG_CLR_RESET;
+        const char* log_letter = " ";
+        switch(level) {
+        case FuriLogLevelError:
+            color = FURI_LOG_CLR_E;
+            log_letter = "E";
+            break;
+        case FuriLogLevelWarn:
+            color = FURI_LOG_CLR_W;
+            log_letter = "W";
+            break;
+        case FuriLogLevelInfo:
+            color = FURI_LOG_CLR_I;
+            log_letter = "I";
+            break;
+        case FuriLogLevelDebug:
+            color = FURI_LOG_CLR_D;
+            log_letter = "D";
+            break;
+        case FuriLogLevelTrace:
+            color = FURI_LOG_CLR_T;
+            log_letter = "T";
+            break;
+        default:
+            break;
+        }
+
+        // Timestamp
+        string_init_printf(
+            string,
+            "%lu %s[%s][%s] " FURI_LOG_CLR_RESET,
+            furi_log.timetamp(),
+            color,
+            log_letter,
+            tag);
+        furi_log.puts(string_get_cstr(string));
+        string_clear(string);
+
+        va_list args;
+        va_start(args, format);
+        string_init_vprintf(string, format, args);
+        va_end(args);
+
+        furi_log.puts(string_get_cstr(string));
+        string_clear(string);
+
+        furi_log.puts("\r\n");
+
+        furi_mutex_release(furi_log.mutex);
+    }
+}
+
 void furi_log_print(FuriLogLevel level, const char* format, ...) {
     if(level <= furi_log.log_level &&
        furi_mutex_acquire(furi_log.mutex, FuriWaitForever) == FuriStatusOk) {

--- a/furi/core/log.c
+++ b/furi/core/log.c
@@ -26,6 +26,7 @@ void furi_log_print_format(FuriLogLevel level, const char* tag, const char* form
     if(level <= furi_log.log_level &&
        furi_mutex_acquire(furi_log.mutex, FuriWaitForever) == FuriStatusOk) {
         string_t string;
+        string_init(string);
 
         const char* color = FURI_LOG_CLR_RESET;
         const char* log_letter = " ";
@@ -55,7 +56,7 @@ void furi_log_print_format(FuriLogLevel level, const char* tag, const char* form
         }
 
         // Timestamp
-        string_init_printf(
+        string_printf(
             string,
             "%lu %s[%s][%s] " FURI_LOG_CLR_RESET,
             furi_log.timetamp(),
@@ -63,11 +64,11 @@ void furi_log_print_format(FuriLogLevel level, const char* tag, const char* form
             log_letter,
             tag);
         furi_log.puts(string_get_cstr(string));
-        string_clear(string);
+        string_reset(string);
 
         va_list args;
         va_start(args, format);
-        string_init_vprintf(string, format, args);
+        string_vprintf(string, format, args);
         va_end(args);
 
         furi_log.puts(string_get_cstr(string));

--- a/furi/core/log.c
+++ b/furi/core/log.c
@@ -79,28 +79,6 @@ void furi_log_print_format(FuriLogLevel level, const char* tag, const char* form
     }
 }
 
-void furi_log_print(FuriLogLevel level, const char* format, ...) {
-    if(level <= furi_log.log_level &&
-       furi_mutex_acquire(furi_log.mutex, FuriWaitForever) == FuriStatusOk) {
-        string_t string;
-
-        // Timestamp
-        string_init_printf(string, "%lu ", furi_log.timetamp());
-        furi_log.puts(string_get_cstr(string));
-        string_clear(string);
-
-        va_list args;
-        va_start(args, format);
-        string_init_vprintf(string, format, args);
-        va_end(args);
-
-        furi_log.puts(string_get_cstr(string));
-        string_clear(string);
-
-        furi_mutex_release(furi_log.mutex);
-    }
-}
-
 void furi_log_set_level(FuriLogLevel level) {
     if(level == FuriLogLevelDefault) {
         level = FURI_LOG_LEVEL_DEFAULT;

--- a/furi/core/log.h
+++ b/furi/core/log.h
@@ -44,13 +44,14 @@ typedef uint32_t (*FuriLogTimestamp)(void);
 /** Initialize logging */
 void furi_log_init();
 
-/** Log record
- *
- * @param[in]  level      The level
- * @param[in]  format     The format
- * @param[in]  <unnamed>  VA args
+/** Print log record
+ * 
+ * @param level 
+ * @param tag 
+ * @param format 
+ * @param ... 
  */
-void furi_log_print(FuriLogLevel level, const char* format, ...);
+void furi_log_print_format(FuriLogLevel level, const char* tag, const char* format, ...);
 
 /** Set log level
  *
@@ -76,11 +77,6 @@ void furi_log_set_puts(FuriLogPuts puts);
  */
 void furi_log_set_timestamp(FuriLogTimestamp timestamp);
 
-#define FURI_LOG_FORMAT(log_letter, tag, format) \
-    FURI_LOG_CLR_##log_letter "[" #log_letter "][" tag "]: " FURI_LOG_CLR_RESET format "\r\n"
-#define FURI_LOG_SHOW(tag, format, log_level, log_letter, ...) \
-    furi_log_print(log_level, FURI_LOG_FORMAT(log_letter, tag, format), ##__VA_ARGS__)
-
 /** Log methods
  *
  * @param      tag     The application tag
@@ -88,13 +84,15 @@ void furi_log_set_timestamp(FuriLogTimestamp timestamp);
  * @param      ...     VA Args
  */
 #define FURI_LOG_E(tag, format, ...) \
-    FURI_LOG_SHOW(tag, format, FuriLogLevelError, E, ##__VA_ARGS__)
-#define FURI_LOG_W(tag, format, ...) FURI_LOG_SHOW(tag, format, FuriLogLevelWarn, W, ##__VA_ARGS__)
-#define FURI_LOG_I(tag, format, ...) FURI_LOG_SHOW(tag, format, FuriLogLevelInfo, I, ##__VA_ARGS__)
+    furi_log_print_format(FuriLogLevelError, tag, format, ##__VA_ARGS__)
+#define FURI_LOG_W(tag, format, ...) \
+    furi_log_print_format(FuriLogLevelWarn, tag, format, ##__VA_ARGS__)
+#define FURI_LOG_I(tag, format, ...) \
+    furi_log_print_format(FuriLogLevelInfo, tag, format, ##__VA_ARGS__)
 #define FURI_LOG_D(tag, format, ...) \
-    FURI_LOG_SHOW(tag, format, FuriLogLevelDebug, D, ##__VA_ARGS__)
+    furi_log_print_format(FuriLogLevelDebug, tag, format, ##__VA_ARGS__)
 #define FURI_LOG_T(tag, format, ...) \
-    FURI_LOG_SHOW(tag, format, FuriLogLevelTrace, T, ##__VA_ARGS__)
+    furi_log_print_format(FuriLogLevelTrace, tag, format, ##__VA_ARGS__)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
# What's new

- Removed tag concatenation in log functions. This will save about 16k flash.

# Verification 

- Look at the uart log output. It should look like before.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
