### PR TITLE
workflows and fbtenv improovements

### DIFF
--- a/.github/workflows/amap_analyse.yml
+++ b/.github/workflows/amap_analyse.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   amap_analyse:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: [self-hosted,FlipperZeroMacShell]
     timeout-minutes: 15
     steps:

--- a/.github/workflows/pvs_studio.yml
+++ b/.github/workflows/pvs_studio.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   analyse_c_cpp:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: [self-hosted, FlipperZeroShell]
     steps:
       - name: 'Decontaminate previous build leftovers'

--- a/scripts/toolchain/fbtenv.sh
+++ b/scripts/toolchain/fbtenv.sh
@@ -202,6 +202,7 @@ fbtenv_clearing()
         rm -rf "${FBT_TOOLCHAIN_PATH:?}/toolchain/*.part";
     fi
     echo "done";
+    trap - 2;
     return 0;
 }
 
@@ -244,7 +245,7 @@ fbtenv_check_download_toolchain()
 
 fbtenv_download_toolchain()
 {
-    trap clearing 2;
+    trap fbtenv_clearing 2;  # trap will be restored in fbtenv_clearing
     fbtenv_check_tar || return 1;
     TOOLCHAIN_TAR="$(basename "$TOOLCHAIN_URL")";
     TOOLCHAIN_DIR="$(echo "$TOOLCHAIN_TAR" | sed "s/-$FBT_TOOLCHAIN_VERSION.tar.gz//g")";
@@ -255,7 +256,6 @@ fbtenv_download_toolchain()
     fbtenv_remove_old_tooclhain;
     fbtenv_unpack_toolchain || return 1;
     fbtenv_clearing;
-    trap - 2;
     return 0;
 }
 

--- a/scripts/toolchain/fbtenv.sh
+++ b/scripts/toolchain/fbtenv.sh
@@ -40,6 +40,9 @@ fbtenv_restore_env()
     elif [ -n "${PROMPT:-""}" ]; then
         PROMPT="$(echo "$PROMPT" | sed 's/\[fbt\]//g')";
     fi
+    unset SCRIPT_PATH;
+    unset FBT_TOOLCHAIN_VERSION;
+    unset FBT_TOOLCHAIN_PATH;
 }
 
 fbtenv_check_sourced()
@@ -198,9 +201,6 @@ fbtenv_clearing()
         rm -rf "${FBT_TOOLCHAIN_PATH:?}/toolchain/*.tar.gz";
         rm -rf "${FBT_TOOLCHAIN_PATH:?}/toolchain/*.part";
     fi
-    unset SCRIPT_PATH;
-    unset FBT_TOOLCHAIN_VERSION;
-    unset FBT_TOOLCHAIN_PATH;
     trap - 2;
     echo "done";
     return 0;

--- a/scripts/toolchain/fbtenv.sh
+++ b/scripts/toolchain/fbtenv.sh
@@ -13,6 +13,9 @@ fbtenv_show_usage()
     echo "Running this script manually is wrong, please source it";
     echo "Example:";
     printf "\tsource scripts/toolchain/fbtenv.sh\n";
+    echo "To restore your enviroment source fbtenv.sh with '--restore'."
+    echo "Example:";
+    printf "\tsource scripts/toolchain/fbtenv.sh --restore\n";
 }
 
 fbtenv_curl()
@@ -23,6 +26,20 @@ fbtenv_curl()
 fbtenv_wget()
 {
     wget --show-progress --progress=bar:force -qO "$1" "$2";
+}
+
+fbtenv_restore_env()
+{
+    TOOLCHAIN_ARCH_DIR_SED="$(echo "$TOOLCHAIN_ARCH_DIR" | sed 's/\//\\\//g')"
+    PATH="$(echo "$PATH" | /usr/bin/sed "s/$TOOLCHAIN_ARCH_DIR_SED\/python\/bin://g")";
+    PATH="$(echo "$PATH" | /usr/bin/sed "s/$TOOLCHAIN_ARCH_DIR_SED\/bin://g")";
+    PATH="$(echo "$PATH" | /usr/bin/sed "s/$TOOLCHAIN_ARCH_DIR_SED\/protobuf\/bin://g")";
+    PATH="$(echo "$PATH" | /usr/bin/sed "s/$TOOLCHAIN_ARCH_DIR_SED\/openocd\/bin://g")";
+    if [ -n "${PS1:-""}" ]; then
+        PS1="$(echo "$PS1" | sed 's/\[fbt\]//g')";
+    elif [ -n "${PROMPT:-""}" ]; then
+        PROMPT="$(echo "$PROMPT" | sed 's/\[fbt\]//g')";
+    fi
 }
 
 fbtenv_check_sourced()
@@ -138,15 +155,17 @@ fbtenv_download_toolchain_tar()
 {
     echo "Downloading toolchain:";
     mkdir -p "$FBT_TOOLCHAIN_PATH/toolchain" || return 1;
-    "$FBT_DOWNLOADER" "$FBT_TOOLCHAIN_PATH/toolchain/$TOOLCHAIN_TAR" "$TOOLCHAIN_URL" || return 1;
+    "$FBT_DOWNLOADER" "$FBT_TOOLCHAIN_PATH/toolchain/$TOOLCHAIN_TAR.part" "$TOOLCHAIN_URL" || return 1;
+    # restoring oroginal filename if file downloaded successfully
+    mv "$FBT_TOOLCHAIN_PATH/toolchain/$TOOLCHAIN_TAR.part" "$FBT_TOOLCHAIN_PATH/toolchain/$TOOLCHAIN_TAR"
     echo "done";
     return 0;
 }
 
 fbtenv_remove_old_tooclhain()
 {
-    printf "Removing old toolchain (if exist)..";
-    rm -rf "${TOOLCHAIN_ARCH_DIR}";
+    printf "Removing old toolchain..";
+    rm -rf "${TOOLCHAIN_ARCH_DIR:?}";
     echo "done";
 }
 
@@ -175,7 +194,14 @@ fbtenv_unpack_toolchain()
 fbtenv_clearing()
 {
     printf "Clearing..";
-    rm -rf "${FBT_TOOLCHAIN_PATH:?}/toolchain/$TOOLCHAIN_TAR";
+    if [ -n "${FBT_TOOLCHAIN_PATH:-""}" ]; then
+        rm -rf "${FBT_TOOLCHAIN_PATH:?}/toolchain/*.tar.gz";
+        rm -rf "${FBT_TOOLCHAIN_PATH:?}/toolchain/*.part";
+    fi
+    unset SCRIPT_PATH;
+    unset FBT_TOOLCHAIN_VERSION;
+    unset FBT_TOOLCHAIN_PATH;
+    trap - SIGINT;
     echo "done";
     return 0;
 }
@@ -224,26 +250,33 @@ fbtenv_download_toolchain()
     TOOLCHAIN_DIR="$(echo "$TOOLCHAIN_TAR" | sed "s/-$FBT_TOOLCHAIN_VERSION.tar.gz//g")";
     if ! fbtenv_check_downloaded_toolchain; then
         fbtenv_curl_wget_check || return 1;
-        fbtenv_download_toolchain_tar;
+        fbtenv_download_toolchain_tar || return 1;
     fi
     fbtenv_remove_old_tooclhain;
-    fbtenv_unpack_toolchain || { fbtenv_clearing && return 1; };
+    fbtenv_unpack_toolchain || return 1;
     fbtenv_clearing;
     return 0;
 }
 
 fbtenv_main()
 {
+    trap clearing SIGINT;
     fbtenv_check_sourced || return 1;
+    fbtenv_get_kernel_type || { fbtenv_clearing && return 1; };
+    if [ "$1" = "--restore" ]; then
+        fbtenv_restore_env;
+        fbtenv_clearing;
+        return 0;
+    fi
     fbtenv_chck_many_source;  # many source it's just a warning
     fbtenv_set_shell_prompt;
-    fbtenv_check_script_path || return 1;
-    fbtenv_get_kernel_type || return 1;
-    fbtenv_check_download_toolchain || return 1;
+    fbtenv_check_script_path || { fbtenv_clearing && return 1; };
+    fbtenv_check_download_toolchain || { fbtenv_clearing && return 1; };
     PATH="$TOOLCHAIN_ARCH_DIR/python/bin:$PATH";
     PATH="$TOOLCHAIN_ARCH_DIR/bin:$PATH";
     PATH="$TOOLCHAIN_ARCH_DIR/protobuf/bin:$PATH";
     PATH="$TOOLCHAIN_ARCH_DIR/openocd/bin:$PATH";
+    fbtenv_clearing;
 }
 
-fbtenv_main;
+fbtenv_main "${1:-""}";

--- a/scripts/toolchain/fbtenv.sh
+++ b/scripts/toolchain/fbtenv.sh
@@ -48,6 +48,7 @@ fbtenv_restore_env()
 fbtenv_check_sourced()
 {
     case "${ZSH_EVAL_CONTEXT:-""}" in *:file:*)
+        setopt +o nomatch;  # disabling 'no match found' warning in zsh
         return 0;;
     esac
     if [ ${0##*/} = "fbtenv.sh" ]; then  # exluding script itself
@@ -198,8 +199,8 @@ fbtenv_clearing()
 {
     printf "Clearing..";
     if [ -n "${FBT_TOOLCHAIN_PATH:-""}" ]; then
-        rm -rf "${FBT_TOOLCHAIN_PATH:?}/toolchain/*.tar.gz";
-        rm -rf "${FBT_TOOLCHAIN_PATH:?}/toolchain/*.part";
+        rm -rf "${FBT_TOOLCHAIN_PATH:?}/toolchain/"*.tar.gz;
+        rm -rf "${FBT_TOOLCHAIN_PATH:?}/toolchain/"*.part;
     fi
     echo "done";
     trap - 2;
@@ -245,10 +246,10 @@ fbtenv_check_download_toolchain()
 
 fbtenv_download_toolchain()
 {
-    trap fbtenv_clearing 2;  # trap will be restored in fbtenv_clearing
     fbtenv_check_tar || return 1;
     TOOLCHAIN_TAR="$(basename "$TOOLCHAIN_URL")";
     TOOLCHAIN_DIR="$(echo "$TOOLCHAIN_TAR" | sed "s/-$FBT_TOOLCHAIN_VERSION.tar.gz//g")";
+    trap fbtenv_clearing 2;  # trap will be restored in fbtenv_clearing
     if ! fbtenv_check_downloaded_toolchain; then
         fbtenv_curl_wget_check || return 1;
         fbtenv_download_toolchain_tar || return 1;
@@ -268,9 +269,9 @@ fbtenv_main()
         return 0;
     fi
     fbtenv_chck_many_source;  # many source it's just a warning
-    fbtenv_set_shell_prompt;
     fbtenv_check_script_path || return 1;
     fbtenv_check_download_toolchain || return 1;
+    fbtenv_set_shell_prompt;
     PATH="$TOOLCHAIN_ARCH_DIR/python/bin:$PATH";
     PATH="$TOOLCHAIN_ARCH_DIR/bin:$PATH";
     PATH="$TOOLCHAIN_ARCH_DIR/protobuf/bin:$PATH";

--- a/scripts/toolchain/fbtenv.sh
+++ b/scripts/toolchain/fbtenv.sh
@@ -201,7 +201,6 @@ fbtenv_clearing()
         rm -rf "${FBT_TOOLCHAIN_PATH:?}/toolchain/*.tar.gz";
         rm -rf "${FBT_TOOLCHAIN_PATH:?}/toolchain/*.part";
     fi
-    trap - 2;
     echo "done";
     return 0;
 }
@@ -245,6 +244,7 @@ fbtenv_check_download_toolchain()
 
 fbtenv_download_toolchain()
 {
+    trap clearing 2;
     fbtenv_check_tar || return 1;
     TOOLCHAIN_TAR="$(basename "$TOOLCHAIN_URL")";
     TOOLCHAIN_DIR="$(echo "$TOOLCHAIN_TAR" | sed "s/-$FBT_TOOLCHAIN_VERSION.tar.gz//g")";
@@ -255,28 +255,26 @@ fbtenv_download_toolchain()
     fbtenv_remove_old_tooclhain;
     fbtenv_unpack_toolchain || return 1;
     fbtenv_clearing;
+    trap - 2;
     return 0;
 }
 
 fbtenv_main()
 {
-    trap clearing 2;
     fbtenv_check_sourced || return 1;
-    fbtenv_get_kernel_type || { fbtenv_clearing && return 1; };
+    fbtenv_get_kernel_type || return 1;
     if [ "$1" = "--restore" ]; then
         fbtenv_restore_env;
-        fbtenv_clearing;
         return 0;
     fi
     fbtenv_chck_many_source;  # many source it's just a warning
     fbtenv_set_shell_prompt;
-    fbtenv_check_script_path || { fbtenv_clearing && return 1; };
-    fbtenv_check_download_toolchain || { fbtenv_clearing && return 1; };
+    fbtenv_check_script_path || return 1;
+    fbtenv_check_download_toolchain || return 1;
     PATH="$TOOLCHAIN_ARCH_DIR/python/bin:$PATH";
     PATH="$TOOLCHAIN_ARCH_DIR/bin:$PATH";
     PATH="$TOOLCHAIN_ARCH_DIR/protobuf/bin:$PATH";
     PATH="$TOOLCHAIN_ARCH_DIR/openocd/bin:$PATH";
-    fbtenv_clearing;
 }
 
 fbtenv_main "${1:-""}";

--- a/scripts/toolchain/fbtenv.sh
+++ b/scripts/toolchain/fbtenv.sh
@@ -201,7 +201,7 @@ fbtenv_clearing()
     unset SCRIPT_PATH;
     unset FBT_TOOLCHAIN_VERSION;
     unset FBT_TOOLCHAIN_PATH;
-    trap - SIGINT;
+    trap - 2;
     echo "done";
     return 0;
 }
@@ -260,7 +260,7 @@ fbtenv_download_toolchain()
 
 fbtenv_main()
 {
-    trap clearing SIGINT;
+    trap clearing 2;
     fbtenv_check_sourced || return 1;
     fbtenv_get_kernel_type || { fbtenv_clearing && return 1; };
     if [ "$1" = "--restore" ]; then


### PR DESCRIPTION
# What's new

- disable PVS Studio and Amap analyses in forks
- add 'fbtenv.sh --restore' arg to fallback env changes
- minor fbtenv.sh clearing improovements

# Verification 

- try to aproove some fork to start github actions, pvs_studio and  amap should not start
- try to source fbtenv.sh and 'unsource' via --restore option

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
