### PR TITLE
[FL-2747, FL-2745] Browser worker fix, Device Info screen update

### DIFF
--- a/applications/desktop/views/desktop_view_debug.c
+++ b/applications/desktop/views/desktop_view_debug.c
@@ -23,11 +23,12 @@ void desktop_debug_render(Canvas* canvas, void* model) {
     const Version* ver;
     char buffer[64];
 
-    static const char* headers[] = {"FW Version Info:", "Dolphin Info:"};
+    static const char* headers[] = {"Device Info:", "Dolphin Info:"};
 
     canvas_set_color(canvas, ColorBlack);
     canvas_set_font(canvas, FontPrimary);
-    canvas_draw_str(canvas, 2, 9 + STATUS_BAR_Y_SHIFT, headers[m->screen]);
+    canvas_draw_str_aligned(
+        canvas, 64, 1 + STATUS_BAR_Y_SHIFT, AlignCenter, AlignTop, headers[m->screen]);
     canvas_set_font(canvas, FontSecondary);
 
     if(m->screen != DesktopViewStatsMeta) {
@@ -44,7 +45,7 @@ void desktop_debug_render(Canvas* canvas, void* model) {
             furi_hal_version_get_hw_region_name(),
             furi_hal_region_get_name(),
             my_name ? my_name : "Unknown");
-        canvas_draw_str(canvas, 5, 19 + STATUS_BAR_Y_SHIFT, buffer);
+        canvas_draw_str(canvas, 0, 19 + STATUS_BAR_Y_SHIFT, buffer);
 
         ver = furi_hal_version_get_firmware_version();
         const BleGlueC2Info* c2_ver = NULL;
@@ -52,7 +53,7 @@ void desktop_debug_render(Canvas* canvas, void* model) {
         c2_ver = ble_glue_get_c2_info();
 #endif
         if(!ver) {
-            canvas_draw_str(canvas, 5, 29 + STATUS_BAR_Y_SHIFT, "No info");
+            canvas_draw_str(canvas, 0, 30 + STATUS_BAR_Y_SHIFT, "No info");
             return;
         }
 
@@ -62,7 +63,7 @@ void desktop_debug_render(Canvas* canvas, void* model) {
             "%s [%s]",
             version_get_version(ver),
             version_get_builddate(ver));
-        canvas_draw_str(canvas, 5, 28 + STATUS_BAR_Y_SHIFT, buffer);
+        canvas_draw_str(canvas, 0, 30 + STATUS_BAR_Y_SHIFT, buffer);
 
         snprintf(
             buffer,
@@ -72,11 +73,11 @@ void desktop_debug_render(Canvas* canvas, void* model) {
             version_get_githash(ver),
             version_get_gitbranchnum(ver),
             c2_ver ? c2_ver->StackTypeString : "<none>");
-        canvas_draw_str(canvas, 5, 39 + STATUS_BAR_Y_SHIFT, buffer);
+        canvas_draw_str(canvas, 0, 40 + STATUS_BAR_Y_SHIFT, buffer);
 
         snprintf(
             buffer, sizeof(buffer), "[%d] %s", version_get_target(ver), version_get_gitbranch(ver));
-        canvas_draw_str(canvas, 5, 50 + STATUS_BAR_Y_SHIFT, buffer);
+        canvas_draw_str(canvas, 0, 50 + STATUS_BAR_Y_SHIFT, buffer);
 
     } else {
         Dolphin* dolphin = furi_record_open(RECORD_DOLPHIN);

--- a/applications/gui/modules/file_browser_worker.c
+++ b/applications/gui/modules/file_browser_worker.c
@@ -99,6 +99,11 @@ static bool browser_folder_check_and_switch(string_t path) {
     FileInfo file_info;
     Storage* storage = furi_record_open(RECORD_STORAGE);
     bool is_root = false;
+
+    if(string_search_rchar(path, '/') == 0) {
+        is_root = true;
+    }
+
     while(1) {
         // Check if folder is existing and navigate back if not
         if(storage_common_stat(storage, string_get_cstr(path), &file_info) == FSE_OK) {

--- a/firmware/targets/f7/ble_glue/ble_glue.c
+++ b/firmware/targets/f7/ble_glue/ble_glue.c
@@ -156,7 +156,7 @@ static void ble_glue_update_c2_fw_info() {
     snprintf(
         local_info->StackTypeString,
         BLE_GLUE_MAX_VERSION_STRING_LEN,
-        "%d.%d.%d.%s",
+        "%d.%d.%d:%s",
         local_info->VersionMajor,
         local_info->VersionMinor,
         local_info->VersionSub,


### PR DESCRIPTION
# What's new

- Fixed root folder detection in browser worker
- Device Info screen update
- New BLE stack version string format

# Verification 

- Check archive browser without SD card
- Check Device Info screen

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
