### PR TITLE
Fix displaying LFRFID protocol names

### DIFF
--- a/applications/lfrfid/scene/lfrfid_app_scene_save_type.cpp
+++ b/applications/lfrfid/scene/lfrfid_app_scene_save_type.cpp
@@ -4,11 +4,17 @@ void LfRfidAppSceneSaveType::on_enter(LfRfidApp* app, bool need_restore) {
     auto submenu = app->view_controller.get<SubmenuVM>();
 
     for(uint8_t i = 0; i < keys_count; i++) {
-        string_init_printf(
-            submenu_name[i],
-            "%s %s",
-            protocol_dict_get_manufacturer(app->dict, i),
-            protocol_dict_get_name(app->dict, i));
+        if(strcmp(
+               protocol_dict_get_manufacturer(app->dict, i),
+               protocol_dict_get_name(app->dict, i))) {
+            string_init_printf(
+                submenu_name[i],
+                "%s %s",
+                protocol_dict_get_manufacturer(app->dict, i),
+                protocol_dict_get_name(app->dict, i));
+        } else {
+            string_init_printf(submenu_name[i], "%s", protocol_dict_get_name(app->dict, i));
+        }
         submenu->add_item(string_get_cstr(submenu_name[i]), i, submenu_callback, app);
     }
 


### PR DESCRIPTION
# What's new

- Protocols no longer have double names

# Verification 

- Verify that Jablotron, Viking and Paradox are not "Jablotron Jablotron", "Viking Viking" etc. in the "Add manually" section of the LFRFID app
![CleanShot 2022-08-29 at 22 58 42@2x](https://user-images.githubusercontent.com/93453568/187287412-7b99eceb-bcce-4c91-8d58-ac4d1a796a88.png)

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
