### PR TITLE
Added log to file to Subghz Frequency Analyzer

### DIFF
--- a/applications/main/subghz/views/subghz_frequency_analyzer.h
+++ b/applications/main/subghz/views/subghz_frequency_analyzer.h
@@ -17,3 +17,6 @@ SubGhzFrequencyAnalyzer* subghz_frequency_analyzer_alloc();
 void subghz_frequency_analyzer_free(SubGhzFrequencyAnalyzer* subghz_static);
 
 View* subghz_frequency_analyzer_get_view(SubGhzFrequencyAnalyzer* subghz_static);
+
+bool subghz_frequency_analyzer_log_to_file();
+void subghz_frequency_analyzer_log(float rssi, uint32_t frequency);


### PR DESCRIPTION
# What's new
Added ability to save the captured frequency and rssi to a log file.
This can be enabled or disabled by renaming a file in the subghz folder: if a file named `fqalogon.txt` is found the logging to file is enabled. If file is renamed to `fqalogoff.txt` logging is disabled. By using a filename as a flag you can enable and disable logging directly on the flipper with the file browser.
At the first startup of the frequency analyzer it would create _(if necessary)_ a default file named `fqalogoff.txt` _(by default logging is disabled)_. The logging is done in files with the capture date used in the name, so every day a new file will be created. The file is also constructed so that it can be easily imported into your preferred spreadsheet for subsequent analysis. The log file is basically a CSV but with a TXT extension.

# Verification 
- Run Subghz Frequency Analyzer
- On first run, the file `fqalogoff.txt` will be created in `subghz` folder
- Use browser _(down button)_ to find and rename file to `fqalogon.txt`
- Run againg Subghz Frequency Analyzer and all captured frequency will be saved to files into `subghz` folder

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
