### PR TITLE
NFC fixes part 3

### DIFF
--- a/lib/nfc/helpers/mf_classic_dict.c
+++ b/lib/nfc/helpers/mf_classic_dict.c
@@ -161,9 +161,8 @@ bool mf_classic_dict_get_next_key_str(MfClassicDict* dict, FuriString* key) {
     furi_string_reset(key);
     while(!key_read) {
         if(!stream_read_line(dict->stream, key)) break;
-        furi_string_trim(key);
         if(furi_string_get_char(key, 0) == '#') continue;
-        if(furi_string_size(key) != NFC_MF_CLASSIC_KEY_LEN - 1) continue;
+        if(furi_string_size(key) != NFC_MF_CLASSIC_KEY_LEN) continue;
         furi_string_left(key, 12);
         key_read = true;
     }

--- a/lib/nfc/helpers/mf_classic_dict.c
+++ b/lib/nfc/helpers/mf_classic_dict.c
@@ -147,8 +147,9 @@ bool mf_classic_dict_get_next_key_str(MfClassicDict* dict, FuriString* key) {
     furi_string_reset(key);
     while(!key_read) {
         if(!stream_read_line(dict->stream, key)) break;
+        furi_string_trim(key);
         if(furi_string_get_char(key, 0) == '#') continue;
-        if(furi_string_size(key) != NFC_MF_CLASSIC_KEY_LEN) continue;
+        if(furi_string_size(key) != NFC_MF_CLASSIC_KEY_LEN - 1) continue;
         furi_string_left(key, 12);
         key_read = true;
     }

--- a/lib/nfc/helpers/mf_classic_dict.c
+++ b/lib/nfc/helpers/mf_classic_dict.c
@@ -62,21 +62,23 @@ MfClassicDict* mf_classic_dict_alloc(MfClassicDictType dict_type) {
                    dict->stream,
                    MF_CLASSIC_DICT_UNIT_TEST_PATH,
                    FSAM_READ_WRITE,
-                   FSOM_CREATE_ALWAYS)) {
+                   FSOM_OPEN_ALWAYS)) {
                 buffered_file_stream_close(dict->stream);
                 break;
             }
         }
 
         // Check for new line ending
-        if(!stream_seek(dict->stream, -1, StreamOffsetFromEnd)) break;
-        uint8_t last_char = 0;
-        if(stream_read(dict->stream, &last_char, 1) != 1) break;
-        if(last_char != '\n') {
-            FURI_LOG_D(TAG, "Adding new line ending");
-            if(stream_write_char(dict->stream, '\n') != 1) break;
+        if(!stream_eof(dict->stream)) {
+            if(!stream_seek(dict->stream, -1, StreamOffsetFromEnd)) break;
+            uint8_t last_char = 0;
+            if(stream_read(dict->stream, &last_char, 1) != 1) break;
+            if(last_char != '\n') {
+                FURI_LOG_D(TAG, "Adding new line ending");
+                if(stream_write_char(dict->stream, '\n') != 1) break;
+            }
+            if(!stream_rewind(dict->stream)) break;
         }
-        if(!stream_rewind(dict->stream)) break;
 
         // Read total amount of keys
         FuriString* next_line;

--- a/lib/nfc/helpers/mf_classic_dict.c
+++ b/lib/nfc/helpers/mf_classic_dict.c
@@ -44,7 +44,10 @@ MfClassicDict* mf_classic_dict_alloc(MfClassicDictType dict_type) {
     do {
         if(dict_type == MfClassicDictTypeFlipper) {
             if(!buffered_file_stream_open(
-                   dict->stream, MF_CLASSIC_DICT_FLIPPER_PATH, FSAM_READ, FSOM_OPEN_EXISTING)) {
+                   dict->stream,
+                   MF_CLASSIC_DICT_FLIPPER_PATH,
+                   FSAM_READ_WRITE,
+                   FSOM_OPEN_EXISTING)) {
                 buffered_file_stream_close(dict->stream);
                 break;
             }
@@ -65,6 +68,16 @@ MfClassicDict* mf_classic_dict_alloc(MfClassicDictType dict_type) {
             }
         }
 
+        // Check for new line ending
+        if(!stream_seek(dict->stream, -1, StreamOffsetFromEnd)) break;
+        uint8_t last_char = 0;
+        if(stream_read(dict->stream, &last_char, 1) != 1) break;
+        if(last_char != '\n') {
+            FURI_LOG_D(TAG, "Adding new line ending");
+            if(stream_write_char(dict->stream, '\n') != 1) break;
+        }
+        if(!stream_rewind(dict->stream)) break;
+
         // Read total amount of keys
         FuriString* next_line;
         next_line = furi_string_alloc();
@@ -73,14 +86,13 @@ MfClassicDict* mf_classic_dict_alloc(MfClassicDictType dict_type) {
                 FURI_LOG_T(TAG, "No keys left in dict");
                 break;
             }
-            furi_string_trim(next_line);
             FURI_LOG_T(
                 TAG,
                 "Read line: %s, len: %d",
                 furi_string_get_cstr(next_line),
                 furi_string_size(next_line));
             if(furi_string_get_char(next_line, 0) == '#') continue;
-            if(furi_string_size(next_line) != NFC_MF_CLASSIC_KEY_LEN - 1) continue;
+            if(furi_string_size(next_line) != NFC_MF_CLASSIC_KEY_LEN) continue;
             dict->total_keys++;
         }
         furi_string_free(next_line);

--- a/lib/nfc/nfc_device.c
+++ b/lib/nfc/nfc_device.c
@@ -921,7 +921,7 @@ static bool nfc_device_save_mifare_classic_keys(NfcDevice* dev) {
                     file, furi_string_get_cstr(temp_str), sec_tr->key_a, 6);
             }
             if(!key_save_success) break;
-            if(FURI_BIT(data->key_a_mask, i)) {
+            if(FURI_BIT(data->key_b_mask, i)) {
                 furi_string_printf(temp_str, "Key B sector %d", i);
                 key_save_success = flipper_format_write_hex(
                     file, furi_string_get_cstr(temp_str), sec_tr->key_b, 6);


### PR DESCRIPTION
# What's new

- Add new line ending on mifare classic dictionary load
- Add unit test for dictionaries with no new line ending
- Fix incorrect key cache save

# Verification 

- Run unit tests
- Add user dictionary file without new line ending. Verify that all keys are processed correctly
- Verify key cache is saved correctly

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
