### PR TITLE
[FL-2819] updater: fixed failing backups on /int with empty files in it

### DIFF
--- a/lib/toolbox/tar/tar_archive.c
+++ b/lib/toolbox/tar/tar_archive.c
@@ -294,6 +294,7 @@ bool tar_archive_add_file(
             break;
         }
 
+        success = true; // if file is empty, that's not an error
         uint16_t bytes_read = 0;
         while((bytes_read = storage_file_read(src_file, file_buffer, FILE_BLOCK_SIZE))) {
             success = tar_archive_file_add_data_block(archive, file_buffer, bytes_read);

--- a/lib/update_util/lfs_backup.c
+++ b/lib/update_util/lfs_backup.c
@@ -42,8 +42,7 @@ bool lfs_backup_create(Storage* storage, const char* destination) {
 
 bool lfs_backup_exists(Storage* storage, const char* source) {
     const char* final_source = source && strlen(source) ? source : LFS_BACKUP_DEFAULT_LOCATION;
-    FileInfo fi;
-    return storage_common_stat(storage, final_source, &fi) == FSE_OK;
+    return storage_common_stat(storage, final_source, NULL) == FSE_OK;
 }
 
 bool lfs_backup_unpack(Storage* storage, const char* source) {


### PR DESCRIPTION
# What's new

- [FL-2819] updater: fixed failing backups on /int with empty files in it

# Verification 

- Upload an empty file to /int
- Verify that updating from older firmware versions fail (or `updater bacup /ext/test.tar` fails)
- Flash this version
- Verify that LFS backups now properly handle empty files

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-2819]: https://flipperzero.atlassian.net/browse/FL-2819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ