### PR TITLE
SD usage add dynamic units and %

### DIFF
--- a/applications/storage_settings/scenes/storage_settings_scene_sd_info.c
+++ b/applications/storage_settings/scenes/storage_settings_scene_sd_info.c
@@ -24,13 +24,44 @@ void storage_settings_scene_sd_info_on_enter(void* context) {
             dialog_ex, "Try to reinsert\nor format SD\ncard.", 3, 19, AlignLeft, AlignTop);
         dialog_ex_set_center_button_text(dialog_ex, "Ok");
     } else {
+        const char unit_kb[] = "KB";
+        const char unit_mb[] = "MB";
+        const char unit_gb[] = "GB";
+
+        uint32_t sd_total_val;
+        char* sd_total_unit = unit_kb;
+        uint32_t sd_free_val;
+        char* sd_free_unit = unit_kb;
+
+        if(sd_info.kb_total > 1024) {
+            sd_total_val = sd_info.kb_total / 1024;
+            sd_total_unit = unit_mb;
+        }
+        if(sd_total_val > 1024) {
+            sd_total_val /= 1024;
+            sd_total_unit = unit_gb;
+        }
+
+        if(sd_info.kb_free > 1024) {
+            sd_free_val = sd_info.kb_free / 1024;
+            sd_free_unit = unit_mb;
+        }
+        if(sd_free_val > 1024) {
+            sd_free_val /= 1024;
+            sd_free_unit = unit_gb;
+        }
+
         string_printf(
             app->text_string,
-            "Label: %s\nType: %s\n%lu KB total\n%lu KB free",
+            "Label: %s\nType: %s\n%lu %s total\n%lu %s free\n%lu%% free",
             sd_info.label,
             sd_api_get_fs_type_text(sd_info.fs_type),
-            sd_info.kb_total,
-            sd_info.kb_free);
+            sd_free_val,
+            sd_free_unit,
+            sd_total_val,
+            sd_total_unit,
+            (sd_info.kb_free * 100) / sd_info.kb_total);
+
         dialog_ex_set_text(
             dialog_ex, string_get_cstr(app->text_string), 4, 4, AlignLeft, AlignTop);
     }


### PR DESCRIPTION
# What's new

- Make units in SD info page dynamic (KB/MB/GB)
- Add free percentage too

# Verification 

- Compiled and loaded, only verified with 32GB sd

# Checklist (For Reviewer)

- [] PR has description of feature/bug or link to Confluence/Jira task
- [] Description contains actions to verify feature/bugfix
- [] I've built this code, uploaded it to the device and verified feature/bugfix
