### PR TITLE
[FL-2886] SubGhz: fix text overlap in read

### DIFF
--- a/applications/main/subghz/subghz_i.c
+++ b/applications/main/subghz/subghz_i.c
@@ -60,7 +60,7 @@ void subghz_get_frequency_modulation(SubGhz* subghz, FuriString* frequency, Furi
             subghz->txrx->preset->frequency / 10000 % 100);
     }
     if(modulation != NULL) {
-        furi_string_printf(modulation, "%2s", furi_string_get_cstr(subghz->txrx->preset->name));
+        furi_string_printf(modulation, "%.2s", furi_string_get_cstr(subghz->txrx->preset->name));
     }
 }
 


### PR DESCRIPTION
# What's new

- [FL-2886] SubGhz: fix text overlap in read

# Verification 

- check the display of the SubGhz->Read interface

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-2886]: https://flipperzero.atlassian.net/browse/FL-2886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ