### PR TITLE
LFRFID RC fixes

### DIFF
--- a/applications/lfrfid/scene/lfrfid_app_scene_write.cpp
+++ b/applications/lfrfid/scene/lfrfid_app_scene_write.cpp
@@ -35,6 +35,11 @@ void LfRfidAppSceneWrite::on_enter(LfRfidApp* app, bool /* need_restore */) {
     popup->set_icon(0, 3, &I_RFIDDolphinSend_97x61);
 
     app->view_controller.switch_to<PopupVM>();
+
+    size_t size = protocol_dict_get_data_size(app->dict, app->protocol_id);
+    app->old_key_data = (uint8_t*)malloc(size);
+    protocol_dict_get_data(app->dict, app->protocol_id, app->old_key_data, size);
+
     lfrfid_worker_start_thread(app->lfworker);
     lfrfid_worker_write_start(
         app->lfworker, (LFRFIDProtocol)app->protocol_id, lfrfid_write_callback, app);
@@ -76,4 +81,8 @@ void LfRfidAppSceneWrite::on_exit(LfRfidApp* app) {
     app->view_controller.get<PopupVM>()->clean();
     lfrfid_worker_stop(app->lfworker);
     lfrfid_worker_stop_thread(app->lfworker);
+
+    size_t size = protocol_dict_get_data_size(app->dict, app->protocol_id);
+    protocol_dict_set_data(app->dict, app->protocol_id, app->old_key_data, size);
+    free(app->old_key_data);
 }

--- a/lib/lfrfid/lfrfid_worker_modes.c
+++ b/lib/lfrfid/lfrfid_worker_modes.c
@@ -522,9 +522,17 @@ static void lfrfid_worker_mode_write_process(LFRFIDWorker* worker) {
                 &read_result);
 
             if(state == LFRFIDWorkerReadOK) {
-                protocol_dict_get_data(worker->protocols, protocol, read_data, data_size);
+                bool read_success = false;
 
-                if(memcmp(read_data, verify_data, data_size) == 0) {
+                if(read_result == protocol) {
+                    protocol_dict_get_data(worker->protocols, protocol, read_data, data_size);
+
+                    if(memcmp(read_data, verify_data, data_size) == 0) {
+                        read_success = true;
+                    }
+                }
+
+                if(read_success) {
                     if(worker->write_cb) {
                         worker->write_cb(LFRFIDWorkerWriteOK, worker->cb_ctx);
                     }


### PR DESCRIPTION
# What's new

- No longer a successful write event occurs after writing to a non-writable key.
- Protocol data remains after write.

# Verification 

- Write to a non-writable key fob (the key data must be different). The success message should not appear.
- Read -> Success (brief info screen) -> Write, press back twice to return to the brief info screen. The key data must be valid.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
