### PR TITLE
[FL-2735] IR green LED fix

### DIFF
--- a/applications/infrared/scenes/infrared_scene_learn_success.c
+++ b/applications/infrared/scenes/infrared_scene_learn_success.c
@@ -87,10 +87,10 @@ bool infrared_scene_learn_success_on_event(void* context, SceneManagerEvent even
             consumed = true;
         } else if(event.event == DialogExPressCenter) {
             infrared_tx_start_received(infrared);
+            infrared_play_notification_message(infrared, InfraredNotificationMessageGreenOff);
             consumed = true;
         } else if(event.event == DialogExReleaseCenter) {
             infrared_tx_stop(infrared);
-            infrared_play_notification_message(infrared, InfraredNotificationMessageGreenOff);
             consumed = true;
         }
     }
@@ -101,4 +101,5 @@ bool infrared_scene_learn_success_on_event(void* context, SceneManagerEvent even
 void infrared_scene_learn_success_on_exit(void* context) {
     Infrared* infrared = context;
     dialog_ex_reset(infrared->dialog_ex);
+    infrared_play_notification_message(infrared, InfraredNotificationMessageGreenOff);
 }

--- a/applications/infrared/scenes/infrared_scene_learn_success.c
+++ b/applications/infrared/scenes/infrared_scene_learn_success.c
@@ -86,8 +86,8 @@ bool infrared_scene_learn_success_on_event(void* context, SceneManagerEvent even
             }
             consumed = true;
         } else if(event.event == DialogExPressCenter) {
-            infrared_tx_start_received(infrared);
             infrared_play_notification_message(infrared, InfraredNotificationMessageGreenOff);
+            infrared_tx_start_received(infrared);
             consumed = true;
         } else if(event.event == DialogExReleaseCenter) {
             infrared_tx_stop(infrared);


### PR DESCRIPTION
# What's new

- Turn off green LED when leaving the LearnSuccess scene

# Verification 

- Learn a remote signal.
- Save it or cancel. The green LED should turn off.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix

