### PR TITLE
NFC: fix crash on MFC read

### DIFF
--- a/lib/nfc/nfc_worker.c
+++ b/lib/nfc/nfc_worker.c
@@ -72,8 +72,8 @@ void nfc_worker_stop(NfcWorker* nfc_worker) {
     furi_assert(nfc_worker);
     furi_assert(nfc_worker->thread);
     if(furi_thread_get_state(nfc_worker->thread) != FuriThreadStateStopped) {
-        nfc_worker_change_state(nfc_worker, NfcWorkerStateStop);
         furi_hal_nfc_stop();
+        nfc_worker_change_state(nfc_worker, NfcWorkerStateStop);
         furi_thread_join(nfc_worker->thread);
     }
 }

--- a/lib/nfc/nfc_worker.c
+++ b/lib/nfc/nfc_worker.c
@@ -70,12 +70,12 @@ void nfc_worker_start(
 
 void nfc_worker_stop(NfcWorker* nfc_worker) {
     furi_assert(nfc_worker);
-    if(nfc_worker->state == NfcWorkerStateBroken || nfc_worker->state == NfcWorkerStateReady) {
-        return;
+    furi_assert(nfc_worker->thread);
+    if(furi_thread_get_state(nfc_worker->thread) != FuriThreadStateStopped) {
+        nfc_worker_change_state(nfc_worker, NfcWorkerStateStop);
+        furi_hal_nfc_stop();
+        furi_thread_join(nfc_worker->thread);
     }
-    furi_hal_nfc_stop();
-    nfc_worker_change_state(nfc_worker, NfcWorkerStateStop);
-    furi_thread_join(nfc_worker->thread);
 }
 
 void nfc_worker_change_state(NfcWorker* nfc_worker, NfcWorkerState state) {

--- a/lib/nfc/nfc_worker.h
+++ b/lib/nfc/nfc_worker.h
@@ -7,7 +7,6 @@ typedef struct NfcWorker NfcWorker;
 typedef enum {
     // Init states
     NfcWorkerStateNone,
-    NfcWorkerStateBroken,
     NfcWorkerStateReady,
     // Main worker states
     NfcWorkerStateRead,


### PR DESCRIPTION
# What's new

- Check worker thread state instead of worker state in nfc_worker_stop()

# Verification 

- No crash on MFC read

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
