### PR TITLE
Furi: show thread allocation balance for child threads

### DIFF
--- a/applications/services/loader/loader.c
+++ b/applications/services/loader/loader.c
@@ -273,11 +273,7 @@ static void loader_thread_state_callback(FuriThreadState thread_state, void* con
             furi_hal_power_insomnia_enter();
         }
     } else if(thread_state == FuriThreadStateStopped) {
-        FURI_LOG_I(
-            TAG,
-            "Application thread stopped. Free heap: %d. Thread allocation balance: %d.",
-            memmgr_get_free_heap(),
-            furi_thread_get_heap_size(instance->application_thread));
+        FURI_LOG_I(TAG, "Application stopped. Free heap: %d", memmgr_get_free_heap());
 
         if(loader_instance->application_arguments) {
             free(loader_instance->application_arguments);

--- a/furi/core/thread.c
+++ b/furi/core/thread.c
@@ -12,6 +12,8 @@
 #include <furi_hal_rtc.h>
 #include <furi_hal_console.h>
 
+#define TAG "FuriThread"
+
 #define THREAD_NOTIFY_INDEX 1 // Index 0 is used for stream buffers
 
 typedef struct FuriThreadStdout FuriThreadStdout;
@@ -82,6 +84,12 @@ static void furi_thread_body(void* context) {
     if(thread->heap_trace_enabled == true) {
         furi_delay_ms(33);
         thread->heap_size = memmgr_heap_get_thread_memory((FuriThreadId)task_handle);
+        furi_log_print_format(
+            thread->heap_size ? FuriLogLevelError : FuriLogLevelInfo,
+            TAG,
+            "%s allocation balance: %d",
+            thread->name ? thread->name : "Thread",
+            thread->heap_size);
         memmgr_heap_disable_thread_trace((FuriThreadId)task_handle);
     }
 
@@ -89,8 +97,8 @@ static void furi_thread_body(void* context) {
 
     if(thread->is_service) {
         FURI_LOG_E(
-            "Service",
-            "%s thread exited. Thread memory cannot be reclaimed.",
+            TAG,
+            "%s service thread exited. Thread memory cannot be reclaimed.",
             thread->name ? thread->name : "<unknown service>");
     }
 


### PR DESCRIPTION
# What's new

- Furi: show thread allocation balance for child threads

# Verification 

- Compile and upload
- Run any app with multiple threads
- Check logs: all app threads now reports their allocation balance

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
