### PR TITLE
[FL-2844] desktop: removing slideshow file when leaving slideshow view

### DIFF
--- a/.vscode/example/launch.json
+++ b/.vscode/example/launch.json
@@ -9,6 +9,10 @@
             "type": "command",
             "command": "shellCommand.execute",
             "args": {
+                "useSingleResult": true,
+                "env": {
+                    "PATH": "${workspaceFolder};${env:PATH}"
+                },
                 "command": "fbt get_blackmagic",
                 "description": "Get Blackmagic device",
             }

--- a/.vscode/example/launch.json
+++ b/.vscode/example/launch.json
@@ -9,7 +9,7 @@
             "type": "command",
             "command": "shellCommand.execute",
             "args": {
-                "command": "./fbt get_blackmagic",
+                "command": "fbt get_blackmagic",
                 "description": "Get Blackmagic device",
             }
         }

--- a/.vscode/example/launch.json
+++ b/.vscode/example/launch.json
@@ -13,7 +13,7 @@
                 "env": {
                     "PATH": "${workspaceFolder};${env:PATH}"
                 },
-                "command": "fbt get_blackmagic",
+                "command": "./fbt get_blackmagic",
                 "description": "Get Blackmagic device",
             }
         }

--- a/SConstruct
+++ b/SConstruct
@@ -236,9 +236,18 @@ distenv.PhonyTarget(
 distenv.PhonyTarget(
     "debug_other",
     "${GDBPYCOM}",
-    GDBPYOPTS='-ex "source debug/PyCortexMDebug/PyCortexMDebug.py" ',
+    GDBOPTS="${GDBOPTS_BASE}",
     GDBREMOTE="${OPENOCD_GDB_PIPE}",
+    GDBPYOPTS='-ex "source debug/PyCortexMDebug/PyCortexMDebug.py" ',
 )
+
+distenv.PhonyTarget(
+    "debug_other_blackmagic",
+    "${GDBPYCOM}",
+    GDBOPTS="${GDBOPTS_BASE}  ${GDBOPTS_BLACKMAGIC}",
+    GDBREMOTE="$${BLACKMAGIC_ADDR}",
+)
+
 
 # Just start OpenOCD
 distenv.PhonyTarget(

--- a/SConstruct
+++ b/SConstruct
@@ -44,6 +44,8 @@ distenv = coreenv.Clone(
         "target extended-remote ${GDBREMOTE}",
         "-ex",
         "set confirm off",
+        "-ex",
+        "set pagination off",
     ],
     GDBOPTS_BLACKMAGIC=[
         "-ex",

--- a/applications/services/desktop/scenes/desktop_scene_slideshow.c
+++ b/applications/services/desktop/scenes/desktop_scene_slideshow.c
@@ -1,3 +1,5 @@
+#include <storage/storage.h>
+
 #include "../desktop_i.h"
 #include "../views/desktop_view_slideshow.h"
 #include "../views/desktop_events.h"
@@ -44,4 +46,8 @@ bool desktop_scene_slideshow_on_event(void* context, SceneManagerEvent event) {
 
 void desktop_scene_slideshow_on_exit(void* context) {
     UNUSED(context);
+
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    storage_common_remove(storage, SLIDESHOW_FS_PATH);
+    furi_record_close(RECORD_STORAGE);
 }

--- a/applications/services/desktop/scenes/desktop_scene_slideshow.c
+++ b/applications/services/desktop/scenes/desktop_scene_slideshow.c
@@ -1,5 +1,3 @@
-#include <storage/storage.h>
-
 #include "../desktop_i.h"
 #include "../views/desktop_view_slideshow.h"
 #include "../views/desktop_events.h"
@@ -22,15 +20,11 @@ void desktop_scene_slideshow_on_enter(void* context) {
 bool desktop_scene_slideshow_on_event(void* context, SceneManagerEvent event) {
     Desktop* desktop = (Desktop*)context;
     bool consumed = false;
-    Storage* storage = NULL;
     Power* power = NULL;
 
     if(event.type == SceneManagerEventTypeCustom) {
         switch(event.event) {
         case DesktopSlideshowCompleted:
-            storage = furi_record_open(RECORD_STORAGE);
-            storage_common_remove(storage, SLIDESHOW_FS_PATH);
-            furi_record_close(RECORD_STORAGE);
             scene_manager_previous_scene(desktop->scene_manager);
             consumed = true;
             break;

--- a/applications/services/desktop/views/desktop_view_slideshow.c
+++ b/applications/services/desktop/views/desktop_view_slideshow.c
@@ -1,7 +1,6 @@
 #include <furi.h>
 #include <furi_hal.h>
 #include <gui/elements.h>
-#include <storage/storage.h>
 
 #include "desktop_view_slideshow.h"
 #include "../desktop_i.h"
@@ -30,12 +29,6 @@ static void desktop_view_slideshow_draw(Canvas* canvas, void* model) {
     if(slideshow_is_loaded(m->slideshow)) {
         slideshow_draw(m->slideshow, canvas, 0, 0);
     }
-}
-
-static void desktop_view_slideshow_delete() {
-    Storage* storage = furi_record_open(RECORD_STORAGE);
-    storage_common_remove(storage, SLIDESHOW_FS_PATH);
-    furi_record_close(RECORD_STORAGE);
 }
 
 static bool desktop_view_slideshow_input(InputEvent* event, void* context) {
@@ -102,8 +95,6 @@ static void desktop_view_slideshow_enter(void* context) {
 
 static void desktop_view_slideshow_exit(void* context) {
     DesktopSlideshowView* instance = context;
-
-    desktop_view_slideshow_delete();
 
     furi_timer_stop(instance->timer);
     furi_timer_free(instance->timer);

--- a/applications/services/desktop/views/desktop_view_slideshow.c
+++ b/applications/services/desktop/views/desktop_view_slideshow.c
@@ -1,6 +1,7 @@
 #include <furi.h>
 #include <furi_hal.h>
 #include <gui/elements.h>
+#include <storage/storage.h>
 
 #include "desktop_view_slideshow.h"
 #include "../desktop_i.h"
@@ -29,6 +30,12 @@ static void desktop_view_slideshow_draw(Canvas* canvas, void* model) {
     if(slideshow_is_loaded(m->slideshow)) {
         slideshow_draw(m->slideshow, canvas, 0, 0);
     }
+}
+
+static void desktop_view_slideshow_delete() {
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    storage_common_remove(storage, SLIDESHOW_FS_PATH);
+    furi_record_close(RECORD_STORAGE);
 }
 
 static bool desktop_view_slideshow_input(InputEvent* event, void* context) {
@@ -95,6 +102,8 @@ static void desktop_view_slideshow_enter(void* context) {
 
 static void desktop_view_slideshow_exit(void* context) {
     DesktopSlideshowView* instance = context;
+
+    desktop_view_slideshow_delete();
 
     furi_timer_stop(instance->timer);
     furi_timer_free(instance->timer);

--- a/documentation/fbt.md
+++ b/documentation/fbt.md
@@ -49,7 +49,7 @@ To run cleanup (think of `make clean`) for specified targets, add `-c` option.
 - `flash` - flash attached device with OpenOCD over ST-Link
 - `flash_usb`, `flash_usb_full` - build, upload and install update package to device over USB. See details on `updater_package`, `updater_minpackage` 
 - `debug` - build and flash firmware, then attach with gdb with firmware's .elf loaded
-- `debug_other` - attach gdb without loading any .elf. Allows to manually add external elf files with `add-symbol-file` in gdb
+- `debug_other`, `debug_other_blackmagic` - attach gdb without loading any .elf. Allows to manually add external elf files with `add-symbol-file` in gdb
 - `updater_debug` - attach gdb with updater's .elf loaded
 - `blackmagic` - debug firmware with Blackmagic probe (WiFi dev board)
 - `openocd` - just start OpenOCD

--- a/firmware/targets/f7/Inc/FreeRTOSConfig.h
+++ b/firmware/targets/f7/Inc/FreeRTOSConfig.h
@@ -76,19 +76,8 @@ to exclude the API function. */
 #define INCLUDE_xTaskGetSchedulerState 1
 #define INCLUDE_xTimerPendFunctionCall 1
 
-/* CMSIS-RTOS V2 flags */
-#define configUSE_OS2_THREAD_SUSPEND_RESUME 1
-#define configUSE_OS2_THREAD_ENUMERATE 1
-#define configUSE_OS2_THREAD_FLAGS 1
-#define configUSE_OS2_TIMER 1
-#define configUSE_OS2_MUTEX 1
-
-// NEVER TO BE USED, because of their hard realtime nature
-// #define configUSE_OS2_EVENTFLAGS_FROM_ISR 1
-
-/* CMSIS-RTOS */
+/* Furi-specific */
 #define configTASK_NOTIFICATION_ARRAY_ENTRIES 2
-#define CMSIS_TASK_NOTIFY_INDEX 1
 
 extern __attribute__((__noreturn__)) void furi_thread_catch();
 #define configTASK_RETURN_ADDRESS (furi_thread_catch + 2)

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,1.7,,
+Version,+,1.8,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,
@@ -157,29 +157,29 @@ Function,-,LL_ADC_REG_Init,ErrorStatus,"ADC_TypeDef*, LL_ADC_REG_InitTypeDef*"
 Function,-,LL_ADC_REG_StructInit,void,LL_ADC_REG_InitTypeDef*
 Function,-,LL_ADC_StructInit,void,LL_ADC_InitTypeDef*
 Function,-,LL_COMP_DeInit,ErrorStatus,COMP_TypeDef*
-Function,-,LL_COMP_Init,ErrorStatus,"COMP_TypeDef*, LL_COMP_InitTypeDef*"
+Function,+,LL_COMP_Init,ErrorStatus,"COMP_TypeDef*, LL_COMP_InitTypeDef*"
 Function,-,LL_COMP_StructInit,void,LL_COMP_InitTypeDef*
 Function,-,LL_CRC_DeInit,ErrorStatus,CRC_TypeDef*
 Function,-,LL_CRS_DeInit,ErrorStatus,
-Function,-,LL_DMA_DeInit,ErrorStatus,"DMA_TypeDef*, uint32_t"
-Function,-,LL_DMA_Init,ErrorStatus,"DMA_TypeDef*, uint32_t, LL_DMA_InitTypeDef*"
+Function,+,LL_DMA_DeInit,ErrorStatus,"DMA_TypeDef*, uint32_t"
+Function,+,LL_DMA_Init,ErrorStatus,"DMA_TypeDef*, uint32_t, LL_DMA_InitTypeDef*"
 Function,-,LL_DMA_StructInit,void,LL_DMA_InitTypeDef*
 Function,-,LL_EXTI_DeInit,ErrorStatus,
 Function,-,LL_EXTI_Init,ErrorStatus,LL_EXTI_InitTypeDef*
 Function,-,LL_EXTI_StructInit,void,LL_EXTI_InitTypeDef*
 Function,-,LL_GPIO_DeInit,ErrorStatus,GPIO_TypeDef*
-Function,-,LL_GPIO_Init,ErrorStatus,"GPIO_TypeDef*, LL_GPIO_InitTypeDef*"
+Function,+,LL_GPIO_Init,ErrorStatus,"GPIO_TypeDef*, LL_GPIO_InitTypeDef*"
 Function,-,LL_GPIO_StructInit,void,LL_GPIO_InitTypeDef*
 Function,-,LL_I2C_DeInit,ErrorStatus,I2C_TypeDef*
-Function,-,LL_I2C_Init,ErrorStatus,"I2C_TypeDef*, LL_I2C_InitTypeDef*"
+Function,+,LL_I2C_Init,ErrorStatus,"I2C_TypeDef*, LL_I2C_InitTypeDef*"
 Function,-,LL_I2C_StructInit,void,LL_I2C_InitTypeDef*
 Function,-,LL_Init1msTick,void,uint32_t
-Function,-,LL_LPTIM_DeInit,ErrorStatus,LPTIM_TypeDef*
+Function,+,LL_LPTIM_DeInit,ErrorStatus,LPTIM_TypeDef*
 Function,-,LL_LPTIM_Disable,void,LPTIM_TypeDef*
-Function,-,LL_LPTIM_Init,ErrorStatus,"LPTIM_TypeDef*, LL_LPTIM_InitTypeDef*"
+Function,+,LL_LPTIM_Init,ErrorStatus,"LPTIM_TypeDef*, LL_LPTIM_InitTypeDef*"
 Function,-,LL_LPTIM_StructInit,void,LL_LPTIM_InitTypeDef*
 Function,-,LL_LPUART_DeInit,ErrorStatus,USART_TypeDef*
-Function,-,LL_LPUART_Init,ErrorStatus,"USART_TypeDef*, LL_LPUART_InitTypeDef*"
+Function,+,LL_LPUART_Init,ErrorStatus,"USART_TypeDef*, LL_LPUART_InitTypeDef*"
 Function,-,LL_LPUART_StructInit,void,LL_LPUART_InitTypeDef*
 Function,-,LL_PKA_DeInit,ErrorStatus,PKA_TypeDef*
 Function,-,LL_PKA_Init,ErrorStatus,"PKA_TypeDef*, LL_PKA_InitTypeDef*"
@@ -193,14 +193,14 @@ Function,-,LL_RCC_GetADCClockFreq,uint32_t,uint32_t
 Function,-,LL_RCC_GetCLK48ClockFreq,uint32_t,uint32_t
 Function,-,LL_RCC_GetI2CClockFreq,uint32_t,uint32_t
 Function,-,LL_RCC_GetLPTIMClockFreq,uint32_t,uint32_t
-Function,-,LL_RCC_GetLPUARTClockFreq,uint32_t,uint32_t
+Function,+,LL_RCC_GetLPUARTClockFreq,uint32_t,uint32_t
 Function,-,LL_RCC_GetRFWKPClockFreq,uint32_t,
 Function,-,LL_RCC_GetRNGClockFreq,uint32_t,uint32_t
 Function,-,LL_RCC_GetRTCClockFreq,uint32_t,
 Function,-,LL_RCC_GetSAIClockFreq,uint32_t,uint32_t
 Function,-,LL_RCC_GetSMPSClockFreq,uint32_t,
 Function,-,LL_RCC_GetSystemClocksFreq,void,LL_RCC_ClocksTypeDef*
-Function,-,LL_RCC_GetUSARTClockFreq,uint32_t,uint32_t
+Function,+,LL_RCC_GetUSARTClockFreq,uint32_t,uint32_t
 Function,-,LL_RCC_GetUSBClockFreq,uint32_t,uint32_t
 Function,-,LL_RNG_DeInit,ErrorStatus,RNG_TypeDef*
 Function,-,LL_RNG_Init,ErrorStatus,"RNG_TypeDef*, LL_RNG_InitTypeDef*"
@@ -212,21 +212,21 @@ Function,-,LL_RTC_ALMB_StructInit,void,LL_RTC_AlarmTypeDef*
 Function,-,LL_RTC_DATE_Init,ErrorStatus,"RTC_TypeDef*, uint32_t, LL_RTC_DateTypeDef*"
 Function,-,LL_RTC_DATE_StructInit,void,LL_RTC_DateTypeDef*
 Function,-,LL_RTC_DeInit,ErrorStatus,RTC_TypeDef*
-Function,-,LL_RTC_EnterInitMode,ErrorStatus,RTC_TypeDef*
+Function,+,LL_RTC_EnterInitMode,ErrorStatus,RTC_TypeDef*
 Function,-,LL_RTC_ExitInitMode,ErrorStatus,RTC_TypeDef*
-Function,-,LL_RTC_Init,ErrorStatus,"RTC_TypeDef*, LL_RTC_InitTypeDef*"
+Function,+,LL_RTC_Init,ErrorStatus,"RTC_TypeDef*, LL_RTC_InitTypeDef*"
 Function,-,LL_RTC_StructInit,void,LL_RTC_InitTypeDef*
 Function,-,LL_RTC_TIME_Init,ErrorStatus,"RTC_TypeDef*, uint32_t, LL_RTC_TimeTypeDef*"
 Function,-,LL_RTC_TIME_StructInit,void,LL_RTC_TimeTypeDef*
 Function,-,LL_RTC_WaitForSynchro,ErrorStatus,RTC_TypeDef*
 Function,-,LL_SPI_DeInit,ErrorStatus,SPI_TypeDef*
-Function,-,LL_SPI_Init,ErrorStatus,"SPI_TypeDef*, LL_SPI_InitTypeDef*"
+Function,+,LL_SPI_Init,ErrorStatus,"SPI_TypeDef*, LL_SPI_InitTypeDef*"
 Function,-,LL_SPI_StructInit,void,LL_SPI_InitTypeDef*
 Function,-,LL_SetFlashLatency,ErrorStatus,uint32_t
-Function,-,LL_SetSystemCoreClock,void,uint32_t
+Function,+,LL_SetSystemCoreClock,void,uint32_t
 Function,-,LL_TIM_BDTR_Init,ErrorStatus,"TIM_TypeDef*, LL_TIM_BDTR_InitTypeDef*"
 Function,-,LL_TIM_BDTR_StructInit,void,LL_TIM_BDTR_InitTypeDef*
-Function,-,LL_TIM_DeInit,ErrorStatus,TIM_TypeDef*
+Function,+,LL_TIM_DeInit,ErrorStatus,TIM_TypeDef*
 Function,-,LL_TIM_ENCODER_Init,ErrorStatus,"TIM_TypeDef*, LL_TIM_ENCODER_InitTypeDef*"
 Function,-,LL_TIM_ENCODER_StructInit,void,LL_TIM_ENCODER_InitTypeDef*
 Function,-,LL_TIM_HALLSENSOR_Init,ErrorStatus,"TIM_TypeDef*, LL_TIM_HALLSENSOR_InitTypeDef*"
@@ -240,7 +240,7 @@ Function,-,LL_TIM_StructInit,void,LL_TIM_InitTypeDef*
 Function,-,LL_USART_ClockInit,ErrorStatus,"USART_TypeDef*, LL_USART_ClockInitTypeDef*"
 Function,-,LL_USART_ClockStructInit,void,LL_USART_ClockInitTypeDef*
 Function,-,LL_USART_DeInit,ErrorStatus,USART_TypeDef*
-Function,-,LL_USART_Init,ErrorStatus,"USART_TypeDef*, LL_USART_InitTypeDef*"
+Function,+,LL_USART_Init,ErrorStatus,"USART_TypeDef*, LL_USART_InitTypeDef*"
 Function,-,LL_USART_StructInit,void,LL_USART_InitTypeDef*
 Function,-,LL_mDelay,void,uint32_t
 Function,-,SystemCoreClockUpdate,void,

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,1.8,,
+Version,+,1.9,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,
@@ -1353,8 +1353,10 @@ Function,+,furi_thread_get_name,const char*,FuriThreadId
 Function,+,furi_thread_get_return_code,int32_t,FuriThread*
 Function,+,furi_thread_get_stack_space,uint32_t,FuriThreadId
 Function,+,furi_thread_get_state,FuriThreadState,FuriThread*
+Function,+,furi_thread_is_suspended,_Bool,FuriThreadId
 Function,+,furi_thread_join,_Bool,FuriThread*
 Function,+,furi_thread_mark_as_service,void,FuriThread*
+Function,+,furi_thread_resume,void,FuriThreadId
 Function,+,furi_thread_set_callback,void,"FuriThread*, FuriThreadCallback"
 Function,+,furi_thread_set_context,void,"FuriThread*, void*"
 Function,+,furi_thread_set_name,void,"FuriThread*, const char*"
@@ -1366,6 +1368,7 @@ Function,+,furi_thread_set_stdout_callback,_Bool,FuriThreadStdoutWriteCallback
 Function,+,furi_thread_start,void,FuriThread*
 Function,+,furi_thread_stdout_flush,int32_t,
 Function,+,furi_thread_stdout_write,size_t,"const char*, size_t"
+Function,+,furi_thread_suspend,void,FuriThreadId
 Function,+,furi_thread_yield,void,
 Function,+,furi_timer_alloc,FuriTimer*,"FuriTimerCallback, FuriTimerType, void*"
 Function,+,furi_timer_free,void,FuriTimer*

--- a/furi/core/thread.c
+++ b/furi/core/thread.c
@@ -89,7 +89,9 @@ static void furi_thread_body(void* context) {
 
     if(thread->is_service) {
         FURI_LOG_E(
-            "Service", "%s thread exited. Thread memory cannot be reclaimed.", thread->name);
+            "Service",
+            "%s thread exited. Thread memory cannot be reclaimed.",
+            thread->name ? thread->name : "<unknown service>");
     }
 
     // clear thread local storage
@@ -515,4 +517,23 @@ size_t furi_thread_stdout_write(const char* data, size_t size) {
 
 int32_t furi_thread_stdout_flush() {
     return __furi_thread_stdout_flush(furi_thread_get_current());
+}
+
+void furi_thread_suspend(FuriThreadId thread_id) {
+    TaskHandle_t hTask = (TaskHandle_t)thread_id;
+    vTaskSuspend(hTask);
+}
+
+void furi_thread_resume(FuriThreadId thread_id) {
+    TaskHandle_t hTask = (TaskHandle_t)thread_id;
+    if(FURI_IS_IRQ_MODE()) {
+        xTaskResumeFromISR(hTask);
+    } else {
+        vTaskResume(hTask);
+    }
+}
+
+bool furi_thread_is_suspended(FuriThreadId thread_id) {
+    TaskHandle_t hTask = (TaskHandle_t)thread_id;
+    return prvTaskIsTaskSuspended(hTask) == pdTRUE;
 }

--- a/furi/core/thread.c
+++ b/furi/core/thread.c
@@ -535,5 +535,5 @@ void furi_thread_resume(FuriThreadId thread_id) {
 
 bool furi_thread_is_suspended(FuriThreadId thread_id) {
     TaskHandle_t hTask = (TaskHandle_t)thread_id;
-    return prvTaskIsTaskSuspended(hTask) == pdTRUE;
+    return eTaskGetState(hTask) == eSuspended;
 }

--- a/furi/core/thread.h
+++ b/furi/core/thread.h
@@ -236,6 +236,25 @@ size_t furi_thread_stdout_write(const char* data, size_t size);
  */
 int32_t furi_thread_stdout_flush();
 
+/** Suspend thread
+ * 
+ * @param thread_id thread id
+ */
+void furi_thread_suspend(FuriThreadId thread_id);
+
+/** Resume thread
+ * 
+ * @param thread_id thread id
+ */
+void furi_thread_resume(FuriThreadId thread_id);
+
+/** Get thread suspended state
+ * 
+ * @param thread_id thread id
+ * @return true if thread is suspended
+ */
+bool furi_thread_is_suspended(FuriThreadId thread_id);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
# What's new

- [FL-2844] desktop: removing slideshow file when leaving slideshow view;
- vscode: fix for BM port fetcher;
- fap api: more symbols for LL

# Verification 

- Check that .slideshow file is removed when desktop programmatically changes scenes

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-2844]: https://flipperzero.atlassian.net/browse/FL-2844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ