### PR TITLE
Fix FuriString oplist (init move)

### DIFF
--- a/applications/main/infrared/infrared_cli.c
+++ b/applications/main/infrared/infrared_cli.c
@@ -9,12 +9,11 @@
 #include "infrared_signal.h"
 #include "infrared_brute_force.h"
 
-#include "m-dict.h"
-#include "m-string.h"
+#include <m-dict.h>
 
 #define INFRARED_CLI_BUF_SIZE 10
 
-DICT_DEF2(dict_signals, string_t, STRING_OPLIST, int, M_DEFAULT_OPLIST)
+DICT_DEF2(dict_signals, FuriString*, FURI_STRING_OPLIST, int, M_DEFAULT_OPLIST)
 
 enum RemoteTypes { TV = 0, AC = 1 };
 
@@ -416,7 +415,7 @@ static void infrared_cli_list_remote_signals(enum RemoteTypes remote_type) {
     Storage* storage = furi_record_open(RECORD_STORAGE);
     FlipperFormat* ff = flipper_format_buffered_file_alloc(storage);
     dict_signals_t signals_dict;
-    string_t key;
+    FuriString* key;
     const char* remote_file = NULL;
     bool success = false;
     int max = 1;
@@ -433,7 +432,7 @@ static void infrared_cli_list_remote_signals(enum RemoteTypes remote_type) {
     }
 
     dict_signals_init(signals_dict);
-    string_init(key);
+    key = furi_string_alloc();
 
     success = flipper_format_buffered_file_open_existing(ff, remote_file);
     if(success) {
@@ -441,7 +440,7 @@ static void infrared_cli_list_remote_signals(enum RemoteTypes remote_type) {
         signal_name = furi_string_alloc();
         printf("Valid signals:\r\n");
         while(flipper_format_read_string(ff, "name", signal_name)) {
-            string_set_str(key, furi_string_get_cstr(signal_name));
+            furi_string_set_str(key, furi_string_get_cstr(signal_name));
             int* v = dict_signals_get(signals_dict, key);
             if(v != NULL) {
                 (*v)++;
@@ -453,12 +452,12 @@ static void infrared_cli_list_remote_signals(enum RemoteTypes remote_type) {
         dict_signals_it_t it;
         for(dict_signals_it(it, signals_dict); !dict_signals_end_p(it); dict_signals_next(it)) {
             const struct dict_signals_pair_s* pair = dict_signals_cref(it);
-            printf("\t%s\r\n", string_get_cstr(pair->key));
+            printf("\t%s\r\n", furi_string_get_cstr(pair->key));
         }
         furi_string_free(signal_name);
     }
 
-    string_clear(key);
+    furi_string_free(key);
     dict_signals_clear(signals_dict);
     flipper_format_free(ff);
     furi_record_close(RECORD_STORAGE);

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,3.3,,
+Version,+,3.4,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,
@@ -976,7 +976,7 @@ Function,-,furi_hal_compress_icon_decode,void,"const uint8_t*, uint8_t**"
 Function,-,furi_hal_compress_icon_init,void,
 Function,+,furi_hal_console_disable,void,
 Function,+,furi_hal_console_enable,void,
-Function,-,furi_hal_console_init,void,
+Function,+,furi_hal_console_init,void,
 Function,+,furi_hal_console_printf,void,"const char[], ..."
 Function,+,furi_hal_console_puts,void,const char*
 Function,+,furi_hal_console_set_tx_callback,void,"FuriHalConsoleTxCallback, void*"

--- a/furi/core/string.h
+++ b/furi/core/string.h
@@ -719,21 +719,26 @@ void furi_string_utf8_decode(char c, FuriStringUTF8State* state, FuriStringUnico
 #define F_STR_INIT_SET(a, b) ((a) = furi_string_alloc_set(b))
 
 /**
+ * @brief INIT SET OPLIST for FuriString.
+ */
+#define F_STR_INIT_MOVE(a, b) ((a) = furi_string_alloc_move(b))
+
+/**
  * @brief OPLIST for FuriString.
  */
-#define FURI_STRING_OPLIST              \
-    (INIT(F_STR_INIT),                  \
-     INIT_SET(F_STR_INIT_SET),          \
-     SET(furi_string_set),              \
-     INIT_MOVE(furi_string_alloc_move), \
-     MOVE(furi_string_move),            \
-     SWAP(furi_string_swap),            \
-     RESET(furi_string_reset),          \
-     EMPTY_P(furi_string_empty),        \
-     CLEAR(furi_string_free),           \
-     HASH(furi_string_hash),            \
-     EQUAL(furi_string_equal),          \
-     CMP(furi_string_cmp),              \
+#define FURI_STRING_OPLIST       \
+    (INIT(F_STR_INIT),           \
+     INIT_SET(F_STR_INIT_SET),   \
+     SET(furi_string_set),       \
+     INIT_MOVE(F_STR_INIT_MOVE), \
+     MOVE(furi_string_move),     \
+     SWAP(furi_string_swap),     \
+     RESET(furi_string_reset),   \
+     EMPTY_P(furi_string_empty), \
+     CLEAR(furi_string_free),    \
+     HASH(furi_string_hash),     \
+     EQUAL(furi_string_equal),   \
+     CMP(furi_string_cmp),       \
      TYPE(FuriString*))
 
 #ifdef __cplusplus

--- a/furi/core/string.h
+++ b/furi/core/string.h
@@ -719,7 +719,7 @@ void furi_string_utf8_decode(char c, FuriStringUTF8State* state, FuriStringUnico
 #define F_STR_INIT_SET(a, b) ((a) = furi_string_alloc_set(b))
 
 /**
- * @brief INIT SET OPLIST for FuriString.
+ * @brief INIT MOVE OPLIST for FuriString.
  */
 #define F_STR_INIT_MOVE(a, b) ((a) = furi_string_alloc_move(b))
 

--- a/lib/flipper_application/elf/elf_file.c
+++ b/lib/flipper_application/elf/elf_file.c
@@ -786,6 +786,16 @@ ELFFileLoadStatus elf_file_load_sections(ELFFile* elf) {
     FURI_LOG_D(TAG, "Trampoline cache size: %u", AddressCache_size(elf->trampoline_cache));
     AddressCache_clear(elf->relocation_cache);
 
+    {
+        size_t total_size = 0;
+        for(ELFSectionDict_it(it, elf->sections); !ELFSectionDict_end_p(it);
+            ELFSectionDict_next(it)) {
+            ELFSectionDict_itref_t* itref = ELFSectionDict_ref(it);
+            total_size += itref->value.size;
+        }
+        FURI_LOG_I(TAG, "Total size of loaded sections: %u", total_size);
+    }
+
     return status;
 }
 


### PR DESCRIPTION
# What's new

- FuriString oplist now supports the `init move` operation.

# Verification 

- CLI command `ir universal list tv` should work and memory should not leak.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
