### PR TITLE
[FL-2717] Fix unexpected behaviour when opening a remote from outside

### DIFF
--- a/applications/ibutton/ibutton.c
+++ b/applications/ibutton/ibutton.c
@@ -305,22 +305,6 @@ void ibutton_text_store_clear(iButton* ibutton) {
     memset(ibutton->text_store, 0, IBUTTON_TEXT_STORE_SIZE);
 }
 
-void ibutton_switch_to_previous_scene_one_of(
-    iButton* ibutton,
-    const uint32_t* scene_ids,
-    size_t scene_ids_size) {
-    furi_assert(scene_ids_size);
-    SceneManager* scene_manager = ibutton->scene_manager;
-
-    for(size_t i = 0; i < scene_ids_size; ++i) {
-        const uint32_t scene_id = scene_ids[i];
-        if(scene_manager_has_previous_scene(scene_manager, scene_id)) {
-            scene_manager_search_and_switch_to_previous_scene(scene_manager, scene_id);
-            return;
-        }
-    }
-}
-
 void ibutton_notification_message(iButton* ibutton, uint32_t message) {
     furi_assert(message < sizeof(ibutton_notification_sequences) / sizeof(NotificationSequence*));
     notification_message(ibutton->notifications, ibutton_notification_sequences[message]);

--- a/applications/ibutton/ibutton_i.h
+++ b/applications/ibutton/ibutton_i.h
@@ -83,8 +83,4 @@ bool ibutton_save_key(iButton* ibutton, const char* key_name);
 bool ibutton_delete_key(iButton* ibutton);
 void ibutton_text_store_set(iButton* ibutton, const char* text, ...);
 void ibutton_text_store_clear(iButton* ibutton);
-void ibutton_switch_to_previous_scene_one_of(
-    iButton* ibutton,
-    const uint32_t* scene_ids,
-    size_t scene_ids_size);
 void ibutton_notification_message(iButton* ibutton, uint32_t message);

--- a/applications/ibutton/scenes/ibutton_scene_save_name.c
+++ b/applications/ibutton/scenes/ibutton_scene_save_name.c
@@ -62,9 +62,7 @@ bool ibutton_scene_save_name_on_event(void* context, SceneManagerEvent event) {
                 const uint32_t possible_scenes[] = {
                     iButtonSceneReadKeyMenu, iButtonSceneSavedKeyMenu, iButtonSceneAddType};
                 scene_manager_search_and_switch_to_previous_scene_one_of(
-                    ibutton->scene_manager,
-                    possible_scenes,
-                    sizeof(possible_scenes) / sizeof(uint32_t));
+                    ibutton->scene_manager, possible_scenes, COUNT_OF(possible_scenes));
             }
         }
     }

--- a/applications/ibutton/scenes/ibutton_scene_save_name.c
+++ b/applications/ibutton/scenes/ibutton_scene_save_name.c
@@ -61,8 +61,10 @@ bool ibutton_scene_save_name_on_event(void* context, SceneManagerEvent event) {
             } else {
                 const uint32_t possible_scenes[] = {
                     iButtonSceneReadKeyMenu, iButtonSceneSavedKeyMenu, iButtonSceneAddType};
-                ibutton_switch_to_previous_scene_one_of(
-                    ibutton, possible_scenes, sizeof(possible_scenes) / sizeof(uint32_t));
+                scene_manager_search_and_switch_to_previous_scene_one_of(
+                    ibutton->scene_manager,
+                    possible_scenes,
+                    sizeof(possible_scenes) / sizeof(uint32_t));
             }
         }
     }

--- a/applications/ibutton/scenes/ibutton_scene_save_success.c
+++ b/applications/ibutton/scenes/ibutton_scene_save_success.c
@@ -31,8 +31,10 @@ bool ibutton_scene_save_success_on_event(void* context, SceneManagerEvent event)
         if(event.event == iButtonCustomEventBack) {
             const uint32_t possible_scenes[] = {
                 iButtonSceneReadKeyMenu, iButtonSceneSavedKeyMenu, iButtonSceneAddType};
-            ibutton_switch_to_previous_scene_one_of(
-                ibutton, possible_scenes, sizeof(possible_scenes) / sizeof(uint32_t));
+            scene_manager_search_and_switch_to_previous_scene_one_of(
+                ibutton->scene_manager,
+                possible_scenes,
+                sizeof(possible_scenes) / sizeof(uint32_t));
         }
     }
 

--- a/applications/ibutton/scenes/ibutton_scene_save_success.c
+++ b/applications/ibutton/scenes/ibutton_scene_save_success.c
@@ -32,9 +32,7 @@ bool ibutton_scene_save_success_on_event(void* context, SceneManagerEvent event)
             const uint32_t possible_scenes[] = {
                 iButtonSceneReadKeyMenu, iButtonSceneSavedKeyMenu, iButtonSceneAddType};
             scene_manager_search_and_switch_to_previous_scene_one_of(
-                ibutton->scene_manager,
-                possible_scenes,
-                sizeof(possible_scenes) / sizeof(uint32_t));
+                ibutton->scene_manager, possible_scenes, COUNT_OF(possible_scenes));
         }
     }
 

--- a/applications/ibutton/scenes/ibutton_scene_write_success.c
+++ b/applications/ibutton/scenes/ibutton_scene_write_success.c
@@ -31,8 +31,10 @@ bool ibutton_scene_write_success_on_event(void* context, SceneManagerEvent event
         consumed = true;
         if(event.event == iButtonCustomEventBack) {
             const uint32_t possible_scenes[] = {iButtonSceneReadKeyMenu, iButtonSceneStart};
-            ibutton_switch_to_previous_scene_one_of(
-                ibutton, possible_scenes, sizeof(possible_scenes) / sizeof(uint32_t));
+            scene_manager_search_and_switch_to_previous_scene_one_of(
+                ibutton->scene_manager,
+                possible_scenes,
+                sizeof(possible_scenes) / sizeof(uint32_t));
         }
     }
 

--- a/applications/ibutton/scenes/ibutton_scene_write_success.c
+++ b/applications/ibutton/scenes/ibutton_scene_write_success.c
@@ -32,9 +32,7 @@ bool ibutton_scene_write_success_on_event(void* context, SceneManagerEvent event
         if(event.event == iButtonCustomEventBack) {
             const uint32_t possible_scenes[] = {iButtonSceneReadKeyMenu, iButtonSceneStart};
             scene_manager_search_and_switch_to_previous_scene_one_of(
-                ibutton->scene_manager,
-                possible_scenes,
-                sizeof(possible_scenes) / sizeof(uint32_t));
+                ibutton->scene_manager, possible_scenes, COUNT_OF(possible_scenes));
         }
     }
 

--- a/applications/infrared/scenes/infrared_scene_edit_delete.c
+++ b/applications/infrared/scenes/infrared_scene_edit_delete.c
@@ -97,7 +97,7 @@ bool infrared_scene_edit_delete_on_event(void* context, SceneManagerEvent event)
             } else {
                 const uint32_t possible_scenes[] = {InfraredSceneRemoteList, InfraredSceneStart};
                 scene_manager_search_and_switch_to_previous_scene_one_of(
-                    scene_manager, possible_scenes, sizeof(possible_scenes) / sizeof(uint32_t));
+                    scene_manager, possible_scenes, COUNT_OF(possible_scenes));
             }
             consumed = true;
         }

--- a/applications/infrared/scenes/infrared_scene_edit_delete_done.c
+++ b/applications/infrared/scenes/infrared_scene_edit_delete_done.c
@@ -28,8 +28,12 @@ bool infrared_scene_edit_delete_done_on_event(void* context, SceneManagerEvent e
                     scene_manager, InfraredSceneRemote);
             } else if(edit_target == InfraredEditTargetRemote) {
                 const uint32_t possible_scenes[] = {InfraredSceneStart, InfraredSceneRemoteList};
-                scene_manager_search_and_switch_to_previous_scene_one_of(
-                    scene_manager, possible_scenes, sizeof(possible_scenes) / sizeof(uint32_t));
+                if(!scene_manager_search_and_switch_to_previous_scene_one_of(
+                       scene_manager,
+                       possible_scenes,
+                       sizeof(possible_scenes) / sizeof(uint32_t))) {
+                    view_dispatcher_stop(infrared->view_dispatcher);
+                }
             } else {
                 furi_assert(0);
             }

--- a/applications/infrared/scenes/infrared_scene_edit_delete_done.c
+++ b/applications/infrared/scenes/infrared_scene_edit_delete_done.c
@@ -29,9 +29,7 @@ bool infrared_scene_edit_delete_done_on_event(void* context, SceneManagerEvent e
             } else if(edit_target == InfraredEditTargetRemote) {
                 const uint32_t possible_scenes[] = {InfraredSceneStart, InfraredSceneRemoteList};
                 if(!scene_manager_search_and_switch_to_previous_scene_one_of(
-                       scene_manager,
-                       possible_scenes,
-                       sizeof(possible_scenes) / sizeof(uint32_t))) {
+                       scene_manager, possible_scenes, COUNT_OF(possible_scenes))) {
                     view_dispatcher_stop(infrared->view_dispatcher);
                 }
             } else {

--- a/applications/infrared/scenes/infrared_scene_edit_rename_done.c
+++ b/applications/infrared/scenes/infrared_scene_edit_rename_done.c
@@ -21,7 +21,10 @@ bool infrared_scene_edit_rename_done_on_event(void* context, SceneManagerEvent e
 
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == InfraredCustomEventTypePopupClosed) {
-            scene_manager_next_scene(infrared->scene_manager, InfraredSceneRemote);
+            if(!scene_manager_search_and_switch_to_previous_scene(
+                   infrared->scene_manager, InfraredSceneRemote)) {
+                scene_manager_next_scene(infrared->scene_manager, InfraredSceneRemote);
+            }
             consumed = true;
         }
     }

--- a/applications/infrared/scenes/infrared_scene_learn_done.c
+++ b/applications/infrared/scenes/infrared_scene_learn_done.c
@@ -29,7 +29,10 @@ bool infrared_scene_learn_done_on_event(void* context, SceneManagerEvent event) 
 
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == InfraredCustomEventTypePopupClosed) {
-            scene_manager_next_scene(infrared->scene_manager, InfraredSceneRemote);
+            if(!scene_manager_search_and_switch_to_previous_scene(
+                   infrared->scene_manager, InfraredSceneRemote)) {
+                scene_manager_next_scene(infrared->scene_manager, InfraredSceneRemote);
+            }
             consumed = true;
         }
     }

--- a/applications/infrared/scenes/infrared_scene_remote.c
+++ b/applications/infrared/scenes/infrared_scene_remote.c
@@ -78,7 +78,7 @@ bool infrared_scene_remote_on_event(void* context, SceneManagerEvent event) {
     if(event.type == SceneManagerEventTypeBack) {
         const uint32_t possible_scenes[] = {InfraredSceneRemoteList, InfraredSceneStart};
         consumed = scene_manager_search_and_switch_to_previous_scene_one_of(
-            scene_manager, possible_scenes, sizeof(possible_scenes) / sizeof(uint32_t));
+            scene_manager, possible_scenes, COUNT_OF(possible_scenes));
     } else if(event.type == SceneManagerEventTypeCustom) {
         const uint16_t custom_type = infrared_custom_event_get_type(event.event);
         const int16_t button_index = infrared_custom_event_get_value(event.event);


### PR DESCRIPTION
# What's new

- Fix getting stuck in application when adding/editing buttons in a remote that was open from Favourites/File browser.
- Remove duplicate function in iButton (doesn't require testing as it's literally the same code).

# Verification 

1.  Go to Favourites or File browser.
2.  Open an IR remote.
3.  Press `+` and add a new button, save it.
4. Press `Back`, the application should exit normally.
5. Repeat steps 1-2.
6. Press `Edit->Rename Button` and rename it.
7. Repeat step 4.
8. Repeat steps 1-2.
9. Press `Edit->Delete Remote`.
10. The application should exit.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
