### PR TITLE
Alter onewire libs so other non-ibutton pins can be used as well

### DIFF
--- a/applications/accessor/accessor_app.cpp
+++ b/applications/accessor/accessor_app.cpp
@@ -33,7 +33,7 @@ void AccessorApp::run(void) {
 
 AccessorApp::AccessorApp() {
     notification = static_cast<NotificationApp*>(furi_record_open(RECORD_NOTIFICATION));
-    onewire_host = onewire_host_alloc();
+    onewire_host = onewire_host_alloc(&ibutton_gpio);
     furi_hal_power_enable_otg();
 }
 

--- a/applications/ibutton/ibutton_cli.c
+++ b/applications/ibutton/ibutton_cli.c
@@ -271,7 +271,7 @@ void onewire_cli_print_usage() {
 
 static void onewire_cli_search(Cli* cli) {
     UNUSED(cli);
-    OneWireHost* onewire = onewire_host_alloc();
+    OneWireHost* onewire = onewire_host_alloc(&ibutton_gpio);
     uint8_t address[8];
     bool done = false;
 

--- a/firmware/targets/f7/furi_hal/furi_hal_ibutton.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_ibutton.c
@@ -1,5 +1,6 @@
 #include <furi_hal_ibutton.h>
 #include <furi_hal_interrupt.h>
+#include <furi_hal_onewire.h>
 #include <furi_hal_resources.h>
 
 #include <stm32wbxx_ll_tim.h>
@@ -90,46 +91,13 @@ void furi_hal_ibutton_emulate_stop() {
 }
 
 void furi_hal_ibutton_start_drive() {
-    furi_hal_ibutton_pin_high();
-    furi_hal_gpio_init(&ibutton_gpio, GpioModeOutputOpenDrain, GpioPullNo, GpioSpeedLow);
-}
-
-void furi_hal_ibutton_start_drive_in_isr() {
-    furi_hal_gpio_init(&ibutton_gpio, GpioModeOutputOpenDrain, GpioPullNo, GpioSpeedLow);
-    LL_EXTI_ClearFlag_0_31(ibutton_gpio.pin);
-}
-
-void furi_hal_ibutton_start_interrupt() {
-    furi_hal_ibutton_pin_high();
-    furi_hal_gpio_init(&ibutton_gpio, GpioModeInterruptRiseFall, GpioPullNo, GpioSpeedLow);
-}
-
-void furi_hal_ibutton_start_interrupt_in_isr() {
-    furi_hal_gpio_init(&ibutton_gpio, GpioModeInterruptRiseFall, GpioPullNo, GpioSpeedLow);
-    LL_EXTI_ClearFlag_0_31(ibutton_gpio.pin);
+    furi_hal_onewire_start_drive(&ibutton_gpio);
 }
 
 void furi_hal_ibutton_stop() {
-    furi_hal_ibutton_pin_high();
-    furi_hal_gpio_init(&ibutton_gpio, GpioModeAnalog, GpioPullNo, GpioSpeedLow);
-}
-
-void furi_hal_ibutton_add_interrupt(GpioExtiCallback cb, void* context) {
-    furi_hal_gpio_add_int_callback(&ibutton_gpio, cb, context);
-}
-
-void furi_hal_ibutton_remove_interrupt() {
-    furi_hal_gpio_remove_int_callback(&ibutton_gpio);
+    furi_hal_onewire_stop(&ibutton_gpio);
 }
 
 void furi_hal_ibutton_pin_low() {
-    furi_hal_gpio_write(&ibutton_gpio, false);
-}
-
-void furi_hal_ibutton_pin_high() {
-    furi_hal_gpio_write(&ibutton_gpio, true);
-}
-
-bool furi_hal_ibutton_pin_get_level() {
-    return furi_hal_gpio_read(&ibutton_gpio);
+    furi_hal_onewire_pin_low(&ibutton_gpio);
 }

--- a/firmware/targets/f7/furi_hal/furi_hal_ibutton.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_ibutton.c
@@ -89,15 +89,3 @@ void furi_hal_ibutton_emulate_stop() {
         furi_hal_ibutton->context = NULL;
     }
 }
-
-void furi_hal_ibutton_start_drive() {
-    furi_hal_onewire_start_drive(&ibutton_gpio);
-}
-
-void furi_hal_ibutton_stop() {
-    furi_hal_onewire_stop(&ibutton_gpio);
-}
-
-void furi_hal_ibutton_pin_low() {
-    furi_hal_onewire_pin_low(&ibutton_gpio);
-}

--- a/firmware/targets/f7/furi_hal/furi_hal_onewire.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_onewire.c
@@ -1,0 +1,56 @@
+#include <furi_hal_onewire.h>
+#include <furi_hal_interrupt.h>
+#include <furi_hal_resources.h>
+
+#include <stm32wbxx_ll_tim.h>
+#include <stm32wbxx_ll_exti.h>
+
+#include <furi.h>
+
+#define FURI_HAL_IBUTTON_TIMER TIM1
+#define FURI_HAL_IBUTTON_TIMER_IRQ FuriHalInterruptIdTim1UpTim16
+
+void furi_hal_onewire_start_drive(const GpioPin* gpio) {
+    furi_hal_onewire_pin_high(gpio);
+    furi_hal_gpio_init(gpio, GpioModeOutputOpenDrain, GpioPullNo, GpioSpeedLow);
+}
+
+void furi_hal_onewire_start_drive_in_isr(const GpioPin* gpio) {
+    furi_hal_gpio_init(gpio, GpioModeOutputOpenDrain, GpioPullNo, GpioSpeedLow);
+    LL_EXTI_ClearFlag_0_31(gpio->pin);
+}
+
+void furi_hal_onewire_start_interrupt(const GpioPin* gpio) {
+    furi_hal_onewire_pin_high(gpio);
+    furi_hal_gpio_init(gpio, GpioModeInterruptRiseFall, GpioPullNo, GpioSpeedLow);
+}
+
+void furi_hal_onewire_start_interrupt_in_isr(const GpioPin* gpio) {
+    furi_hal_gpio_init(gpio, GpioModeInterruptRiseFall, GpioPullNo, GpioSpeedLow);
+    LL_EXTI_ClearFlag_0_31(gpio->pin);
+}
+
+void furi_hal_onewire_stop(const GpioPin* gpio) {
+    furi_hal_onewire_pin_high(gpio);
+    furi_hal_gpio_init(gpio, GpioModeAnalog, GpioPullNo, GpioSpeedLow);
+}
+
+void furi_hal_onewire_add_interrupt(const GpioPin* gpio, GpioExtiCallback cb, void* context) {
+    furi_hal_gpio_add_int_callback(gpio, cb, context);
+}
+
+void furi_hal_onewire_remove_interrupt(const GpioPin* gpio) {
+    furi_hal_gpio_remove_int_callback(gpio);
+}
+
+void furi_hal_onewire_pin_low(const GpioPin* gpio) {
+    furi_hal_gpio_write(gpio, false);
+}
+
+void furi_hal_onewire_pin_high(const GpioPin* gpio) {
+    furi_hal_gpio_write(gpio, true);
+}
+
+bool furi_hal_onewire_pin_get_level(const GpioPin* gpio) {
+    return furi_hal_gpio_read(gpio);
+}

--- a/firmware/targets/f7/furi_hal/furi_hal_rfid.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_rfid.c
@@ -1,6 +1,6 @@
 #include <furi_hal_rfid.h>
-#include <furi_hal_ibutton.h>
 #include <furi_hal_interrupt.h>
+#include <furi_hal_onewire.h>
 #include <furi_hal_resources.h>
 #include <furi.h>
 
@@ -69,7 +69,7 @@ void furi_hal_rfid_init() {
 
 void furi_hal_rfid_pins_reset() {
     // ibutton bus disable
-    furi_hal_ibutton_stop();
+    furi_hal_onewire_stop(&ibutton_gpio);
 
     // pulldown rfid antenna
     furi_hal_gpio_init(&gpio_rfid_carrier_out, GpioModeOutputPushPull, GpioPullNo, GpioSpeedLow);
@@ -86,8 +86,8 @@ void furi_hal_rfid_pins_reset() {
 
 void furi_hal_rfid_pins_emulate() {
     // ibutton low
-    furi_hal_ibutton_start_drive();
-    furi_hal_ibutton_pin_low();
+    furi_hal_onewire_start_drive(&ibutton_gpio);
+    furi_hal_onewire_pin_low(&ibutton_gpio);
 
     // pull pin to timer out
     furi_hal_gpio_init_ex(
@@ -107,8 +107,8 @@ void furi_hal_rfid_pins_emulate() {
 
 void furi_hal_rfid_pins_read() {
     // ibutton low
-    furi_hal_ibutton_start_drive();
-    furi_hal_ibutton_pin_low();
+    furi_hal_onewire_start_drive(&ibutton_gpio);
+    furi_hal_onewire_pin_low(&ibutton_gpio);
 
     // dont pull rfid antenna
     furi_hal_gpio_init(&gpio_nfc_irq_rfid_pull, GpioModeOutputPushPull, GpioPullNo, GpioSpeedLow);

--- a/firmware/targets/furi_hal_include/furi_hal.h
+++ b/firmware/targets/furi_hal_include/furi_hal.h
@@ -31,6 +31,7 @@ template <unsigned int N> struct STOP_EXTERNING_ME {};
 #include "furi_hal_flash.h"
 #include "furi_hal_subghz.h"
 #include "furi_hal_vibro.h"
+#include "furi_hal_onewire.h"
 #include "furi_hal_ibutton.h"
 #include "furi_hal_rfid.h"
 #include "furi_hal_nfc.h"

--- a/firmware/targets/furi_hal_include/furi_hal_ibutton.h
+++ b/firmware/targets/furi_hal_include/furi_hal_ibutton.h
@@ -27,21 +27,6 @@ void furi_hal_ibutton_emulate_set_next(uint32_t period);
 
 void furi_hal_ibutton_emulate_stop();
 
-/**
- * Sets the pin to normal mode (open collector), and sets it to float
- */
-void furi_hal_ibutton_start_drive();
-
-/**
- * Sets the pin to analog mode, and sets it to float
- */
-void furi_hal_ibutton_stop();
-
-/**
- * Sets the pin to low
- */
-void furi_hal_ibutton_pin_low();
-
 #ifdef __cplusplus
 }
 #endif

--- a/firmware/targets/furi_hal_include/furi_hal_ibutton.h
+++ b/firmware/targets/furi_hal_include/furi_hal_ibutton.h
@@ -33,55 +33,14 @@ void furi_hal_ibutton_emulate_stop();
 void furi_hal_ibutton_start_drive();
 
 /**
- * Sets the pin to normal mode (open collector), and clears pin EXTI interrupt.
- * Used in EXTI interrupt context.
- */
-void furi_hal_ibutton_start_drive_in_isr();
-
-/**
- * Sets the pin to interrupt mode (EXTI interrupt on rise or fall), and sets it to float
- */
-void furi_hal_ibutton_start_interrupt();
-
-/**
- * Sets the pin to interrupt mode (EXTI interrupt on rise or fall), and clears pin EXTI interrupt.
- * Used in EXTI interrupt context.
- */
-void furi_hal_ibutton_start_interrupt_in_isr();
-
-/**
  * Sets the pin to analog mode, and sets it to float
  */
 void furi_hal_ibutton_stop();
 
 /**
- * Attach interrupt callback to iButton pin
- * @param cb callback
- * @param context context
- */
-void furi_hal_ibutton_add_interrupt(GpioExtiCallback cb, void* context);
-
-/**
- * Remove interrupt callback from iButton pin
- */
-void furi_hal_ibutton_remove_interrupt();
-
-/**
  * Sets the pin to low
  */
 void furi_hal_ibutton_pin_low();
-
-/**
- * Sets the pin to high (float in iButton pin modes)
- */
-void furi_hal_ibutton_pin_high();
-
-/**
- * Get pin level
- * @return true if level is high
- * @return false if level is low
- */
-bool furi_hal_ibutton_pin_get_level();
 
 #ifdef __cplusplus
 }

--- a/firmware/targets/furi_hal_include/furi_hal_onewire.h
+++ b/firmware/targets/furi_hal_include/furi_hal_onewire.h
@@ -1,0 +1,79 @@
+/**
+ * @file furi_hal_onewire.h
+ * OneWire HAL API
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "furi_hal_gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Sets the pin to normal mode (open collector), and sets it to float
+ * @param gpio
+ */
+void furi_hal_onewire_start_drive(const GpioPin* gpio);
+
+/**
+ * Sets the pin to normal mode (open collector), and clears pin EXTI interrupt.
+ * Used in EXTI interrupt context.
+ * @param gpio
+ */
+void furi_hal_onewire_start_drive_in_isr(const GpioPin* gpio);
+
+/**
+ * Sets the pin to interrupt mode (EXTI interrupt on rise or fall), and sets it to float
+ * @param gpio
+ */
+void furi_hal_onewire_start_interrupt(const GpioPin* gpio);
+
+/**
+ * Sets the pin to interrupt mode (EXTI interrupt on rise or fall), and clears pin EXTI interrupt.
+ * Used in EXTI interrupt context.
+ * @param gpio
+ */
+void furi_hal_onewire_start_interrupt_in_isr(const GpioPin* gpio);
+
+/**
+ * Sets the pin to analog mode, and sets it to float
+ * @param gpio
+ */
+void furi_hal_onewire_stop(const GpioPin* gpio);
+
+/**
+ * Attach interrupt callback to OneWire pin
+ * @param cb callback
+ * @param context context
+ */
+void furi_hal_onewire_add_interrupt(const GpioPin* gpio, GpioExtiCallback cb, void* context);
+
+/**
+ * Remove interrupt callback from OneWire pin
+ */
+void furi_hal_onewire_remove_interrupt(const GpioPin* gpio);
+
+/**
+ * Sets the pin to low
+ */
+void furi_hal_onewire_pin_low(const GpioPin* gpio);
+
+/**
+ * Sets the pin to high (float in OneWire pin modes)
+ */
+void furi_hal_onewire_pin_high(const GpioPin* gpio);
+
+/**
+ * Get pin level
+ * @return true if level is high
+ * @return false if level is low
+ */
+bool furi_hal_onewire_pin_get_level(const GpioPin* gpio);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/one_wire/ibutton/ibutton_worker.c
+++ b/lib/one_wire/ibutton/ibutton_worker.c
@@ -25,8 +25,8 @@ iButtonWorker* ibutton_worker_alloc() {
     iButtonWorker* worker = malloc(sizeof(iButtonWorker));
     worker->key_p = NULL;
     worker->key_data = malloc(ibutton_key_get_max_size());
-    worker->host = onewire_host_alloc();
-    worker->slave = onewire_slave_alloc();
+    worker->host = onewire_host_alloc(&ibutton_gpio);
+    worker->slave = onewire_slave_alloc(&ibutton_gpio);
     worker->writer = ibutton_writer_alloc(worker->host);
     worker->device = onewire_device_alloc(0, 0, 0, 0, 0, 0, 0, 0);
     worker->messages = furi_message_queue_alloc(1, sizeof(iButtonMessage));

--- a/lib/one_wire/ibutton/ibutton_worker_modes.c
+++ b/lib/one_wire/ibutton/ibutton_worker_modes.c
@@ -238,12 +238,14 @@ void ibutton_worker_emulate_timer_cb(void* context) {
     LevelDuration level =
         protocol_dict_encoder_yield(worker->protocols, worker->protocol_to_encode);
 
+    const GpioPin* gpio_pin = onewire_host_get_gpio_pin(worker->host);
+
     furi_hal_ibutton_emulate_set_next(level_duration_get_duration(level));
 
     if(level_duration_get_level(level)) {
-        furi_hal_ibutton_pin_high();
+        furi_hal_onewire_pin_high(gpio_pin);
     } else {
-        furi_hal_ibutton_pin_low();
+        furi_hal_onewire_pin_low(gpio_pin);
     }
 }
 
@@ -251,6 +253,8 @@ void ibutton_worker_emulate_timer_start(iButtonWorker* worker) {
     furi_assert(worker->key_p);
     const uint8_t* key_id = ibutton_key_get_data_p(worker->key_p);
     const uint8_t key_size = ibutton_key_get_max_size();
+
+    const GpioPin* gpio_pin;
 
     switch(ibutton_key_get_type(worker->key_p)) {
     case iButtonKeyDS1990:
@@ -267,7 +271,8 @@ void ibutton_worker_emulate_timer_start(iButtonWorker* worker) {
     protocol_dict_set_data(worker->protocols, worker->protocol_to_encode, key_id, key_size);
     protocol_dict_encoder_start(worker->protocols, worker->protocol_to_encode);
 
-    furi_hal_ibutton_start_drive();
+    gpio_pin = onewire_host_get_gpio_pin(worker->host);
+    furi_hal_onewire_start_drive(gpio_pin);
     furi_hal_ibutton_emulate_start(0, ibutton_worker_emulate_timer_cb, worker);
 }
 

--- a/lib/one_wire/one_wire_host.h
+++ b/lib/one_wire/one_wire_host.h
@@ -22,16 +22,23 @@ typedef struct OneWireHost OneWireHost;
 
 /**
  * Allocate onewire host bus
- * @param gpio 
+ * @param gpio_pin
  * @return OneWireHost* 
  */
-OneWireHost* onewire_host_alloc();
+OneWireHost* onewire_host_alloc(const GpioPin *gpio_pin);
 
 /**
  * Deallocate onewire host bus
  * @param host 
  */
 void onewire_host_free(OneWireHost* host);
+
+/**
+ * Get pointer to relevant pin
+ * @param host
+ * @return const GpioPin*
+ */
+const GpioPin* onewire_host_get_gpio_pin(OneWireHost* host);
 
 /**
  * Reset bus

--- a/lib/one_wire/one_wire_slave.h
+++ b/lib/one_wire/one_wire_slave.h
@@ -19,10 +19,10 @@ typedef void (*OneWireSlaveResultCallback)(void* context);
 
 /**
  * Allocate onewire slave
- * @param pin 
+ * @param gpio_pin
  * @return OneWireSlave* 
  */
-OneWireSlave* onewire_slave_alloc();
+OneWireSlave* onewire_slave_alloc(const GpioPin* gpio_pin);
 
 /**
  * Free onewire slave


### PR DESCRIPTION
# What's new

Changes so `onewire_host_alloc()` now takes a mandatory GpioPin. For iButton, this would be `&ibutton_gpio`. For other uses, the `&gpio_ext_pa7` (and other pins) can be used.

This changeset allows us to implement plugins/apps that speak the OneWire protocol over the top gpio pins.

Closes: #1596

# Verification 

- Someone needs to confirm that the iButton functionality still works. I have no such thing to test.
- To test the new behaviour, I hacked up a temperature sensor plugin where you can connect a DS18x20 temperature sensor and cycle through the pins using LEFT/RIGHT. Dirty version here: https://junk.devs.nu/2022/flipper/sensors_ds18x20_1.patch

![image](https://user-images.githubusercontent.com/1225014/185898200-955e2a75-c088-4838-be06-30f1cd4dbadd.png)

- In the image above, the DS sensor is connected to pin C0. The temperature reads 23.3 celcius.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
