### PR TITLE
Frequency analyzer: allow setting rssi threshold

### DIFF
--- a/applications/main/subghz/helpers/subghz_frequency_analyzer_worker.h
+++ b/applications/main/subghz/helpers/subghz_frequency_analyzer_worker.h
@@ -11,7 +11,8 @@ typedef void (*SubGhzFrequencyAnalyzerWorkerPairCallback)(
     void* context,
     uint32_t frequency,
     float rssi,
-    bool signal);
+    bool signal,
+    float* rssi_thresh);
 
 typedef struct {
     uint32_t frequency_coarse;

--- a/applications/main/subghz/views/subghz_frequency_analyzer.c
+++ b/applications/main/subghz/views/subghz_frequency_analyzer.c
@@ -179,9 +179,13 @@ void subghz_frequency_analyzer_draw(Canvas* canvas, SubGhzFrequencyAnalyzerModel
     } else {
         canvas_draw_str(canvas, 20, 8, "Frequency Analyzer");
         canvas_draw_str(canvas, 0, 64, "RSSI");
-        canvas_draw_str(canvas, 0, 38, "Threshold:");
-        snprintf(buffer, sizeof(buffer), "%.1f", (double)model->rssi_min_thresh);
-        canvas_draw_str(canvas, 0, 47, buffer);
+        canvas_draw_str(canvas, 8, 40, "Threshold:");
+        snprintf(buffer, sizeof(buffer), "%.1fdB", (double)model->rssi_min_thresh);
+
+        canvas_draw_triangle(canvas, 3, 38, 6, 6, CanvasDirectionBottomToTop);
+        canvas_draw_triangle(canvas, 3, 42, 6, 6, CanvasDirectionTopToBottom);
+
+        canvas_draw_str(canvas, 8, 49, buffer);
 
         subghz_frequency_analyzer_draw_rssi(canvas, model->rssi, 20, 64);
 
@@ -369,6 +373,7 @@ void subghz_frequency_analyzer_pair_callback(
     bool signal,
     float* rssi_thresh) {
     SubGhzFrequencyAnalyzer* instance = context;
+
     if((rssi == 0.f) && (instance->locked)) {
         if(instance->callback) {
             instance->callback(SubGhzCustomEventSceneAnalyzerUnlock, instance->context);

--- a/applications/main/subghz/views/subghz_frequency_analyzer.c
+++ b/applications/main/subghz/views/subghz_frequency_analyzer.c
@@ -39,6 +39,7 @@ typedef struct {
     uint32_t frequency;
     uint8_t rssi;
     uint32_t history_frequency[3];
+    float rssi_min_thresh;
     bool signal;
     SubGhzFrequencyAnalyzerLogItemArray_t log_frequency;
     SubGhzFrequencyAnalyzerFragmentBottomType fragment_bottom_type;
@@ -178,6 +179,10 @@ void subghz_frequency_analyzer_draw(Canvas* canvas, SubGhzFrequencyAnalyzerModel
     } else {
         canvas_draw_str(canvas, 20, 8, "Frequency Analyzer");
         canvas_draw_str(canvas, 0, 64, "RSSI");
+        canvas_draw_str(canvas, 0, 38, "Threshold:");
+        snprintf(buffer, sizeof(buffer), "%.1f", (double)model->rssi_min_thresh);
+        canvas_draw_str(canvas, 0, 47, buffer);
+
         subghz_frequency_analyzer_draw_rssi(canvas, model->rssi, 20, 64);
 
         subghz_frequency_analyzer_history_frequency_draw(canvas, model);
@@ -246,6 +251,29 @@ bool subghz_frequency_analyzer_input(InputEvent* event, void* context) {
                 }
             },
             true);
+    } else if(
+        (event->type == InputTypeShort) &&
+        ((event->key == InputKeyUp) || (event->key == InputKeyDown))) {
+        //update min threshold display and value
+        with_view_model(
+            instance->view,
+            SubGhzFrequencyAnalyzerModel * model,
+            {
+                if(model->fragment_bottom_type == SubGhzFrequencyAnalyzerFragmentBottomTypeMain) {
+                    //main page showing
+                    if(event->key == InputKeyUp) {
+                        ++model->rssi_min_thresh;
+                    }
+                    //increment model min rssi
+
+                    else if(event->key == InputKeyDown) {
+                        --model->rssi_min_thresh;
+                        //decrement model min rssi
+                    }
+                }
+            },
+            true);
+        //
     } else if((event->type == InputTypeShort) || (event->type == InputTypeRepeat)) {
         with_view_model(
             instance->view,
@@ -338,7 +366,8 @@ void subghz_frequency_analyzer_pair_callback(
     void* context,
     uint32_t frequency,
     float rssi,
-    bool signal) {
+    bool signal,
+    float* rssi_thresh) {
     SubGhzFrequencyAnalyzer* instance = context;
     if((rssi == 0.f) && (instance->locked)) {
         if(instance->callback) {
@@ -374,6 +403,7 @@ void subghz_frequency_analyzer_pair_callback(
                     model, frequency != instance->last_frequency);
                 instance->last_frequency = frequency;
             }
+            *rssi_thresh = model->rssi_min_thresh;
         },
         true);
 }
@@ -397,6 +427,7 @@ void subghz_frequency_analyzer_enter(void* context) {
         SubGhzFrequencyAnalyzerModel * model,
         {
             model->rssi = 0u;
+            model->rssi_min_thresh = -93.0f;
             model->frequency = 0;
             model->fragment_bottom_type = SubGhzFrequencyAnalyzerFragmentBottomTypeMain;
             model->log_frequency_order_by = SubGhzFrequencyAnalyzerLogOrderBySeqDesc;
@@ -427,6 +458,7 @@ void subghz_frequency_analyzer_exit(void* context) {
             model->fragment_bottom_type = SubGhzFrequencyAnalyzerFragmentBottomTypeMain;
             model->log_frequency_order_by = SubGhzFrequencyAnalyzerLogOrderBySeqDesc;
             model->log_frequency_scroll_offset = 0;
+            model->rssi_min_thresh = 0;
             model->history_frequency[0] = model->history_frequency[1] =
                 model->history_frequency[2] = 0;
             SubGhzFrequencyAnalyzerLogItemArray_clear(model->log_frequency);


### PR DESCRIPTION
# What's new

On the frequency analyzer, you can set the RSSI threshold that the UI will show a detected frequency.
<img width="237" alt="image" src="https://user-images.githubusercontent.com/6108031/207239560-66d841b3-ac69-4375-bf97-d98607ff31ea.png">

# Verification 

Launch the Sub-Ghz frequency analyzer, and press the up/down buttons to change the threshold. Lowering the threshold will allow signals that are weaker to be shown as detected, and logged if they meet the appropriate criteria for logging (unchanged).

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
