### PR TITLE
[FL-2645, FL-2810] SubGhz: handle missing key in cryptostore. Lib: lower default display contrast. 

### DIFF
--- a/lib/subghz/subghz_keystore.c
+++ b/lib/subghz/subghz_keystore.c
@@ -116,7 +116,7 @@ static bool subghz_keystore_read_file(SubGhzKeystore* instance, Stream* stream, 
 
     do {
         if(iv) {
-            if (!furi_hal_crypto_store_load_key(SUBGHZ_KEYSTORE_FILE_ENCRYPTION_KEY_SLOT, iv)) {
+            if(!furi_hal_crypto_store_load_key(SUBGHZ_KEYSTORE_FILE_ENCRYPTION_KEY_SLOT, iv)) {
                 FURI_LOG_E(TAG, "Unable to load decryption key");
                 break;
             }

--- a/lib/subghz/subghz_keystore.c
+++ b/lib/subghz/subghz_keystore.c
@@ -114,62 +114,69 @@ static bool subghz_keystore_read_file(SubGhzKeystore* instance, Stream* stream, 
     char* encrypted_line = malloc(SUBGHZ_KEYSTORE_FILE_ENCRYPTED_LINE_SIZE);
     size_t encrypted_line_cursor = 0;
 
-    if(iv) furi_hal_crypto_store_load_key(SUBGHZ_KEYSTORE_FILE_ENCRYPTION_KEY_SLOT, iv);
-
-    size_t ret = 0;
     do {
-        ret = stream_read(stream, buffer, FILE_BUFFER_SIZE);
-        for(uint16_t i = 0; i < ret; i++) {
-            if(buffer[i] == '\n' && encrypted_line_cursor > 0) {
-                // Process line
-                if(iv) {
-                    // Data alignment check, 32 instead of 16 because of hex encoding
-                    size_t len = strlen(encrypted_line);
-                    if(len % 32 == 0) {
-                        // Inplace hex to bin conversion
-                        for(size_t i = 0; i < len; i += 2) {
-                            uint8_t hi_nibble = 0;
-                            uint8_t lo_nibble = 0;
-                            hex_char_to_hex_nibble(encrypted_line[i], &hi_nibble);
-                            hex_char_to_hex_nibble(encrypted_line[i + 1], &lo_nibble);
-                            encrypted_line[i / 2] = (hi_nibble << 4) | lo_nibble;
-                        }
-                        len /= 2;
-
-                        if(furi_hal_crypto_decrypt(
-                               (uint8_t*)encrypted_line, (uint8_t*)decrypted_line, len)) {
-                            subghz_keystore_process_line(instance, decrypted_line);
-                        } else {
-                            FURI_LOG_E(TAG, "Decryption failed");
-                            result = false;
-                            break;
-                        }
-                    } else {
-                        FURI_LOG_E(TAG, "Invalid encrypted data: %s", encrypted_line);
-                    }
-                } else {
-                    subghz_keystore_process_line(instance, encrypted_line);
-                }
-                // reset line buffer
-                memset(decrypted_line, 0, SUBGHZ_KEYSTORE_FILE_DECRYPTED_LINE_SIZE);
-                memset(encrypted_line, 0, SUBGHZ_KEYSTORE_FILE_ENCRYPTED_LINE_SIZE);
-                encrypted_line_cursor = 0;
-            } else if(buffer[i] == '\r' || buffer[i] == '\n') {
-                // do not add line endings to the buffer
-            } else {
-                if(encrypted_line_cursor < SUBGHZ_KEYSTORE_FILE_ENCRYPTED_LINE_SIZE) {
-                    encrypted_line[encrypted_line_cursor] = buffer[i];
-                    encrypted_line_cursor++;
-                } else {
-                    FURI_LOG_E(TAG, "Malformed file");
-                    result = false;
-                    break;
-                }
+        if(iv) {
+            if (!furi_hal_crypto_store_load_key(SUBGHZ_KEYSTORE_FILE_ENCRYPTION_KEY_SLOT, iv)) {
+                FURI_LOG_E(TAG, "Unable to load decryption key");
+                break;
             }
         }
-    } while(ret > 0 && result);
 
-    if(iv) furi_hal_crypto_store_unload_key(SUBGHZ_KEYSTORE_FILE_ENCRYPTION_KEY_SLOT);
+        size_t ret = 0;
+        do {
+            ret = stream_read(stream, buffer, FILE_BUFFER_SIZE);
+            for(uint16_t i = 0; i < ret; i++) {
+                if(buffer[i] == '\n' && encrypted_line_cursor > 0) {
+                    // Process line
+                    if(iv) {
+                        // Data alignment check, 32 instead of 16 because of hex encoding
+                        size_t len = strlen(encrypted_line);
+                        if(len % 32 == 0) {
+                            // Inplace hex to bin conversion
+                            for(size_t i = 0; i < len; i += 2) {
+                                uint8_t hi_nibble = 0;
+                                uint8_t lo_nibble = 0;
+                                hex_char_to_hex_nibble(encrypted_line[i], &hi_nibble);
+                                hex_char_to_hex_nibble(encrypted_line[i + 1], &lo_nibble);
+                                encrypted_line[i / 2] = (hi_nibble << 4) | lo_nibble;
+                            }
+                            len /= 2;
+
+                            if(furi_hal_crypto_decrypt(
+                                   (uint8_t*)encrypted_line, (uint8_t*)decrypted_line, len)) {
+                                subghz_keystore_process_line(instance, decrypted_line);
+                            } else {
+                                FURI_LOG_E(TAG, "Decryption failed");
+                                result = false;
+                                break;
+                            }
+                        } else {
+                            FURI_LOG_E(TAG, "Invalid encrypted data: %s", encrypted_line);
+                        }
+                    } else {
+                        subghz_keystore_process_line(instance, encrypted_line);
+                    }
+                    // reset line buffer
+                    memset(decrypted_line, 0, SUBGHZ_KEYSTORE_FILE_DECRYPTED_LINE_SIZE);
+                    memset(encrypted_line, 0, SUBGHZ_KEYSTORE_FILE_ENCRYPTED_LINE_SIZE);
+                    encrypted_line_cursor = 0;
+                } else if(buffer[i] == '\r' || buffer[i] == '\n') {
+                    // do not add line endings to the buffer
+                } else {
+                    if(encrypted_line_cursor < SUBGHZ_KEYSTORE_FILE_ENCRYPTED_LINE_SIZE) {
+                        encrypted_line[encrypted_line_cursor] = buffer[i];
+                        encrypted_line_cursor++;
+                    } else {
+                        FURI_LOG_E(TAG, "Malformed file");
+                        result = false;
+                        break;
+                    }
+                }
+            }
+        } while(ret > 0 && result);
+
+        if(iv) furi_hal_crypto_store_unload_key(SUBGHZ_KEYSTORE_FILE_ENCRYPTION_KEY_SLOT);
+    } while(false);
 
     free(encrypted_line);
     free(decrypted_line);

--- a/lib/u8g2/u8g2_glue.c
+++ b/lib/u8g2/u8g2_glue.c
@@ -225,7 +225,7 @@ uint8_t u8x8_d_st756x_flipper(u8x8_t* u8x8, uint8_t msg, uint8_t arg_int, void* 
                  * RR = 10 / ((1 - (63 - 32) / 162) * 2.1) ~= 5.88 is 6 (0b110)
                  * Bias = 1/9 (false)
                  */
-                u8x8_d_st756x_init(u8x8, 32, 0b110, false);
+                u8x8_d_st756x_init(u8x8, 31, 0b110, false);
             } else {
                 /* ERC v1(ST7565) and v2(ST7567)
                  * EV = 33
@@ -233,7 +233,7 @@ uint8_t u8x8_d_st756x_flipper(u8x8_t* u8x8, uint8_t msg, uint8_t arg_int, void* 
                  * RR = 9.3 / ((1 - (63 - 32) / 162) * 2.1) ~= 5.47 is 5.5 (0b101)
                  * Bias = 1/9 (false)
                  */
-                u8x8_d_st756x_init(u8x8, 33, 0b101, false);
+                u8x8_d_st756x_init(u8x8, 32, 0b101, false);
             }
             break;
         case U8X8_MSG_DISPLAY_SET_FLIP_MODE:


### PR DESCRIPTION
# What's new

- SubGhz: handle missing key in cryptostore.
- Lib: lower default display contrast.

# Verification 

- Compile and upload
- Do you know what
- Check that subghz is not crashing on start
- Check LCD: contrast is a 1 point lower.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
