### PR TITLE
Preliminary Rust support

### DIFF
--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -433,8 +433,8 @@ Function,-,acoshl,long double,long double
 Function,-,acosl,long double,long double
 Function,+,acquire_mutex,void*,"ValueMutex*, uint32_t"
 Function,-,aligned_alloc,void*,"size_t, size_t"
-Function,-,aligned_free,void,void*
-Function,-,aligned_malloc,void*,"size_t, size_t"
+Function,+,aligned_free,void,void*
+Function,+,aligned_malloc,void*,"size_t, size_t"
 Function,-,arc4random,__uint32_t,
 Function,-,arc4random_buf,void,"void*, size_t"
 Function,-,arc4random_uniform,__uint32_t,__uint32_t

--- a/firmware/targets/f7/application-ext.ld
+++ b/firmware/targets/f7/application-ext.ld
@@ -48,5 +48,7 @@ SECTIONS
 	{
 		*(.comment)
 		*(.comment.*)
+		*(.llvmbc)
+		*(.llvmcmd)
 	}
 }

--- a/lib/flipper_application/elf/elf.h
+++ b/lib/flipper_application/elf/elf.h
@@ -1116,6 +1116,8 @@ typedef struct {
 #define R_ARM_LDR_SBREL_11_0 35
 #define R_ARM_ALU_SBREL_19_12 36
 #define R_ARM_ALU_SBREL_27_20 37
+#define R_ARM_THM_MOVW_ABS_NC 47 /* Direct 16 bit (Thumb32 MOVW) */
+#define R_ARM_THM_MOVT_ABS 48 /* Direct high 16 bit */
 #define R_ARM_GNU_VTENTRY 100
 #define R_ARM_GNU_VTINHERIT 101
 #define R_ARM_THM_PC11 102 /* thumb unconditional branch */


### PR DESCRIPTION
# What's new

- Add support for `R_ARM_THM_MOVW_ABS_NC` and `R_ARM_THM_MOVT_ABS` relocations
- Expose `aligned_malloc`/`aligned_free` to extension applications
- Strip LLVM bitcode from extension applications

# Verification 

- Clone [dcoles/flipperzero-hello-rust](https://github.com/dcoles/flipperzero-hello-rust) into `applications_user`
- Follow [building instructions](https://github.com/dcoles/flipperzero-hello-rust#building)
- Open `log` in Flipper CLI then start the `Hello Rust` app
- Observe that the application prints "Hello, Rust! 🦀" in the logs, sleeps for 1 second and then exits

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
