### PR TITLE
Furi Thread: don't use thread pointer after FuriThreadStateStopped callback

### DIFF
--- a/furi/core/thread.c
+++ b/furi/core/thread.c
@@ -98,14 +98,10 @@ static void furi_thread_body(void* context) {
     furi_assert(pvTaskGetThreadLocalStoragePointer(NULL, 0) != NULL);
     vTaskSetThreadLocalStoragePointer(NULL, 0, NULL);
 
-    // Copy task handle on stack, because thread pointer can be freed by thread->state_callback
-    volatile TaskHandle_t task_handle_on_stack = thread->task_handle;
-    FURI_SW_MEMBARRIER();
-
     // from here we can't use thread pointer
     furi_thread_set_state(thread, FuriThreadStateStopped);
 
-    vTaskDelete(task_handle_on_stack);
+    vTaskDelete(NULL);
     furi_thread_catch();
 }
 

--- a/furi/core/thread.c
+++ b/furi/core/thread.c
@@ -207,6 +207,8 @@ void furi_thread_start(FuriThread* thread) {
 bool furi_thread_join(FuriThread* thread) {
     furi_assert(thread);
 
+    furi_check(furi_thread_get_current() != thread);
+
     while(eTaskGetState(thread->task_handle) != eDeleted) {
         furi_delay_ms(10);
     }


### PR DESCRIPTION
# What's new

- Correct furi_thread_join.
- Do not use thread pointer after FuriThreadStateStopped callback.

# Verification 

- `¯\_(ツ)_/¯`

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
