### PR TITLE
Threads: Clear TLS after thread stop.

### DIFF
--- a/furi/core/thread.c
+++ b/furi/core/thread.c
@@ -93,13 +93,15 @@ static void furi_thread_body(void* context) {
             thread->name ? thread->name : "<unknown service>");
     }
 
-    // clear thread local storage
+    // flush stdout
     __furi_thread_stdout_flush(thread);
-    furi_assert(pvTaskGetThreadLocalStoragePointer(NULL, 0) != NULL);
-    vTaskSetThreadLocalStoragePointer(NULL, 0, NULL);
 
     // from here we can't use thread pointer
     furi_thread_set_state(thread, FuriThreadStateStopped);
+
+    // clear thread local storage
+    furi_assert(pvTaskGetThreadLocalStoragePointer(NULL, 0) != NULL);
+    vTaskSetThreadLocalStoragePointer(NULL, 0, NULL);
 
     vTaskDelete(NULL);
     furi_thread_catch();


### PR DESCRIPTION
# What's new

- Threads: Clear TLS after thread stop.
- furi_thread_join no longer hangs the flipper when the ScreenStream stops.

# Verification 

- Start qFlipper, start screen stream, exit qFlipper.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
