### PR TITLE
NFC: ST25TB type is not handled

### DIFF
--- a/firmware/targets/f7/furi_hal/furi_hal_nfc.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_nfc.c
@@ -124,7 +124,9 @@ bool furi_hal_nfc_detect(FuriHalNfcDevData* nfc_data, uint32_t timeout) {
             }
             nfc_data->cuid = (cuid_start[0] << 24) | (cuid_start[1] << 16) | (cuid_start[2] << 8) |
                              (cuid_start[3]);
-        } else if(dev_list[0].type == RFAL_NFC_LISTEN_TYPE_NFCB) {
+        } else if(dev_list[0].type == RFAL_NFC_LISTEN_TYPE_NFCB ||
+                  dev_list[0].type == RFAL_NFC_LISTEN_TYPE_ST25TB)
+        {
             nfc_data->type = FuriHalNfcTypeB;
         } else if(dev_list[0].type == RFAL_NFC_LISTEN_TYPE_NFCF) {
             nfc_data->type = FuriHalNfcTypeF;


### PR DESCRIPTION
We search for ST25TB type cards, but not handling them being found.
As a result, such cards are detected as NFC-A with 8-byte UID, which lead
to read error on emulation attempt.

# What's new

- ST25TB cards are handled as NFC-B cards (which they are, according to specs)

# Verification 

- Read the ST25TB card, it has to show NFC-B uid.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
