### PR TITLE
music_player: Return to browser instead of exiting on back button

### DIFF
--- a/applications/plugins/music_player/music_player_worker.c
+++ b/applications/plugins/music_player/music_player_worker.c
@@ -133,6 +133,7 @@ static bool is_space(const char c) {
 
 static size_t extract_number(const char* string, uint32_t* number) {
     size_t ret = 0;
+    *number = 0;
     while(is_digit(*string)) {
         *number *= 10;
         *number += (*string - '0');
@@ -144,6 +145,7 @@ static size_t extract_number(const char* string, uint32_t* number) {
 
 static size_t extract_dots(const char* string, uint32_t* number) {
     size_t ret = 0;
+    *number = 0;
     while(*string == '.') {
         *number += 1;
         string++;

--- a/applications/plugins/music_player/music_player_worker.c
+++ b/applications/plugins/music_player/music_player_worker.c
@@ -108,6 +108,10 @@ MusicPlayerWorker* music_player_worker_alloc() {
     return instance;
 }
 
+void music_player_worker_clear(MusicPlayerWorker* instance) {
+    NoteBlockArray_reset(instance->notes);
+}
+
 void music_player_worker_free(MusicPlayerWorker* instance) {
     furi_assert(instance);
     furi_thread_free(instance->thread);

--- a/applications/plugins/music_player/music_player_worker.h
+++ b/applications/plugins/music_player/music_player_worker.h
@@ -14,6 +14,8 @@ typedef struct MusicPlayerWorker MusicPlayerWorker;
 
 MusicPlayerWorker* music_player_worker_alloc();
 
+void music_player_worker_clear(MusicPlayerWorker* instance);
+
 void music_player_worker_free(MusicPlayerWorker* instance);
 
 bool music_player_worker_load(MusicPlayerWorker* instance, const char* file_path);


### PR DESCRIPTION
# What's new

- Pressing back button after selecting a song will return to the browser instead of exiting the app
- Fix RTTTL parsing

Resolves #1765

# Verification 

1. Load a song
2. Press back
3. You should see the browser
4. Select a RTTTL and repeatedly go back and reload song. App should not mysteriously exit

*App seem to cause hourglass animation sometimes when exiting currently, looking into that.  
Update: reflashed and it's not hanging anymore, so who knows what that was all about.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
