### PR TITLE
Fix directory name in lib readme

### DIFF
--- a/lib/ReadMe.md
+++ b/lib/ReadMe.md
@@ -15,7 +15,7 @@
 - `microtar`            - TAR archive support library
 - `mlib`                - Algorithms and containers
 - `nanopb`              - Nano Protobuf library
-- `nfc_protocols`       - Nfc protocols library
+- `nfc`                 - Nfc library
 - `one_wire`            - One wire library
 - `qrcode`              - Qr code generator library
 - `ST25RFAL002`         - ST253916 driver and NFC hal


### PR DESCRIPTION
# What's new

Fix the **nfc** directory name in the ReadMe of the lib.

# Verification 

Verify that the folder name is correct : https://github.com/flipperdevices/flipperzero-firmware/tree/dev/lib/nfc

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
