### PR TITLE
fbt: fix for cincludes in app's private library definition

### DIFF
--- a/scripts/fbt_tools/fbt_extapps.py
+++ b/scripts/fbt_tools/fbt_extapps.py
@@ -80,10 +80,7 @@ def BuildAppElf(env, app):
                 *lib_def.cflags,
             ],
             CPPDEFINES=lib_def.cdefines,
-            CPPPATH=list(
-                os.path.join(app._appdir.path, cinclude)
-                for cinclude in lib_def.cincludes
-            ),
+            CPPPATH=list(map(app._appdir.Dir, lib_def.cincludes)),
         )
 
         lib = private_lib_env.StaticLibrary(


### PR DESCRIPTION
# What's new

- Fixed path handling for cincludes field in app's private libs

# Verification 

- idk

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
