### PR TITLE
nfc: Change furi_assert to furi_crash for default switch cases

### DIFF
--- a/applications/nfc/helpers/nfc_generators.c
+++ b/applications/nfc/helpers/nfc_generators.c
@@ -254,7 +254,7 @@ static void
         session_register_page = 234;
         break;
     default:
-        furi_assert(false);
+        furi_crash("new MFUL type values missing\n");
         break;
     }
 

--- a/applications/nfc/helpers/nfc_generators.c
+++ b/applications/nfc/helpers/nfc_generators.c
@@ -254,7 +254,7 @@ static void
         session_register_page = 234;
         break;
     default:
-        furi_crash("new MFUL type values missing\n");
+        furi_crash("Unknown MFUL");
         break;
     }
 

--- a/lib/nfc/protocols/mifare_ultralight.c
+++ b/lib/nfc/protocols/mifare_ultralight.c
@@ -940,7 +940,7 @@ static bool mf_ul_check_lock(MfUltralightEmulator* emulator, int16_t write_page)
         if(write_page >= 512) return true;
         break;
     default:
-        furi_crash("new MFUL type values missing\n");
+        furi_crash("Unknown MFUL");
         return true;
     }
 
@@ -967,7 +967,7 @@ static bool mf_ul_check_lock(MfUltralightEmulator* emulator, int16_t write_page)
         else if(write_page == 41)
             shift = 12;
         else {
-            furi_crash("new MFUL type values missing\n");
+            furi_crash("Unknown MFUL");
         }
 
         break;
@@ -998,7 +998,7 @@ static bool mf_ul_check_lock(MfUltralightEmulator* emulator, int16_t write_page)
             shift = (write_page - 16) / 32;
         break;
     default:
-        furi_crash("new MFUL type values missing\n");
+        furi_crash("Unknown MFUL");
         break;
     }
 
@@ -1175,7 +1175,7 @@ static void mf_ul_emulate_write(
                 block_lock_count = 8;
                 break;
             default:
-                furi_crash("new MFUL type values missing\n");
+                furi_crash("Unknown MFUL");
                 break;
             }
 

--- a/lib/nfc/protocols/mifare_ultralight.c
+++ b/lib/nfc/protocols/mifare_ultralight.c
@@ -940,7 +940,7 @@ static bool mf_ul_check_lock(MfUltralightEmulator* emulator, int16_t write_page)
         if(write_page >= 512) return true;
         break;
     default:
-        furi_assert(false);
+        furi_crash("new MFUL type values missing\n");
         return true;
     }
 
@@ -967,8 +967,7 @@ static bool mf_ul_check_lock(MfUltralightEmulator* emulator, int16_t write_page)
         else if(write_page == 41)
             shift = 12;
         else {
-            furi_assert(false);
-            shift = 0;
+            furi_crash("new MFUL type values missing\n");
         }
 
         break;
@@ -999,8 +998,7 @@ static bool mf_ul_check_lock(MfUltralightEmulator* emulator, int16_t write_page)
             shift = (write_page - 16) / 32;
         break;
     default:
-        furi_assert(false);
-        shift = 0;
+        furi_crash("new MFUL type values missing\n");
         break;
     }
 
@@ -1177,8 +1175,7 @@ static void mf_ul_emulate_write(
                 block_lock_count = 8;
                 break;
             default:
-                furi_assert(false);
-                block_lock_count = 0;
+                furi_crash("new MFUL type values missing\n");
                 break;
             }
 


### PR DESCRIPTION
# What's new

- Changed select instances of `furi_assert` to `furi_crash` so code will build when `DEBUG=0`
- Any additions to the tag type enum (i.e. new type supported) **must** be handled to provide the correct values or it will crash at runtime

# Verification 

- NFC still works the same as before, no crashing

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
