### PR TITLE
fix: typo badusb demo windows

### DIFF
--- a/assets/resources/badusb/demo_windows.txt
+++ b/assets/resources/badusb/demo_windows.txt
@@ -78,7 +78,7 @@ ENTER
 
 STRING Flipper Zero BadUSB feature is compatible with USB Rubber Ducky script format
 ENTER
-STRING More information about script synax can be found here:
+STRING More information about script syntax can be found here:
 ENTER
 STRING https://github.com/hak5darren/USB-Rubber-Ducky/wiki/Duckyscript
 ENTER


### PR DESCRIPTION
# What's new

- Fix a typo in the badusb demo script for Windows.

# Verification 

- Yet another typo: synax -> syn**t**ax

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
