### PR TITLE
Fix building updater package from VSCode tasks

### DIFF
--- a/.vscode/example/tasks.json
+++ b/.vscode/example/tasks.json
@@ -55,13 +55,13 @@
             "label": "[Release] Build update bundle",
             "group": "build",
             "type": "shell",
-            "command": "./fbt update_package COMPACT=1 DEBUG=0"
+            "command": "./fbt updater_package COMPACT=1 DEBUG=0"
         },
         {
             "label": "[Debug] Build update bundle",
             "group": "build",
             "type": "shell",
-            "command": "./fbt update_package"
+            "command": "./fbt updater_package"
         },
         {
             "label": "[Release] Build updater",


### PR DESCRIPTION
# What's new

- fixed typo in command arguments - update_package -> updater_package

# Verification 

- `./fbt vscode_dist`
- Install recommended extensions
- F1 - run task - [Release] Build update bundle or [Debug] Build update bundle
- All works fine

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
