### PR TITLE
Furi Thread: fixed furi_thread_join, check if thread has not been started

### DIFF
--- a/furi/core/thread.c
+++ b/furi/core/thread.c
@@ -209,10 +209,13 @@ bool furi_thread_join(FuriThread* thread) {
 
     furi_check(furi_thread_get_current() != thread);
 
-    while(eTaskGetState(thread->task_handle) != eDeleted) {
-        furi_delay_ms(10);
+    // Check if thread was started
+    if(thread->task_handle != NULL) {
+        // Wait for thread to stop
+        while(eTaskGetState(thread->task_handle) != eDeleted) {
+            furi_delay_ms(10);
+        }
     }
-
     return FuriStatusOk;
 }
 

--- a/furi/core/thread.c
+++ b/furi/core/thread.c
@@ -210,13 +210,16 @@ bool furi_thread_join(FuriThread* thread) {
     furi_check(furi_thread_get_current() != thread);
 
     // Check if thread was started
-    if(thread->task_handle != NULL) {
-        // Wait for thread to stop
-        while(eTaskGetState(thread->task_handle) != eDeleted) {
-            furi_delay_ms(10);
-        }
+    if(thread->task_handle == NULL) {
+        return false;
     }
-    return FuriStatusOk;
+
+    // Wait for thread to stop
+    while(eTaskGetState(thread->task_handle) != eDeleted) {
+        furi_delay_ms(10);
+    }
+
+    return true;
 }
 
 FuriThreadId furi_thread_get_id(FuriThread* thread) {


### PR DESCRIPTION
# What's new

- Fixed furi_thread_join, check if thread has not been started.

# Verification 

- `¯\_(ツ)_/¯`
- Start reading NFC, exit the application. Flipper should not freeze.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
