### PR TITLE
Fix BT Remote 'stay' button bug on first plugin launch

### DIFF
--- a/applications/bt/bt_hid_app/bt_hid.c
+++ b/applications/bt/bt_hid_app/bt_hid.c
@@ -134,7 +134,8 @@ BtHid* bt_hid_app_alloc() {
         app->view_dispatcher, BtHidViewMouse, bt_hid_mouse_get_view(app->bt_hid_mouse));
 
     // TODO switch to menu after Media is done
-    view_dispatcher_switch_to_view(app->view_dispatcher, BtHidViewKeynote);
+    app->view_id = BtHidViewKeynote;
+    view_dispatcher_switch_to_view(app->view_dispatcher, app->view_id);
 
     return app;
 }


### PR DESCRIPTION
# What's new

- Fix BT Remote 'stay' button bug on first plugin launch

# Verification 

- open 'Bluetooth Remote' plugin, hold back key, press left('stay') key on 'Close Current App' dialog, and you should stay on 'Keynote' scene instead of going menu(bug)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
