### PR TITLE
Gui: fix memory leak in file browser module

### DIFF
--- a/applications/services/gui/modules/file_browser.c
+++ b/applications/services/gui/modules/file_browser.c
@@ -57,7 +57,6 @@ static void BrowserItem_t_set(BrowserItem_t* obj, const BrowserItem_t* src) {
     furi_string_set(obj->path, src->path);
     furi_string_set(obj->display_name, src->display_name);
     if(src->custom_icon_data) {
-        obj->custom_icon_data = malloc(CUSTOM_ICON_MAX_SIZE);
         memcpy(obj->custom_icon_data, src->custom_icon_data, CUSTOM_ICON_MAX_SIZE);
     } else {
         obj->custom_icon_data = NULL;
@@ -379,6 +378,9 @@ static void
             });
         furi_string_free(item.display_name);
         furi_string_free(item.path);
+        if(item.custom_icon_data) {
+            free(item.custom_icon_data);
+        }
     } else {
         with_view_model(
             browser->view, (FileBrowserModel * model) {


### PR DESCRIPTION
# What's new

- Fix memory leak in gui file browser module

# Verification 

- Compile and upload
- Check apps that uses file browser module
- Ensure that it's not leaking anymore

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
