### PR TITLE
[FL-2794] Lib: update LFS to v2.5.0, lower update free page limit

### DIFF
--- a/applications/storage/storages/storage_int.c
+++ b/applications/storage/storages/storage_int.c
@@ -9,7 +9,7 @@
 
 /* When less than LFS_RESERVED_PAGES_COUNT are left free, creation & 
  * modification of non-dot files is restricted */
-#define LFS_RESERVED_PAGES_COUNT 5
+#define LFS_RESERVED_PAGES_COUNT 3
 
 typedef struct {
     const size_t start_address;

--- a/lib/lfs_config.h
+++ b/lib/lfs_config.h
@@ -5,20 +5,25 @@
 #ifdef FURI_NDEBUG
 #define LFS_NO_ASSERT
 #define LFS_ASSERT(x)
-#else 
+#else
 #define LFS_ASSERT furi_assert
 #endif
 
 #define LFS_TAG "Lfs"
 
+#ifdef FURI_LFS_DEBUG
 #define LFS_TRACE(...) FURI_LOG_T(LFS_TAG, __VA_ARGS__);
 
 #define LFS_DEBUG(...) FURI_LOG_D(LFS_TAG, __VA_ARGS__);
+#else
+#define LFS_TRACE(...)
+
+#define LFS_DEBUG(...)
+#endif // FURI_LFS_DEBUG
 
 #define LFS_WARN(...) FURI_LOG_W(LFS_TAG, __VA_ARGS__);
 
 #define LFS_ERROR(...) FURI_LOG_E(LFS_TAG, __VA_ARGS__);
-
 
 // Because crc
 #undef LFS_CONFIG
@@ -35,16 +40,13 @@
 #ifndef LFS_NO_ASSERT
 #include <assert.h>
 #endif
-#if !defined(LFS_NO_DEBUG) || \
-        !defined(LFS_NO_WARN) || \
-        !defined(LFS_NO_ERROR) || \
-        defined(LFS_YES_TRACE)
+#if !defined(LFS_NO_DEBUG) || !defined(LFS_NO_WARN) || !defined(LFS_NO_ERROR) || \
+    defined(LFS_YES_TRACE)
 #include <stdio.h>
 #endif
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
 // Builtin functions, these may be replaced by more efficient
@@ -66,21 +68,29 @@ static inline uint32_t lfs_aligndown(uint32_t a, uint32_t alignment) {
 }
 
 static inline uint32_t lfs_alignup(uint32_t a, uint32_t alignment) {
-    return lfs_aligndown(a + alignment-1, alignment);
+    return lfs_aligndown(a + alignment - 1, alignment);
 }
 
 // Find the smallest power of 2 greater than or equal to a
 static inline uint32_t lfs_npw2(uint32_t a) {
 #if !defined(LFS_NO_INTRINSICS) && (defined(__GNUC__) || defined(__CC_ARM))
-    return 32 - __builtin_clz(a-1);
+    return 32 - __builtin_clz(a - 1);
 #else
     uint32_t r = 0;
     uint32_t s;
     a -= 1;
-    s = (a > 0xffff) << 4; a >>= s; r |= s;
-    s = (a > 0xff  ) << 3; a >>= s; r |= s;
-    s = (a > 0xf   ) << 2; a >>= s; r |= s;
-    s = (a > 0x3   ) << 1; a >>= s; r |= s;
+    s = (a > 0xffff) << 4;
+    a >>= s;
+    r |= s;
+    s = (a > 0xff) << 3;
+    a >>= s;
+    r |= s;
+    s = (a > 0xf) << 2;
+    a >>= s;
+    r |= s;
+    s = (a > 0x3) << 1;
+    a >>= s;
+    r |= s;
     return (r | (a >> 1)) + 1;
 #endif
 }
@@ -114,20 +124,23 @@ static inline int lfs_scmp(uint32_t a, uint32_t b) {
 
 // Convert between 32-bit little-endian and native order
 static inline uint32_t lfs_fromle32(uint32_t a) {
-#if !defined(LFS_NO_INTRINSICS) && ( \
-    (defined(  BYTE_ORDER  ) && defined(  ORDER_LITTLE_ENDIAN  ) &&   BYTE_ORDER   ==   ORDER_LITTLE_ENDIAN  ) || \
-    (defined(__BYTE_ORDER  ) && defined(__ORDER_LITTLE_ENDIAN  ) && __BYTE_ORDER   == __ORDER_LITTLE_ENDIAN  ) || \
-    (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
+#if !defined(LFS_NO_INTRINSICS) &&                                   \
+    ((defined(BYTE_ORDER) && defined(ORDER_LITTLE_ENDIAN) &&         \
+      BYTE_ORDER == ORDER_LITTLE_ENDIAN) ||                          \
+     (defined(__BYTE_ORDER) && defined(__ORDER_LITTLE_ENDIAN) &&     \
+      __BYTE_ORDER == __ORDER_LITTLE_ENDIAN) ||                      \
+     (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
+      __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
     return a;
-#elif !defined(LFS_NO_INTRINSICS) && ( \
-    (defined(  BYTE_ORDER  ) && defined(  ORDER_BIG_ENDIAN  ) &&   BYTE_ORDER   ==   ORDER_BIG_ENDIAN  ) || \
-    (defined(__BYTE_ORDER  ) && defined(__ORDER_BIG_ENDIAN  ) && __BYTE_ORDER   == __ORDER_BIG_ENDIAN  ) || \
-    (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
+#elif !defined(LFS_NO_INTRINSICS) &&                                                         \
+    ((defined(BYTE_ORDER) && defined(ORDER_BIG_ENDIAN) && BYTE_ORDER == ORDER_BIG_ENDIAN) || \
+     (defined(__BYTE_ORDER) && defined(__ORDER_BIG_ENDIAN) &&                                \
+      __BYTE_ORDER == __ORDER_BIG_ENDIAN) ||                                                 \
+     (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                            \
+      __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
     return __builtin_bswap32(a);
 #else
-    return (((uint8_t*)&a)[0] <<  0) |
-           (((uint8_t*)&a)[1] <<  8) |
-           (((uint8_t*)&a)[2] << 16) |
+    return (((uint8_t*)&a)[0] << 0) | (((uint8_t*)&a)[1] << 8) | (((uint8_t*)&a)[2] << 16) |
            (((uint8_t*)&a)[3] << 24);
 #endif
 }
@@ -138,21 +151,24 @@ static inline uint32_t lfs_tole32(uint32_t a) {
 
 // Convert between 32-bit big-endian and native order
 static inline uint32_t lfs_frombe32(uint32_t a) {
-#if !defined(LFS_NO_INTRINSICS) && ( \
-    (defined(  BYTE_ORDER  ) && defined(  ORDER_LITTLE_ENDIAN  ) &&   BYTE_ORDER   ==   ORDER_LITTLE_ENDIAN  ) || \
-    (defined(__BYTE_ORDER  ) && defined(__ORDER_LITTLE_ENDIAN  ) && __BYTE_ORDER   == __ORDER_LITTLE_ENDIAN  ) || \
-    (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
+#if !defined(LFS_NO_INTRINSICS) &&                                   \
+    ((defined(BYTE_ORDER) && defined(ORDER_LITTLE_ENDIAN) &&         \
+      BYTE_ORDER == ORDER_LITTLE_ENDIAN) ||                          \
+     (defined(__BYTE_ORDER) && defined(__ORDER_LITTLE_ENDIAN) &&     \
+      __BYTE_ORDER == __ORDER_LITTLE_ENDIAN) ||                      \
+     (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
+      __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
     return __builtin_bswap32(a);
-#elif !defined(LFS_NO_INTRINSICS) && ( \
-    (defined(  BYTE_ORDER  ) && defined(  ORDER_BIG_ENDIAN  ) &&   BYTE_ORDER   ==   ORDER_BIG_ENDIAN  ) || \
-    (defined(__BYTE_ORDER  ) && defined(__ORDER_BIG_ENDIAN  ) && __BYTE_ORDER   == __ORDER_BIG_ENDIAN  ) || \
-    (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
+#elif !defined(LFS_NO_INTRINSICS) &&                                                         \
+    ((defined(BYTE_ORDER) && defined(ORDER_BIG_ENDIAN) && BYTE_ORDER == ORDER_BIG_ENDIAN) || \
+     (defined(__BYTE_ORDER) && defined(__ORDER_BIG_ENDIAN) &&                                \
+      __BYTE_ORDER == __ORDER_BIG_ENDIAN) ||                                                 \
+     (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                            \
+      __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
     return a;
 #else
-    return (((uint8_t*)&a)[0] << 24) |
-           (((uint8_t*)&a)[1] << 16) |
-           (((uint8_t*)&a)[2] <<  8) |
-           (((uint8_t*)&a)[3] <<  0);
+    return (((uint8_t*)&a)[0] << 24) | (((uint8_t*)&a)[1] << 16) | (((uint8_t*)&a)[2] << 8) |
+           (((uint8_t*)&a)[3] << 0);
 #endif
 }
 
@@ -161,11 +177,11 @@ static inline uint32_t lfs_tobe32(uint32_t a) {
 }
 
 // Calculate CRC-32 with polynomial = 0x04c11db7
-uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size);
+uint32_t lfs_crc(uint32_t crc, const void* buffer, size_t size);
 
 // Allocate memory, only used if buffers are not provided to littlefs
 // Note, memory must be 64-bit aligned
-static inline void *lfs_malloc(size_t size) {
+static inline void* lfs_malloc(size_t size) {
 #ifndef LFS_NO_MALLOC
     return malloc(size);
 #else
@@ -175,14 +191,13 @@ static inline void *lfs_malloc(size_t size) {
 }
 
 // Deallocate memory, only used if buffers are not provided to littlefs
-static inline void lfs_free(void *p) {
+static inline void lfs_free(void* p) {
 #ifndef LFS_NO_MALLOC
     free(p);
 #else
     (void)p;
 #endif
 }
-
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/lib/update_util/update_operation.c
+++ b/lib/update_util/update_operation.c
@@ -12,7 +12,7 @@
 #define UPDATE_ROOT_DIR EXT_PATH("update")
 
 /* Need at least 4 free LFS pages before update */
-#define UPDATE_MIN_INT_FREE_SPACE 4 * 4 * 1024
+#define UPDATE_MIN_INT_FREE_SPACE 2 * 4 * 1024
 
 static const char* update_prepare_result_descr[] = {
     [UpdatePrepareResultOK] = "OK",


### PR DESCRIPTION
# What's new

- [FL-2794] Lib: update LFS to v2.5.0
- Lower update free page limit

# Verification 

- Compile and flash
- Update with 4 free pages left

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix

[FL-2794]: https://flipperzero.atlassian.net/browse/FL-2794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ