### PR TITLE
Elf loader: do not load .ARM.* sections

### DIFF
--- a/lib/flipper_application/elf/elf_file.c
+++ b/lib/flipper_application/elf/elf_file.c
@@ -521,7 +521,7 @@ static SectionType elf_preload_section(
     // TODO: how to do it not by name?
     // .ARM: type 0x70000001, flags SHF_ALLOC | SHF_LINK_ORDER
     // .rel.ARM: type 0x9, flags SHT_REL
-    if(str_prefix(name, ".ARM") || str_prefix(name, ".rel.ARM")) {
+    if(str_prefix(name, ".ARM.") || str_prefix(name, ".rel.ARM.")) {
         FURI_LOG_D(TAG, "Ignoring ARM section");
         return SectionTypeUnused;
     }


### PR DESCRIPTION
# What's new

- .ARM.* sections no longer load
- Rust [hello world](https://github.com/dcoles/flipperzero-hello-rust) app now loads correctly.

# Verification 

- Build and execute hello-rust app.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
