### PR TITLE
NFC: fix NTAG203 info scene

### DIFF
--- a/applications/main/nfc/scenes/nfc_scene_nfc_data_info.c
+++ b/applications/main/nfc/scenes/nfc_scene_nfc_data_info.c
@@ -89,18 +89,20 @@ void nfc_scene_nfc_data_info_on_enter(void* context) {
             furi_string_cat_printf(temp_str, "\nPassword-protected");
         } else if(data->auth_success) {
             MfUltralightConfigPages* config_pages = mf_ultralight_get_config_pages(data);
-            furi_string_cat_printf(
-                temp_str,
-                "\nPassword: %02X %02X %02X %02X",
-                config_pages->auth_data.pwd.raw[0],
-                config_pages->auth_data.pwd.raw[1],
-                config_pages->auth_data.pwd.raw[2],
-                config_pages->auth_data.pwd.raw[3]);
-            furi_string_cat_printf(
-                temp_str,
-                "\nPACK: %02X %02X",
-                config_pages->auth_data.pack.raw[0],
-                config_pages->auth_data.pack.raw[1]);
+            if(config_pages) {
+                furi_string_cat_printf(
+                    temp_str,
+                    "\nPassword: %02X %02X %02X %02X",
+                    config_pages->auth_data.pwd.raw[0],
+                    config_pages->auth_data.pwd.raw[1],
+                    config_pages->auth_data.pwd.raw[2],
+                    config_pages->auth_data.pwd.raw[3]);
+                furi_string_cat_printf(
+                    temp_str,
+                    "\nPACK: %02X %02X",
+                    config_pages->auth_data.pack.raw[0],
+                    config_pages->auth_data.pack.raw[1]);
+            }
         }
     } else if(protocol == NfcDeviceProtocolMifareClassic) {
         MfClassicData* data = &dev_data->mf_classic_data;


### PR DESCRIPTION
# What's new

- Check existence of configuration pages before serializing them

# Verification 

- Open saved NTAG203, NTAG I2C 1k, 2k. Verify Info screen works correctly

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
