### PR TITLE
[FL-2848] Universal Remote fix

### DIFF
--- a/applications/main/infrared/infrared_brute_force.c
+++ b/applications/main/infrared/infrared_brute_force.c
@@ -153,3 +153,7 @@ void infrared_brute_force_add_record(
     InfraredBruteForceRecordDict_set_at(brute_force->records, key, value);
     string_clear(key);
 }
+
+void infrared_brute_force_reset(InfraredBruteForce* brute_force) {
+    InfraredBruteForceRecordDict_reset(brute_force->records);
+}

--- a/applications/main/infrared/infrared_brute_force.h
+++ b/applications/main/infrared/infrared_brute_force.h
@@ -20,3 +20,4 @@ void infrared_brute_force_add_record(
     InfraredBruteForce* brute_force,
     uint32_t index,
     const char* name);
+void infrared_brute_force_reset(InfraredBruteForce* brute_force);

--- a/applications/main/infrared/scenes/common/infrared_scene_universal_common.c
+++ b/applications/main/infrared/scenes/common/infrared_scene_universal_common.c
@@ -87,5 +87,6 @@ void infrared_scene_universal_common_on_exit(void* context) {
     Infrared* infrared = context;
     ButtonPanel* button_panel = infrared->button_panel;
     view_stack_remove_view(infrared->view_stack, button_panel_get_view(button_panel));
+    infrared_brute_force_reset(infrared->brute_force);
     button_panel_reset(button_panel);
 }

--- a/applications/services/gui/modules/button_panel.c
+++ b/applications/services/gui/modules/button_panel.c
@@ -133,6 +133,8 @@ void button_panel_reset(ButtonPanel* button_panel) {
             }
             model->reserve_x = 0;
             model->reserve_y = 0;
+            model->selected_item_x = 0;
+            model->selected_item_y = 0;
             LabelList_reset(model->labels);
             ButtonMatrix_reset(model->button_matrix);
             return true;


### PR DESCRIPTION
# What's new

- Fix switching between universal remote types (TV and A/C)
- Reset selected button on exit from universal remote

# Verification 

1. Go to `Infrared -> Universal Remotes`.
2.  Go to `TVs`.
3. Select and press as many buttons as you like.
4. Go back.
5. Go to `Air Conditioners`.
6. Select and press as many buttons as you like.
7. Repeat steps 2-6 any number of times.

The correct signals must be transmitted every time.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
