### PR TITLE
Add task "Serial console" and group task with sequence calling

### DIFF
--- a/.vscode/example/tasks.json
+++ b/.vscode/example/tasks.json
@@ -128,6 +128,33 @@
             "group": "build",
             "type": "shell",
             "command": "./fbt COMPACT=1 DEBUG=0 launch_app APPSRC=${relativeFileDirname}"
+        },
+        {
+            "label": "[Debug] Launch App on Flipper with Serial Console",
+            "dependsOrder": "sequence",
+            "problemMatcher": [],
+            "dependsOn": [
+                "[Debug] Launch App on Flipper",
+                "Serial Console"
+            ]
+        },
+        {
+            // Press Ctrl+] to quit
+            "label": "Serial Console",
+            "type": "shell",
+            "command": "./scripts/serial_cli.py",
+            "group": "none",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "always",
+                "revealProblems": "never",
+                "showReuseMessage": false,
+                "panel": "dedicated",
+                "focus": true,
+                "echo": true,
+                "close": true,
+                "group": "Logger"
+            }
         }
     ]
 }


### PR DESCRIPTION
# What's new

- Add task "Serial console" to call serial_cli.py
- Add task to show example of group tasks with run application and run console after it
- This example will be useful for those who are not so familiar with VSCode. I've seen this question a lot in Discord

# Verification 

- In VSCode run tasks: "Serial console", "[Debug] Launch App on Flipper with Serial Console"

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
