### PR TITLE
[FL-2883] NFC: bank card rework reading

### DIFF
--- a/applications/main/nfc/scenes/nfc_scene_emv_menu.c
+++ b/applications/main/nfc/scenes/nfc_scene_emv_menu.c
@@ -1,7 +1,6 @@
 #include "../nfc_i.h"
 
 enum SubmenuIndex {
-    SubmenuIndexSave,
     SubmenuIndexInfo,
 };
 
@@ -15,7 +14,6 @@ void nfc_scene_emv_menu_on_enter(void* context) {
     Nfc* nfc = context;
     Submenu* submenu = nfc->submenu;
 
-    submenu_add_item(submenu, "Save", SubmenuIndexSave, nfc_scene_emv_menu_submenu_callback, nfc);
     submenu_add_item(submenu, "Info", SubmenuIndexInfo, nfc_scene_emv_menu_submenu_callback, nfc);
     submenu_set_selected_item(
         nfc->submenu, scene_manager_get_scene_state(nfc->scene_manager, NfcSceneEmvMenu));
@@ -28,13 +26,7 @@ bool nfc_scene_emv_menu_on_event(void* context, SceneManagerEvent event) {
     bool consumed = false;
 
     if(event.type == SceneManagerEventTypeCustom) {
-        if(event.event == SubmenuIndexSave) {
-            nfc->dev->format = NfcDeviceSaveFormatBankCard;
-            // Clear device name
-            nfc_device_set_name(nfc->dev, "");
-            scene_manager_next_scene(nfc->scene_manager, NfcSceneSaveName);
-            consumed = true;
-        } else if(event.event == SubmenuIndexInfo) {
+        if(event.event == SubmenuIndexInfo) {
             scene_manager_next_scene(nfc->scene_manager, NfcSceneNfcDataInfo);
             consumed = true;
         }

--- a/lib/nfc/nfc_device.c
+++ b/lib/nfc/nfc_device.c
@@ -636,35 +636,7 @@ bool nfc_device_load_mifare_df_data(FlipperFormat* file, NfcDevice* dev) {
     return parsed;
 }
 
-static bool nfc_device_save_bank_card_data(FlipperFormat* file, NfcDevice* dev) {
-    bool saved = false;
-    EmvData* data = &dev->dev_data.emv_data;
-    uint32_t data_temp = 0;
-
-    do {
-        // Write Bank card specific data
-        if(!flipper_format_write_comment_cstr(file, "Bank card specific data")) break;
-        if(!flipper_format_write_hex(file, "AID", data->aid, data->aid_len)) break;
-        if(!flipper_format_write_string_cstr(file, "Name", data->name)) break;
-        if(!flipper_format_write_hex(file, "Number", data->number, data->number_len)) break;
-        if(data->exp_mon) {
-            uint8_t exp_data[2] = {data->exp_mon, data->exp_year};
-            if(!flipper_format_write_hex(file, "Exp data", exp_data, sizeof(exp_data))) break;
-        }
-        if(data->country_code) {
-            data_temp = data->country_code;
-            if(!flipper_format_write_uint32(file, "Country code", &data_temp, 1)) break;
-        }
-        if(data->currency_code) {
-            data_temp = data->currency_code;
-            if(!flipper_format_write_uint32(file, "Currency code", &data_temp, 1)) break;
-        }
-        saved = true;
-    } while(false);
-
-    return saved;
-}
-
+// Leave for backward compatibility
 bool nfc_device_load_bank_card_data(FlipperFormat* file, NfcDevice* dev) {
     bool parsed = false;
     EmvData* data = &dev->dev_data.emv_data;
@@ -1068,7 +1040,7 @@ static bool nfc_device_save_file(
         if(!flipper_format_write_header_cstr(file, nfc_file_header, nfc_file_version)) break;
         // Write nfc device type
         if(!flipper_format_write_comment_cstr(
-               file, "Nfc device type can be UID, Mifare Ultralight, Mifare Classic, Bank card"))
+               file, "Nfc device type can be UID, Mifare Ultralight, Mifare Classic"))
             break;
         nfc_device_prepare_format_string(dev, temp_str);
         if(!flipper_format_write_string(file, "Device type", temp_str)) break;
@@ -1083,8 +1055,6 @@ static bool nfc_device_save_file(
             if(!nfc_device_save_mifare_ul_data(file, dev)) break;
         } else if(dev->format == NfcDeviceSaveFormatMifareDesfire) {
             if(!nfc_device_save_mifare_df_data(file, dev)) break;
-        } else if(dev->format == NfcDeviceSaveFormatBankCard) {
-            if(!nfc_device_save_bank_card_data(file, dev)) break;
         } else if(dev->format == NfcDeviceSaveFormatMifareClassic) {
             // Save data
             if(!nfc_device_save_mifare_classic_data(file, dev)) break;

--- a/lib/nfc/protocols/emv.c
+++ b/lib/nfc/protocols/emv.c
@@ -213,7 +213,7 @@ static bool emv_select_ppse(FuriHalNfcTxRxContext* tx_rx, EmvApplication* app) {
 }
 
 static bool emv_select_app(FuriHalNfcTxRxContext* tx_rx, EmvApplication* app) {
-    app->aid_found = false;
+    app->app_started = false;
     const uint8_t emv_select_header[] = {
         0x00,
         0xA4, // SELECT application
@@ -236,7 +236,7 @@ static bool emv_select_app(FuriHalNfcTxRxContext* tx_rx, EmvApplication* app) {
     if(furi_hal_nfc_tx_rx(tx_rx, 300)) {
         emv_trace(tx_rx, "Start application answer:");
         if(emv_decode_response(tx_rx->rx_data, tx_rx->rx_bits / 8, app)) {
-            app->aid_found = true;
+            app->app_started = true;
         } else {
             FURI_LOG_E(TAG, "Failed to read PAN or PDOL");
         }
@@ -244,7 +244,7 @@ static bool emv_select_app(FuriHalNfcTxRxContext* tx_rx, EmvApplication* app) {
         FURI_LOG_E(TAG, "Failed to start application");
     }
 
-    return app->aid_found;
+    return app->app_started;
 }
 
 static uint16_t emv_prepare_pdol(APDU* dest, APDU* src) {

--- a/lib/nfc/protocols/emv.c
+++ b/lib/nfc/protocols/emv.c
@@ -182,7 +182,7 @@ static bool emv_decode_response(uint8_t* buff, uint16_t len, EmvApplication* app
     return success;
 }
 
-bool emv_select_ppse(FuriHalNfcTxRxContext* tx_rx, EmvApplication* app) {
+static bool emv_select_ppse(FuriHalNfcTxRxContext* tx_rx, EmvApplication* app) {
     bool app_aid_found = false;
     const uint8_t emv_select_ppse_cmd[] = {
         0x00, 0xA4, // SELECT ppse
@@ -212,8 +212,8 @@ bool emv_select_ppse(FuriHalNfcTxRxContext* tx_rx, EmvApplication* app) {
     return app_aid_found;
 }
 
-bool emv_select_app(FuriHalNfcTxRxContext* tx_rx, EmvApplication* app) {
-    bool select_app_success = false;
+static bool emv_select_app(FuriHalNfcTxRxContext* tx_rx, EmvApplication* app) {
+    app->aid_found = false;
     const uint8_t emv_select_header[] = {
         0x00,
         0xA4, // SELECT application
@@ -236,7 +236,7 @@ bool emv_select_app(FuriHalNfcTxRxContext* tx_rx, EmvApplication* app) {
     if(furi_hal_nfc_tx_rx(tx_rx, 300)) {
         emv_trace(tx_rx, "Start application answer:");
         if(emv_decode_response(tx_rx->rx_data, tx_rx->rx_bits / 8, app)) {
-            select_app_success = true;
+            app->aid_found = true;
         } else {
             FURI_LOG_E(TAG, "Failed to read PAN or PDOL");
         }
@@ -244,7 +244,7 @@ bool emv_select_app(FuriHalNfcTxRxContext* tx_rx, EmvApplication* app) {
         FURI_LOG_E(TAG, "Failed to start application");
     }
 
-    return select_app_success;
+    return app->aid_found;
 }
 
 static uint16_t emv_prepare_pdol(APDU* dest, APDU* src) {
@@ -365,14 +365,6 @@ static bool emv_read_files(FuriHalNfcTxRxContext* tx_rx, EmvApplication* app) {
     }
 
     return card_num_read;
-}
-
-bool emv_search_application(FuriHalNfcTxRxContext* tx_rx, EmvApplication* emv_app) {
-    furi_assert(tx_rx);
-    furi_assert(emv_app);
-    memset(emv_app, 0, sizeof(EmvApplication));
-
-    return emv_select_ppse(tx_rx, emv_app);
 }
 
 bool emv_read_bank_card(FuriHalNfcTxRxContext* tx_rx, EmvApplication* emv_app) {

--- a/lib/nfc/protocols/emv.h
+++ b/lib/nfc/protocols/emv.h
@@ -45,6 +45,7 @@ typedef struct {
     uint8_t priority;
     uint8_t aid[16];
     uint8_t aid_len;
+    bool aid_found;
     char name[32];
     bool name_found;
     uint8_t card_number[10];
@@ -67,15 +68,6 @@ typedef struct {
  * @return true on success
  */
 bool emv_read_bank_card(FuriHalNfcTxRxContext* tx_rx, EmvApplication* emv_app);
-
-/** Search for EMV Application
- *
- * @param tx_rx     FuriHalNfcTxRxContext instance
- * @param emv_app   EmvApplication instance
- *
- * @return true on success
- */
-bool emv_search_application(FuriHalNfcTxRxContext* tx_rx, EmvApplication* emv_app);
 
 /** Emulate bank card
  * @note Answer to application selection and PDOL

--- a/lib/nfc/protocols/emv.h
+++ b/lib/nfc/protocols/emv.h
@@ -45,7 +45,7 @@ typedef struct {
     uint8_t priority;
     uint8_t aid[16];
     uint8_t aid_len;
-    bool aid_found;
+    bool app_started;
     char name[32];
     bool name_found;
     uint8_t card_number[10];


### PR DESCRIPTION
# What's new

- Remove save bank card option
- Try a few times to start EMV application if it was found
- Display AID even if card number wasn't parsed

# Verification 

- Bank cards can't be saved
- Find a distance when flipper can read AID but can't start EMV app. Verify flipper tries to start it for 3 times (in logs).
- Flipper displays AID if it can't parse bank card number

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
