### PR TITLE
Fix serial no and btn display for princeton encoding on scripts

### DIFF
--- a/lib/subghz/protocols/princeton.c
+++ b/lib/subghz/protocols/princeton.c
@@ -158,6 +158,7 @@ bool subghz_protocol_encoder_princeton_deserialize(void* context, FlipperFormat*
             FURI_LOG_E(TAG, "Missing TE");
             break;
         }
+
         if(instance->generic.data_count_bit !=
            subghz_protocol_princeton_const.min_count_bit_for_found) {
             FURI_LOG_E(TAG, "Wrong number of bits in key");
@@ -355,6 +356,9 @@ void subghz_protocol_decoder_princeton_get_string(void* context, string_t output
 
     uint32_t code_found_reverse_lo = code_found_reverse & 0x00000000ffffffff;
 
+    int32_t serial = ((instance->generic.data >> 4) & 0xFFFFF);
+    int8_t  btn = (uint8_t)(instance->generic.data & 0x00000F);
+
     string_cat_printf(
         output,
         "%s %dbit\r\n"
@@ -366,7 +370,7 @@ void subghz_protocol_decoder_princeton_get_string(void* context, string_t output
         instance->generic.data_count_bit,
         code_found_lo,
         code_found_reverse_lo,
-        instance->generic.serial,
-        instance->generic.btn,
+        serial,
+        btn,
         instance->te);
 }


### PR DESCRIPTION
# What's new

Running any subghz script with princeton encoding, the display doesn't show the right serial and btn. (Unlike when using saved recordings). Serial and btn are by default 0. This fix corrects this behaviour and displays the serial and button.

# Verification 

Create a script : 
`Filetype: Flipper SubGhz Key File
Version: 1
# 
Frequency: 433920000
Preset: FuriHalSubGhzPresetOok650Async
Protocol: Princeton
Bit: 24
Key: 00 00 00 00 00 75 ED 64
TE: 338`

If the script is being run, it should display serial as 0x75ED6 and button (btn) as 4.

# Checklist (For Reviewer)

- [X] PR has description of feature/bug or link to Confluence/Jira task
- [X] Description contains actions to verify feature/bugfix
- [X] I've built this code, uploaded it to the device and verified feature/bugfix
