### PR TITLE
[FL-3052] WS: add choice fahrenheit/celsius

### DIFF
--- a/applications/plugins/weather_station/helpers/weather_station_types.h
+++ b/applications/plugins/weather_station/helpers/weather_station_types.h
@@ -3,7 +3,7 @@
 #include <furi.h>
 #include <furi_hal.h>
 
-#define WS_VERSION_APP "0.6"
+#define WS_VERSION_APP "0.6.1"
 #define WS_DEVELOPED "SkorP"
 #define WS_GITHUB "https://github.com/flipperdevices/flipperzero-firmware"
 

--- a/applications/plugins/weather_station/protocols/ambient_weather.c
+++ b/applications/plugins/weather_station/protocols/ambient_weather.c
@@ -134,8 +134,8 @@ static void ws_protocol_ambient_weather_remote_controller(WSBlockGeneric* instan
     instance->id = (instance->data >> 32) & 0xFF;
     instance->battery_low = (instance->data >> 31) & 1;
     instance->channel = ((instance->data >> 28) & 0x07) + 1;
-    instance->temp = locale_fahrenheit_to_celsius(
-        ((float)((instance->data >> 16) & 0x0FFF) - 400.0f) / 10.0f);
+    instance->temp =
+        locale_fahrenheit_to_celsius(((float)((instance->data >> 16) & 0x0FFF) - 400.0f) / 10.0f);
     instance->humidity = (instance->data >> 8) & 0xFF;
     instance->btn = WS_NO_BTN;
 

--- a/applications/plugins/weather_station/protocols/ambient_weather.c
+++ b/applications/plugins/weather_station/protocols/ambient_weather.c
@@ -134,7 +134,7 @@ static void ws_protocol_ambient_weather_remote_controller(WSBlockGeneric* instan
     instance->id = (instance->data >> 32) & 0xFF;
     instance->battery_low = (instance->data >> 31) & 1;
     instance->channel = ((instance->data >> 28) & 0x07) + 1;
-    instance->temp = ws_block_generic_fahrenheit_to_celsius(
+    instance->temp = locale_fahrenheit_to_celsius(
         ((float)((instance->data >> 16) & 0x0FFF) - 400.0f) / 10.0f);
     instance->humidity = (instance->data >> 8) & 0xFF;
     instance->btn = WS_NO_BTN;

--- a/applications/plugins/weather_station/protocols/infactory.c
+++ b/applications/plugins/weather_station/protocols/infactory.c
@@ -143,7 +143,7 @@ static void ws_protocol_infactory_remote_controller(WSBlockGeneric* instance) {
     instance->id = instance->data >> 32;
     instance->battery_low = (instance->data >> 26) & 1;
     instance->btn = WS_NO_BTN;
-    instance->temp = ws_block_generic_fahrenheit_to_celsius(
+    instance->temp = locale_fahrenheit_to_celsius(
         ((float)((instance->data >> 12) & 0x0FFF) - 900.0f) / 10.0f);
     instance->humidity =
         (((instance->data >> 8) & 0x0F) * 10) + ((instance->data >> 4) & 0x0F); // BCD, 'A0'=100%rH

--- a/applications/plugins/weather_station/protocols/infactory.c
+++ b/applications/plugins/weather_station/protocols/infactory.c
@@ -143,8 +143,8 @@ static void ws_protocol_infactory_remote_controller(WSBlockGeneric* instance) {
     instance->id = instance->data >> 32;
     instance->battery_low = (instance->data >> 26) & 1;
     instance->btn = WS_NO_BTN;
-    instance->temp = locale_fahrenheit_to_celsius(
-        ((float)((instance->data >> 12) & 0x0FFF) - 900.0f) / 10.0f);
+    instance->temp =
+        locale_fahrenheit_to_celsius(((float)((instance->data >> 12) & 0x0FFF) - 900.0f) / 10.0f);
     instance->humidity =
         (((instance->data >> 8) & 0x0F) * 10) + ((instance->data >> 4) & 0x0F); // BCD, 'A0'=100%rH
     instance->channel = instance->data & 0x03;

--- a/applications/plugins/weather_station/protocols/ws_generic.c
+++ b/applications/plugins/weather_station/protocols/ws_generic.c
@@ -209,7 +209,3 @@ bool ws_block_generic_deserialize(WSBlockGeneric* instance, FlipperFormat* flipp
 
     return res;
 }
-
-float ws_block_generic_fahrenheit_to_celsius(float fahrenheit) {
-    return (fahrenheit - 32.0f) / 1.8f;
-}

--- a/applications/plugins/weather_station/protocols/ws_generic.h
+++ b/applications/plugins/weather_station/protocols/ws_generic.h
@@ -8,6 +8,7 @@
 #include "furi.h"
 #include "furi_hal.h"
 #include <lib/subghz/types.h>
+#include <locale/locale.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -61,8 +62,6 @@ bool ws_block_generic_serialize(
  * @return true On success
  */
 bool ws_block_generic_deserialize(WSBlockGeneric* instance, FlipperFormat* flipper_format);
-
-float ws_block_generic_fahrenheit_to_celsius(float fahrenheit);
 
 #ifdef __cplusplus
 }

--- a/applications/plugins/weather_station/views/weather_station_receiver_info.c
+++ b/applications/plugins/weather_station/views/weather_station_receiver_info.c
@@ -81,13 +81,33 @@ void ws_view_receiver_info_draw(Canvas* canvas, WSReceiverInfoModel* model) {
 
     if(model->generic->temp != WS_NO_TEMPERATURE) {
         canvas_draw_icon(canvas, 6, 43, &I_Therm_7x16);
-        snprintf(buffer, sizeof(buffer), "%3.1f C", (double)model->generic->temp);
-        uint8_t temp_x1 = 47;
-        uint8_t temp_x2 = 38;
-        if(model->generic->temp < -9.0) {
-            temp_x1 = 49;
-            temp_x2 = 40;
+
+        uint8_t temp_x1 = 0;
+        uint8_t temp_x2 = 0;
+        if(furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric) {
+            snprintf(buffer, sizeof(buffer), "%3.1f C", (double)model->generic->temp);
+            if(model->generic->temp < -9.0f) {
+                temp_x1 = 49;
+                temp_x2 = 40;
+            } else {
+                temp_x1 = 47;
+                temp_x2 = 38;
+            }
+        } else {
+            snprintf(
+                buffer,
+                sizeof(buffer),
+                "%3.1f F",
+                (double)locale_celsius_to_fahrenheit(model->generic->temp));
+            if((model->generic->temp < -27.77f) || (model->generic->temp > 37.77f)) {
+                temp_x1 = 50;
+                temp_x2 = 42;
+            } else {
+                temp_x1 = 48;
+                temp_x2 = 40;
+            }
         }
+
         canvas_draw_str_aligned(canvas, temp_x1, 47, AlignRight, AlignTop, buffer);
         canvas_draw_circle(canvas, temp_x2, 46, 1);
     }


### PR DESCRIPTION
# What's new

- [FL-3052] WS: add choice fahrenheit/celsius

# Verification 

- Select "Metric" and "Imperial" in the settings, depending on the settings, the temperature in the WS should be displayed in "Celsius" or "Fahrenheit"

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-3052]: https://flipperzero.atlassian.net/browse/FL-3052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ