### PR TITLE
Archive: don't start browser worker on favourites tab

### DIFF
--- a/applications/archive/helpers/archive_browser.c
+++ b/applications/archive/helpers/archive_browser.c
@@ -77,14 +77,24 @@ static void archive_long_load_cb(void* context) {
         });
 }
 
-void archive_file_browser_set_callbacks(ArchiveBrowserView* browser) {
+static void archive_file_browser_set_path(
+    ArchiveBrowserView* browser,
+    string_t path,
+    const char* filter_ext,
+    bool skip_assets) {
     furi_assert(browser);
-
-    file_browser_worker_set_callback_context(browser->worker, browser);
-    file_browser_worker_set_folder_callback(browser->worker, archive_folder_open_cb);
-    file_browser_worker_set_list_callback(browser->worker, archive_list_load_cb);
-    file_browser_worker_set_item_callback(browser->worker, archive_list_item_cb);
-    file_browser_worker_set_long_load_callback(browser->worker, archive_long_load_cb);
+    if(!browser->worker_running) {
+        browser->worker = file_browser_worker_alloc(path, filter_ext, skip_assets);
+        file_browser_worker_set_callback_context(browser->worker, browser);
+        file_browser_worker_set_folder_callback(browser->worker, archive_folder_open_cb);
+        file_browser_worker_set_list_callback(browser->worker, archive_list_load_cb);
+        file_browser_worker_set_item_callback(browser->worker, archive_list_item_cb);
+        file_browser_worker_set_long_load_callback(browser->worker, archive_long_load_cb);
+        browser->worker_running = true;
+    } else {
+        furi_assert(browser->worker);
+        file_browser_worker_set_config(browser->worker, path, filter_ext, skip_assets);
+    }
 }
 
 bool archive_is_item_in_array(ArchiveBrowserViewModel* model, uint32_t idx) {
@@ -438,8 +448,8 @@ void archive_switch_tab(ArchiveBrowserView* browser, InputKey key) {
         tab = archive_get_tab(browser);
         if(archive_is_dir_exists(browser->path)) {
             bool skip_assets = (strcmp(archive_get_tab_ext(tab), "*") == 0) ? false : true;
-            file_browser_worker_set_config(
-                browser->worker, browser->path, archive_get_tab_ext(tab), skip_assets);
+            archive_file_browser_set_path(
+                browser, browser->path, archive_get_tab_ext(tab), skip_assets);
             tab_empty = false; // Empty check will be performed later
         } else {
             tab_empty = true;

--- a/applications/archive/helpers/archive_browser.h
+++ b/applications/archive/helpers/archive_browser.h
@@ -87,4 +87,3 @@ void archive_switch_tab(ArchiveBrowserView* browser, InputKey key);
 void archive_enter_dir(ArchiveBrowserView* browser, string_t name);
 void archive_leave_dir(ArchiveBrowserView* browser);
 void archive_refresh_dir(ArchiveBrowserView* browser);
-void archive_file_browser_set_callbacks(ArchiveBrowserView* browser);

--- a/applications/archive/views/archive_browser_view.c
+++ b/applications/archive/views/archive_browser_view.c
@@ -370,18 +370,15 @@ ArchiveBrowserView* browser_alloc() {
             return true;
         });
 
-    browser->worker = file_browser_worker_alloc(browser->path, "*", false);
-    archive_file_browser_set_callbacks(browser);
-
-    file_browser_worker_set_callback_context(browser->worker, browser);
-
     return browser;
 }
 
 void browser_free(ArchiveBrowserView* browser) {
     furi_assert(browser);
 
-    file_browser_worker_free(browser->worker);
+    if(browser->worker_running) {
+        file_browser_worker_free(browser->worker);
+    }
 
     with_view_model(
         browser->view, (ArchiveBrowserViewModel * model) {

--- a/applications/archive/views/archive_browser_view.h
+++ b/applications/archive/views/archive_browser_view.h
@@ -74,6 +74,7 @@ typedef enum {
 struct ArchiveBrowserView {
     View* view;
     BrowserWorker* worker;
+    bool worker_running;
     ArchiveBrowserViewCallback callback;
     void* context;
     string_t path;


### PR DESCRIPTION
# What's new

- Browser worker starts only on file tab
- Fixes #1623 

# Verification 

- Check archive, first open tab should be favourites

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
