### PR TITLE
File browser scroll large names

### DIFF
--- a/applications/services/gui/elements.c
+++ b/applications/services/gui/elements.c
@@ -547,6 +547,19 @@ void elements_string_fit_width(Canvas* canvas, FuriString* string, uint8_t width
     }
 }
 
+void elements_string_fit_width_trunc(Canvas* canvas, FuriString* string, uint8_t width) {
+    furi_assert(canvas);
+    furi_assert(string);
+
+    uint16_t len_px = canvas_string_width(canvas, furi_string_get_cstr(string));
+    if(len_px > width) {
+        do {
+            furi_string_left(string, furi_string_size(string) - 1);
+            len_px = canvas_string_width(canvas, furi_string_get_cstr(string));
+        } while(len_px > width);
+    }
+}
+
 void elements_text_box(
     Canvas* canvas,
     uint8_t x,

--- a/applications/services/gui/elements.h
+++ b/applications/services/gui/elements.h
@@ -192,6 +192,14 @@ void elements_bubble_str(
  */
 void elements_string_fit_width(Canvas* canvas, FuriString* string, uint8_t width);
 
+/** Trim string buffer to fit width in pixels. If the string is longer it truncates without ellipsis (...)
+ *
+ * @param   canvas  Canvas instance
+ * @param   string  string to trim
+ * @param   width   max width
+ */
+void elements_string_fit_width_trunc(Canvas* canvas, FuriString* string, uint8_t width);
+
 /** Draw text box element
  *
  * @param       canvas          Canvas instance

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,11.0,,
+Version,+,11.1,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,
@@ -756,6 +756,7 @@ Function,+,elements_scrollbar_pos,void,"Canvas*, uint8_t, uint8_t, uint8_t, uint
 Function,+,elements_slightly_rounded_box,void,"Canvas*, uint8_t, uint8_t, uint8_t, uint8_t"
 Function,+,elements_slightly_rounded_frame,void,"Canvas*, uint8_t, uint8_t, uint8_t, uint8_t"
 Function,+,elements_string_fit_width,void,"Canvas*, FuriString*, uint8_t"
+Function,+,elements_string_fit_width_trunc,void,"Canvas*, FuriString*, uint8_t"
 Function,+,elements_text_box,void,"Canvas*, uint8_t, uint8_t, uint8_t, uint8_t, Align, Align, const char*, _Bool"
 Function,+,empty_screen_alloc,EmptyScreen*,
 Function,+,empty_screen_free,void,EmptyScreen*


### PR DESCRIPTION
# What's new
- Implements scrolling text on File Browser when the file name is longer than allowed on-screen as requested in #1901 

# Verification 

- Open any app which uses the file browser.
- Search for a file which has a name longer than allowed on screen. Look for the three dots (...) at the right.
- The file name should start scrolling after 1 second.
- Only the selected file should be scrolling.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
