### PR TITLE
Scripts: add new region to otp generator

### DIFF
--- a/scripts/otp.py
+++ b/scripts/otp.py
@@ -24,6 +24,7 @@ OTP_REGIONS = {
     "eu_ru": 0x01,
     "us_ca_au": 0x02,
     "jp": 0x03,
+    "world": 0x04,
 }
 
 OTP_DISPLAYS = {


### PR DESCRIPTION
# What's new

- Scripts: add new region to otp generator

# Verification 

- ` ./scripts/otp.py generate --version 13 --firmware 7 --body 8 --connect 9 --display mgg --color white --region world --name nani test.otp`

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
