### PR TITLE
[FL-3003] Fix logical error in storage script

### DIFF
--- a/scripts/flipper/storage.py
+++ b/scripts/flipper/storage.py
@@ -240,7 +240,7 @@ class FlipperStorage:
             self.send("y")
             chunk_size = min(size - read_size, buffer_size)
             filedata.extend(self.port.read(chunk_size))
-            read_size = read_size + chunk_size 
+            read_size = read_size + chunk_size
 
             percent = str(math.ceil(read_size / size * 100))
             total_chunks = str(math.ceil(size / buffer_size))

--- a/scripts/flipper/storage.py
+++ b/scripts/flipper/storage.py
@@ -238,9 +238,9 @@ class FlipperStorage:
         while read_size < size:
             self.read.until("Ready?" + self.CLI_EOL)
             self.send("y")
-            read_size = min(size - read_size, buffer_size)
-            filedata.extend(self.port.read(read_size))
-            read_size = read_size + read_size
+            chunk_size = min(size - read_size, buffer_size)
+            filedata.extend(self.port.read(chunk_size))
+            read_size = read_size + chunk_size 
 
             percent = str(math.ceil(read_size / size * 100))
             total_chunks = str(math.ceil(size / buffer_size))


### PR DESCRIPTION
# What's new

- Fix logical error in `scripts/storage.py`

# Verification 

- Run `./scripts/storage.py stress /ext/stress.tmp 500000` with Flipper connected to the USB.
- While the script is running, go to `Sub-GHz -> Saved` and open and send any RAW signal. No crashes, deadlocks or OOMs should occur.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
