### PR TITLE
Fix FileNotFoundError in ./fbt flash_usb

### DIFF
--- a/scripts/update.py
+++ b/scripts/update.py
@@ -115,7 +115,7 @@ class Main(App):
         if self.args.dfu:
             dfu_size = os.stat(self.args.dfu).st_size
             shutil.copyfile(self.args.dfu, join(self.args.directory, dfu_basename))
-        if radiobin_basename:
+        if self.args.radiobin:
             shutil.copyfile(
                 self.args.radiobin, join(self.args.directory, radiobin_basename)
             )
@@ -158,7 +158,7 @@ class Main(App):
         file.writeKey("Radio", radiobin_basename or "")
         file.writeKey("Radio address", self.int2ffhex(radio_addr))
         file.writeKey("Radio version", self.int2ffhex(radio_version, 12))
-        if radiobin_basename:
+        if self.args.radiobin:
             file.writeKey("Radio CRC", self.int2ffhex(self.crc(self.args.radiobin)))
         else:
             file.writeKey("Radio CRC", self.int2ffhex(0))

--- a/scripts/update.py
+++ b/scripts/update.py
@@ -78,8 +78,12 @@ class Main(App):
 
     def generate(self):
         stage_basename = "updater.bin"  # used to be basename(self.args.stage)
-        dfu_basename = "firmware.dfu"  # used to be basename(self.args.dfu)
-        radiobin_basename = "radio.bin"  # used to be basename(self.args.radiobin)
+        dfu_basename = (
+            "firmware.dfu" if self.args.dfu else ""
+        )  # used to be basename(self.args.dfu)
+        radiobin_basename = (
+            "radio.bin" if self.args.radiobin else ""
+        )  # used to be basename(self.args.radiobin)
         resources_basename = ""
 
         radio_version = 0
@@ -115,7 +119,7 @@ class Main(App):
         if self.args.dfu:
             dfu_size = os.stat(self.args.dfu).st_size
             shutil.copyfile(self.args.dfu, join(self.args.directory, dfu_basename))
-        if self.args.radiobin:
+        if radiobin_basename:
             shutil.copyfile(
                 self.args.radiobin, join(self.args.directory, radiobin_basename)
             )
@@ -158,7 +162,7 @@ class Main(App):
         file.writeKey("Radio", radiobin_basename or "")
         file.writeKey("Radio address", self.int2ffhex(radio_addr))
         file.writeKey("Radio version", self.int2ffhex(radio_version, 12))
-        if self.args.radiobin:
+        if radiobin_basename:
             file.writeKey("Radio CRC", self.int2ffhex(self.crc(self.args.radiobin)))
         else:
             file.writeKey("Radio CRC", self.int2ffhex(0))


### PR DESCRIPTION
# What's new

- Seems like `./fbt flash_usb` broke due to https://github.com/flipperdevices/flipperzero-firmware/pull/1871 

```
    return self.args.func()
  File "/Users/kevin/Github/flipperzero-firmware/scripts/update.py", line 119, in generate
    shutil.copyfile(
  File "/Users/kevin/Github/flipperzero-firmware/toolchain/x86_64-darwin/python/lib/python3.9/shutil.py", line 264, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: ''
```

# Verification 

- ./fbt flash_usb

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
