### PR TITLE
Add support for building/flashing on NixOS

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -78,7 +78,7 @@ brew bundle --verbose
 
 ## Linux Prerequisites
 
-The FBT tool handles everything, only `git` is required.
+The FBT tool handles everything, only `git` is required. NixOS users can run `nix-shell` to drop into a development shell.
 
 ### Optional dependencies
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,20 @@
+{ pkgs ? import <nixpkgs> {} }:
+(pkgs.buildFHSUserEnv {
+  name = "flipperzero";
+  targetPkgs = pkgs: (with pkgs; [
+    zlib
+    python39
+    python39Packages.pip
+    python39Packages.virtualenv
+    protobuf
+
+    scons
+    gcc-arm-embedded
+
+    openocd
+    dfu-util
+  ]);
+  runScript = ''
+    bash --init-file <(echo "virtualenv venv; source venv/bin/activate; pip3 install -r scripts/requirements.txt; export FBT_NOENV=1")
+  '';
+}).env


### PR DESCRIPTION
NixOS users can run `nix-shell` to land in a development environment where ./fbt commands will work.

# What's new

- Compiling & flashing now works on NixOS.

# Verification 

- Tested with ./fbt, ./fbt flash_usb, and ./fbt plugin_dist

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
