### PR TITLE
Remove obsolete info from docs

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -74,19 +74,7 @@ brew bundle --verbose
 
 ## Linux Prerequisites
 
-### gcc-arm-none-eabi
-
-```sh
-toolchain="gcc-arm-none-eabi-10.3-2021.10"
-toolchain_package="$toolchain-$(uname -m)-linux"
-
-wget -P /opt "https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/$toolchain_package.tar.bz2"
-
-tar xjf /opt/$toolchain_package.tar.bz2 -C /opt
-rm /opt/$toolchain_package.tar.bz2
-
-for file in /opt/$toolchain/bin/* ; do ln -s "${file}" "/usr/bin/$(basename ${file})" ; done
-```
+The FBT tool handles everything, only `git` is required.
 
 ### Optional dependencies
 

--- a/documentation/fbt.md
+++ b/documentation/fbt.md
@@ -6,7 +6,6 @@ It is invoked by `./fbt` in the firmware project root directory. Internally, it 
 ## Requirements
 
 Please install Python packages required by assets build scripts: `pip3 install -r scripts/requirements.txt`
-Make sure that `gcc-arm-none-eabi` toolchain & OpenOCD executables are in system's PATH.
 
 ## NB
 

--- a/scripts/ReadMe.md
+++ b/scripts/ReadMe.md
@@ -26,7 +26,6 @@ Also display type, region and etc...
 
 ## Core1 and Core2 firmware flashing
 
-Main flashing sequence can be found in root `Makefile`.
 Core2 goes first, then Core1.
 Never flash FUS or you will loose your job, girlfriend and keys in secure enclave.
 


### PR DESCRIPTION
# What's new

Looks like the documentation has not been properly updated after https://github.com/flipperdevices/flipperzero-firmware/pull/1351.

Manual actions are not required anymore.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
