### PR TITLE
[FL-2912] Forced RAW receive option for Infrared CLI

### DIFF
--- a/lib/infrared/worker/infrared_worker.c
+++ b/lib/infrared/worker/infrared_worker.c
@@ -57,6 +57,7 @@ struct InfraredWorker {
     InfraredDecoderHandler* infrared_decoder;
     NotificationApp* notification;
     bool blink_enable;
+    bool decode_enable;
 
     union {
         struct {
@@ -131,7 +132,8 @@ static void infrared_worker_process_timeout(InfraredWorker* instance) {
 static void
     infrared_worker_process_timings(InfraredWorker* instance, uint32_t duration, bool level) {
     const InfraredMessage* message_decoded =
-        infrared_decode(instance->infrared_decoder, level, duration);
+        instance->decode_enable ? infrared_decode(instance->infrared_decoder, level, duration) :
+                                  NULL;
     if(message_decoded) {
         instance->signal.message = *message_decoded;
         instance->signal.timings_cnt = 0;
@@ -233,6 +235,7 @@ InfraredWorker* infrared_worker_alloc() {
     instance->infrared_decoder = infrared_alloc_decoder();
     instance->infrared_encoder = infrared_alloc_encoder();
     instance->blink_enable = false;
+    instance->decode_enable = true;
     instance->notification = furi_record_open(RECORD_NOTIFICATION);
     instance->state = InfraredWorkerStateIdle;
 
@@ -314,6 +317,11 @@ const InfraredMessage* infrared_worker_get_decoded_signal(const InfraredWorkerSi
 void infrared_worker_rx_enable_blink_on_receiving(InfraredWorker* instance, bool enable) {
     furi_assert(instance);
     instance->blink_enable = enable;
+}
+
+void infrared_worker_rx_enable_signal_decoding(InfraredWorker* instance, bool enable) {
+    furi_assert(instance);
+    instance->decode_enable = enable;
 }
 
 void infrared_worker_tx_start(InfraredWorker* instance) {

--- a/lib/infrared/worker/infrared_worker.h
+++ b/lib/infrared/worker/infrared_worker.h
@@ -76,6 +76,14 @@ void infrared_worker_rx_set_received_signal_callback(
  */
 void infrared_worker_rx_enable_blink_on_receiving(InfraredWorker* instance, bool enable);
 
+/** Enable decoding of received infrared signals.
+ *
+ * @param[in]   instance - instance of InfraredWorker
+ * @param[in]   enable - true if you want to enable decoding
+ *                       false otherwise
+ */
+void infrared_worker_rx_enable_signal_decoding(InfraredWorker* instance, bool enable);
+
 /** Clarify is received signal either decoded or raw
  *
  * @param[in]   signal - received signal


### PR DESCRIPTION
# What's new
Implement a raw-only mode for the Infrared command-line interface.

# Verification 
1. Open a CLI session with Flipper.
2. Run `ir rx` and send some IR signals that are known to be decodable. Observe the decoded output.
3. Run `ir rx raw` and send the same signals as in step 2. No decoding should be performed, the RAW data should be printed instead.
4. Verify that receiving in the RAW mode has no effect on signals that are known to be non-decodable.
5. Run `ir rx <garbage input>`. A usage help should be printed.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
