### PR TITLE
[FL-2802] Furi: wait for timer wind down in destructor

### DIFF
--- a/applications/gui/modules/text_input.c
+++ b/applications/gui/modules/text_input.c
@@ -463,8 +463,6 @@ void text_input_free(TextInput* text_input) {
 
     // Send stop command
     furi_timer_stop(text_input->timer);
-    // Wait till timer stop
-    while(furi_timer_is_running(text_input->timer)) furi_delay_tick(1);
     // Release allocated memory
     furi_timer_free(text_input->timer);
 


### PR DESCRIPTION
# What's new

- Furi: wait for timer wind down in destructor

# Verification 

- Compile and upload
- Check all apps working
- Snake: fixes use after free in timer callback on app exit

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
