### PR TITLE
More sensible guiding text when reading NFC

### DIFF
--- a/applications/nfc/scenes/nfc_scene_read.c
+++ b/applications/nfc/scenes/nfc_scene_read.c
@@ -25,7 +25,7 @@ void nfc_scene_read_set_state(Nfc* nfc, NfcSceneReadState state) {
         if(state == NfcSceneReadStateDetecting) {
             popup_reset(nfc->popup);
             popup_set_text(
-                nfc->popup, "Apply card to\nFlipper's back", 97, 24, AlignCenter, AlignTop);
+                nfc->popup, "Place Flipper\non the card\n with the\ndevice screen\nfacing up\n", 97, 6, AlignCenter, AlignTop);
             popup_set_icon(nfc->popup, 0, 8, &I_NFC_manual);
         } else if(state == NfcSceneReadStateReading) {
             popup_reset(nfc->popup);


### PR DESCRIPTION
# What's new

- Changed text to better explain how to place your Flipper on the card when reading NFC
![Screenshot-20220829-161512](https://user-images.githubusercontent.com/34287035/187210172-3c48b4c6-fbf0-4687-b70d-112fea3fb63e.png)
(tried my best to align it vertically)

# Verification 

- Go into NFC -> Read and verify the text has changed

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
