### PR TITLE
iButton: Fix header "Saved!" message stays on other screens

### DIFF
--- a/applications/main/ibutton/scenes/ibutton_scene_delete_success.c
+++ b/applications/main/ibutton/scenes/ibutton_scene_delete_success.c
@@ -39,10 +39,5 @@ void ibutton_scene_delete_success_on_exit(void* context) {
     iButton* ibutton = context;
     Popup* popup = ibutton->popup;
 
-    popup_set_text(popup, NULL, 0, 0, AlignCenter, AlignTop);
-    popup_set_icon(popup, 0, 0, NULL);
-
-    popup_disable_timeout(popup);
-    popup_set_context(popup, NULL);
-    popup_set_callback(popup, NULL);
+    popup_reset(popup);
 }

--- a/applications/main/ibutton/scenes/ibutton_scene_save_success.c
+++ b/applications/main/ibutton/scenes/ibutton_scene_save_success.c
@@ -39,11 +39,5 @@ void ibutton_scene_save_success_on_exit(void* context) {
     iButton* ibutton = context;
     Popup* popup = ibutton->popup;
 
-    popup_set_header(popup, NULL, 0, 0, AlignCenter, AlignBottom);
-    popup_set_text(popup, NULL, 0, 0, AlignCenter, AlignTop);
-    popup_set_icon(popup, 0, 0, NULL);
-
-    popup_disable_timeout(popup);
-    popup_set_context(popup, NULL);
-    popup_set_callback(popup, NULL);
+    popup_reset(popup);
 }

--- a/applications/main/ibutton/scenes/ibutton_scene_save_success.c
+++ b/applications/main/ibutton/scenes/ibutton_scene_save_success.c
@@ -39,6 +39,7 @@ void ibutton_scene_save_success_on_exit(void* context) {
     iButton* ibutton = context;
     Popup* popup = ibutton->popup;
 
+    popup_set_header(popup, NULL, 0, 0, AlignCenter, AlignBottom);
     popup_set_text(popup, NULL, 0, 0, AlignCenter, AlignTop);
     popup_set_icon(popup, 0, 0, NULL);
 

--- a/applications/main/ibutton/scenes/ibutton_scene_write_success.c
+++ b/applications/main/ibutton/scenes/ibutton_scene_write_success.c
@@ -43,10 +43,5 @@ void ibutton_scene_write_success_on_exit(void* context) {
     iButton* ibutton = context;
     Popup* popup = ibutton->popup;
 
-    popup_set_text(popup, NULL, 0, 0, AlignCenter, AlignTop);
-    popup_set_icon(popup, 0, 0, NULL);
-
-    popup_disable_timeout(popup);
-    popup_set_context(popup, NULL);
-    popup_set_callback(popup, NULL);
+    popup_reset(popup);
 }

--- a/applications/main/subghz/scenes/subghz_scene_delete_success.c
+++ b/applications/main/subghz/scenes/subghz_scene_delete_success.c
@@ -44,14 +44,7 @@ bool subghz_scene_delete_success_on_event(void* context, SceneManagerEvent event
 
 void subghz_scene_delete_success_on_exit(void* context) {
     SubGhz* subghz = context;
-
-    // Clear view
     Popup* popup = subghz->popup;
-    popup_set_header(popup, NULL, 0, 0, AlignCenter, AlignBottom);
-    popup_set_text(popup, NULL, 0, 0, AlignCenter, AlignTop);
-    popup_set_icon(popup, 0, 0, NULL);
-    popup_set_callback(popup, NULL);
-    popup_set_context(popup, NULL);
-    popup_set_timeout(popup, 0);
-    popup_disable_timeout(popup);
+
+    popup_reset(popup);
 }

--- a/applications/main/subghz/scenes/subghz_scene_save_success.c
+++ b/applications/main/subghz/scenes/subghz_scene_save_success.c
@@ -44,14 +44,7 @@ bool subghz_scene_save_success_on_event(void* context, SceneManagerEvent event) 
 
 void subghz_scene_save_success_on_exit(void* context) {
     SubGhz* subghz = context;
-
-    // Clear view
     Popup* popup = subghz->popup;
-    popup_set_header(popup, NULL, 0, 0, AlignCenter, AlignBottom);
-    popup_set_text(popup, NULL, 0, 0, AlignCenter, AlignTop);
-    popup_set_icon(popup, 0, 0, NULL);
-    popup_set_callback(popup, NULL);
-    popup_set_context(popup, NULL);
-    popup_set_timeout(popup, 0);
-    popup_disable_timeout(popup);
+
+    popup_reset(popup);
 }

--- a/applications/main/subghz/scenes/subghz_scene_show_error_sub.c
+++ b/applications/main/subghz/scenes/subghz_scene_show_error_sub.c
@@ -36,16 +36,10 @@ bool subghz_scene_show_error_sub_on_event(void* context, SceneManagerEvent event
 
 void subghz_scene_show_error_sub_on_exit(void* context) {
     SubGhz* subghz = context;
-
-    // Clear view
     Popup* popup = subghz->popup;
-    popup_set_header(popup, NULL, 0, 0, AlignCenter, AlignBottom);
-    popup_set_text(popup, NULL, 0, 0, AlignCenter, AlignTop);
-    popup_set_icon(popup, 0, 0, NULL);
-    popup_set_callback(popup, NULL);
-    popup_set_context(popup, NULL);
-    popup_set_timeout(popup, 0);
-    popup_disable_timeout(popup);
+
+    popup_reset(popup);
+
     furi_string_reset(subghz->error_str);
 
     notification_message(subghz->notifications, &sequence_reset_rgb);

--- a/applications/main/subghz/scenes/subghz_scene_show_only_rx.c
+++ b/applications/main/subghz/scenes/subghz_scene_show_only_rx.c
@@ -43,14 +43,7 @@ bool subghz_scene_show_only_rx_on_event(void* context, SceneManagerEvent event) 
 
 void subghz_scene_show_only_rx_on_exit(void* context) {
     SubGhz* subghz = context;
-
-    // Clear view
     Popup* popup = subghz->popup;
-    popup_set_header(popup, NULL, 0, 0, AlignCenter, AlignBottom);
-    popup_set_text(popup, NULL, 0, 0, AlignCenter, AlignTop);
-    popup_set_icon(popup, 0, 0, NULL);
-    popup_set_callback(popup, NULL);
-    popup_set_context(popup, NULL);
-    popup_set_timeout(popup, 0);
-    popup_disable_timeout(popup);
+
+    popup_reset(popup);
 }


### PR DESCRIPTION
# What's new

- Fixed bug with header message doesn’t reset on scene exit

Before:
![telegram-cloud-photo-size-2-5435912465146823575-x](https://user-images.githubusercontent.com/10697207/201348051-80d665cc-7828-488b-a6e9-34571d4c5479.jpg)

After:
![telegram-cloud-photo-size-2-5435912465146823573-x](https://user-images.githubusercontent.com/10697207/201348210-1fecc692-0215-4716-9fac-c86b6fbfba41.jpg)

# Verification 

- How to replicate: Read key -> Save -> Open any key -> Write

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
