### PR TITLE
[FL- 3014] Untangle NFC from Unit Tests

### DIFF
--- a/applications/debug/unit_tests/nfc/nfc_test.c
+++ b/applications/debug/unit_tests/nfc/nfc_test.c
@@ -102,7 +102,10 @@ static bool nfc_test_digital_signal_test_encode(
 
     do {
         // Read test data
-        if(!nfc_test_read_signal_from_file(file_name)) break;
+        if(!nfc_test_read_signal_from_file(file_name)) {
+            FURI_LOG_E(TAG, "Failed to read signal from file");
+            break;
+        }
 
         // Encode signal
         FURI_CRITICAL_ENTER();

--- a/applications/debug/unit_tests/nfc/nfc_test.c
+++ b/applications/debug/unit_tests/nfc/nfc_test.c
@@ -6,7 +6,7 @@
 #include <lib/nfc/helpers/mf_classic_dict.h>
 #include <lib/digital_signal/digital_signal.h>
 #include <lib/nfc/nfc_device.h>
-#include <applications/main/nfc/helpers/nfc_generators.h>
+#include <lib/nfc/helpers/nfc_generators.h>
 
 #include <lib/flipper_format/flipper_format_i.h>
 #include <lib/toolbox/stream/file_stream.h>

--- a/applications/main/nfc/nfc_i.h
+++ b/applications/main/nfc/nfc_i.h
@@ -27,6 +27,7 @@
 #include <lib/nfc/nfc_device.h>
 #include <lib/nfc/helpers/mf_classic_dict.h>
 #include <lib/nfc/parsers/nfc_supported_card.h>
+#include <lib/nfc/helpers/nfc_generators.h>
 
 #include "views/dict_attack.h"
 #include "views/detect_reader.h"
@@ -49,9 +50,6 @@ typedef enum {
     NfcRpcStateEmulating,
     NfcRpcStateEmulated,
 } NfcRpcState;
-
-// Forward declaration due to circular dependency
-typedef struct NfcGenerator NfcGenerator;
 
 struct Nfc {
     NfcWorker* worker;

--- a/applications/main/nfc/scenes/nfc_scene_generate_info.c
+++ b/applications/main/nfc/scenes/nfc_scene_generate_info.c
@@ -1,5 +1,5 @@
 #include "../nfc_i.h"
-#include "../helpers/nfc_generators.h"
+#include "lib/nfc/helpers/nfc_generators.h"
 
 void nfc_scene_generate_info_dialog_callback(DialogExResult result, void* context) {
     Nfc* nfc = context;
@@ -39,7 +39,12 @@ bool nfc_scene_generate_info_on_event(void* context, SceneManagerEvent event) {
 
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == DialogExResultRight) {
-            scene_manager_next_scene(nfc->scene_manager, nfc->generator->next_scene);
+            // Switch either to NfcSceneMfClassicMenu or NfcSceneMfUltralightMenu
+            if(nfc->dev->dev_data.protocol == NfcDeviceProtocolMifareClassic) {
+                scene_manager_next_scene(nfc->scene_manager, NfcSceneMfClassicMenu);
+            } else if(nfc->dev->dev_data.protocol == NfcDeviceProtocolMifareUl) {
+                scene_manager_next_scene(nfc->scene_manager, NfcSceneMfUltralightMenu);
+            }
             consumed = true;
         }
     }

--- a/applications/main/nfc/scenes/nfc_scene_set_type.c
+++ b/applications/main/nfc/scenes/nfc_scene_set_type.c
@@ -1,5 +1,5 @@
 #include "../nfc_i.h"
-#include "../helpers/nfc_generators.h"
+#include "lib/nfc/helpers/nfc_generators.h"
 
 enum SubmenuIndex {
     SubmenuIndexNFCA4,

--- a/fbt_options.py
+++ b/fbt_options.py
@@ -81,7 +81,6 @@ FIRMWARE_APPS = {
         "basic_services",
         "updater_app",
         "unit_tests",
-        "nfc",
     ],
 }
 

--- a/lib/nfc/helpers/nfc_generators.c
+++ b/lib/nfc/helpers/nfc_generators.c
@@ -376,103 +376,86 @@ static void nfc_generate_mf_classic_4k_7b_uid(NfcDeviceData* data) {
 static const NfcGenerator mf_ul_generator = {
     .name = "Mifare Ultralight",
     .generator_func = nfc_generate_mf_ul_orig,
-    .next_scene = NfcSceneMfUltralightMenu,
 };
 
 static const NfcGenerator mf_ul_11_generator = {
     .name = "Mifare Ultralight EV1 11",
     .generator_func = nfc_generate_mf_ul_11,
-    .next_scene = NfcSceneMfUltralightMenu,
 };
 
 static const NfcGenerator mf_ul_h11_generator = {
     .name = "Mifare Ultralight EV1 H11",
     .generator_func = nfc_generate_mf_ul_h11,
-    .next_scene = NfcSceneMfUltralightMenu,
 };
 
 static const NfcGenerator mf_ul_21_generator = {
     .name = "Mifare Ultralight EV1 21",
     .generator_func = nfc_generate_mf_ul_21,
-    .next_scene = NfcSceneMfUltralightMenu,
 };
 
 static const NfcGenerator mf_ul_h21_generator = {
     .name = "Mifare Ultralight EV1 H21",
     .generator_func = nfc_generate_mf_ul_h21,
-    .next_scene = NfcSceneMfUltralightMenu,
 };
 
 static const NfcGenerator ntag203_generator = {
     .name = "NTAG203",
     .generator_func = nfc_generate_mf_ul_ntag203,
-    .next_scene = NfcSceneMfUltralightMenu,
 };
 
 static const NfcGenerator ntag213_generator = {
     .name = "NTAG213",
     .generator_func = nfc_generate_ntag213,
-    .next_scene = NfcSceneMfUltralightMenu,
 };
 
 static const NfcGenerator ntag215_generator = {
     .name = "NTAG215",
     .generator_func = nfc_generate_ntag215,
-    .next_scene = NfcSceneMfUltralightMenu,
 };
 
 static const NfcGenerator ntag216_generator = {
     .name = "NTAG216",
     .generator_func = nfc_generate_ntag216,
-    .next_scene = NfcSceneMfUltralightMenu,
 };
 
 static const NfcGenerator ntag_i2c_1k_generator = {
     .name = "NTAG I2C 1k",
     .generator_func = nfc_generate_ntag_i2c_1k,
-    .next_scene = NfcSceneMfUltralightMenu,
 };
 
 static const NfcGenerator ntag_i2c_2k_generator = {
     .name = "NTAG I2C 2k",
     .generator_func = nfc_generate_ntag_i2c_2k,
-    .next_scene = NfcSceneMfUltralightMenu,
 };
 
 static const NfcGenerator ntag_i2c_plus_1k_generator = {
     .name = "NTAG I2C Plus 1k",
     .generator_func = nfc_generate_ntag_i2c_plus_1k,
-    .next_scene = NfcSceneMfUltralightMenu,
 };
 
 static const NfcGenerator ntag_i2c_plus_2k_generator = {
     .name = "NTAG I2C Plus 2k",
     .generator_func = nfc_generate_ntag_i2c_plus_2k,
-    .next_scene = NfcSceneMfUltralightMenu,
 };
 
 static const NfcGenerator mifare_classic_1k_4b_uid_generator = {
     .name = "Mifare Classic 1k 4byte UID",
     .generator_func = nfc_generate_mf_classic_1k_4b_uid,
-    .next_scene = NfcSceneMfClassicMenu,
 };
 
 static const NfcGenerator mifare_classic_1k_7b_uid_generator = {
     .name = "Mifare Classic 1k 7byte UID",
     .generator_func = nfc_generate_mf_classic_1k_7b_uid,
-    .next_scene = NfcSceneMfClassicMenu,
 };
 
 static const NfcGenerator mifare_classic_4k_4b_uid_generator = {
     .name = "Mifare Classic 4k 4byte UID",
     .generator_func = nfc_generate_mf_classic_4k_4b_uid,
-    .next_scene = NfcSceneMfClassicMenu,
 };
 
 static const NfcGenerator mifare_classic_4k_7b_uid_generator = {
     .name = "Mifare Classic 4k 7byte UID",
     .generator_func = nfc_generate_mf_classic_4k_7b_uid,
-    .next_scene = NfcSceneMfClassicMenu,
 };
 
 const NfcGenerator* const nfc_generators[] = {

--- a/lib/nfc/helpers/nfc_generators.h
+++ b/lib/nfc/helpers/nfc_generators.h
@@ -1,14 +1,13 @@
 #pragma once
 
-#include "../nfc_i.h"
+#include "../nfc_device.h"
 
 typedef void (*NfcGeneratorFunc)(NfcDeviceData* data);
 
-struct NfcGenerator {
+typedef struct {
     const char* name;
     NfcGeneratorFunc generator_func;
-    NfcScene next_scene;
-};
+} NfcGenerator;
 
 extern const NfcGenerator* const nfc_generators[];
 


### PR DESCRIPTION
# What's new

- `unit_tests` build no longer requires `nfc` to be built
- NFC Generators now live in /lib/nfc

# Verification 

- Run NFC unit tests, check that all the generator-related tests work (digital signal may fail if you don't have the unit test files)
- Run the NFC app, manually generate a Mifare Classic and a Mifare Ultralight card, check that it works properly (all the scenes are shown etc)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
