### PR TITLE
Fix typo in fap loader logging

### DIFF
--- a/applications/main/fap_loader/fap_loader_app.c
+++ b/applications/main/fap_loader/fap_loader_app.c
@@ -101,7 +101,7 @@ static bool fap_loader_run_selected_app(FapLoader* loader) {
         }
 
         FURI_LOG_I(TAG, "Loaded in %ums", (size_t)(furi_get_tick() - start));
-        FURI_LOG_I(TAG, "FAP Loader is staring app");
+        FURI_LOG_I(TAG, "FAP Loader is starting app");
 
         FuriThread* thread = flipper_application_spawn(loader->app, NULL);
         furi_thread_start(thread);


### PR DESCRIPTION
# What's new

The output of the FAP loader includes the line
"FAP Loader is staring app" which contains a typo.

This adds the missing letter.

# Verification 

- Open serial connection
- Type "log"
- Load application from SD card
- Check output for correct spelling

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
