### PR TITLE
OpenOCD: get logs over SWO

### DIFF
--- a/debug/swo.cfg
+++ b/debug/swo.cfg
@@ -1,0 +1,19 @@
+# script for configuring the TPIU in order to
+# pipe flipper logs through ST-LINK's SWO pin
+
+set _HCLK 64000000
+set _CONSOLE_BAUDRATE 230400
+
+set _OPENOCD_LOG_OUTPUT "/dev/stdout"
+if { $tcl_platform(platform) eq "windows" } {
+    set _OPENOCD_LOG_OUTPUT "CON"
+}
+if { [info exists ::env(OPENOCD_LOGS_OUTPUT)]
+        && $::env(OPENOCD_LOGS_OUTPUT) ne "" } {
+    set _OPENOCD_LOG_OUTPUT $::env(OPENOCD_LOGS_OUTPUT)
+}
+
+set _TPIUNAME $_TARGETNAME.tpiu
+tpiu create $_TPIUNAME -dap $_CHIPNAME.dap -ap-num 0
+$_TPIUNAME configure -protocol uart -traceclk $_HCLK -pin-freq $_CONSOLE_BAUDRATE -output $_OPENOCD_LOG_OUTPUT
+$_TPIUNAME enable

--- a/documentation/fbt.md
+++ b/documentation/fbt.md
@@ -52,7 +52,7 @@ FBT keeps track of internal dependencies, so you only need to build the highest-
 - `debug_other` - attach gdb without loading any .elf. Allows to manually add external elf files with `add-symbol-file` in gdb
 - `updater_debug` - attach gdb with updater's .elf loaded
 - `blackmagic` - debug firmware with Blackmagic probe (WiFi dev board)
-- `openocd` - just start OpenOCD
+- `openocd` - just start OpenOCD. Set `OPENOCD_LOGS_SWO=True` to receive flipper logs over SWO
 - `get_blackmagic` - output blackmagic address in gdb remote format. Useful for IDE integration
 - `lint`, `format` - run clang-tidy on C source code to check and reformat it according to `.clang-format` specs
 - `lint_py`, `format_py` - run [black](https://black.readthedocs.io/en/stable/index.html) on Python source code, build system files & application manifests 

--- a/site_scons/commandline.scons
+++ b/site_scons/commandline.scons
@@ -163,6 +163,18 @@ vars.Add(
 )
 
 vars.Add(
+    "OPENOCD_LOGS_SWO",
+    help="Configure OpenOCD to receive logs over SWO",
+    default=False,
+)
+
+vars.Add(
+    "OPENOCD_LOGS_OUTPUT",
+    help="Override logs destination when OPENOCD_LOGS_SWO is set (defaults to stdout)",
+    default="",
+)
+
+vars.Add(
     "BLACKMAGIC",
     help="Blackmagic probe location",
     default="auto",

--- a/site_scons/site_tools/openocd.py
+++ b/site_scons/site_tools/openocd.py
@@ -3,6 +3,8 @@ from SCons.Action import Action
 from SCons.Defaults import Touch
 import SCons
 
+import os
+
 __OPENOCD_BIN = "openocd"
 
 _oocd_action = Action(
@@ -12,6 +14,9 @@ _oocd_action = Action(
 
 
 def generate(env):
+    if env["OPENOCD_LOGS_SWO"]:
+        os.environ["OPENOCD_LOGS_OUTPUT"] = env["OPENOCD_LOGS_OUTPUT"]
+        env.Append(OPENOCD_OPTS=["-f", "debug/swo.cfg"])
     env.SetDefault(
         OPENOCD=__OPENOCD_BIN,
         OPENOCD_OPTS="",


### PR DESCRIPTION
# What's new

After finally getting an ST-LINK, I was a bit annoyed of not getting flipper logs back through it. Being novice with embedded devices I didn't find it straightforward to figure out how to do it, but did manage in the end.

If the SWD interface has a SWO pin, once can simply wire it to flipper GPIO pin 13 (aka USART TX / PB6), and then correctly set up openOCD, as done in this PR...

[On discord](https://discord.com/channels/740930220399525928/986635575664726026/1010121926083092480) @zhovner requested a writeup, but I figured a PR was maybe more straightforward and useful.

Checked it works on osx, and windows (to validate writing to `CON` works). The default behaviour may not be entirely portable (when `/dev/stdout` isn't a thing), but that's also why it's configurable.

Only adding this as an opt-in config option to make sure it doesn't suddenly break things for people.

# Verification 

1. Have an ST-LINK, plugged into computer
2. Connect SWD pins (VDD, CLK, GND, DIO, SWO) to flipper pins 9-13.
3. Run `./fbt OPENOCD_LOGS_SWO=True openocd`
4. Produce some logs with flipper
5. Observe they are being printed to terminal through openocd

`OPENOCD_LOGS_OUTPUT` can be set to change where logs are being sent. Can be a file, a local TCP port (preceded by `:`), or `-` to have them forwarded to TCL.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
