### PR TITLE
Add VIZIO signals to tv.ir

### DIFF
--- a/assets/resources/infrared/assets/tv.ir
+++ b/assets/resources/infrared/assets/tv.ir
@@ -1656,3 +1656,21 @@ type: parsed
 protocol: RC5
 address: 01 00 00 00
 command: 21 00 00 00
+# Model: VIZIO
+name: Mute
+type: parsed
+protocol: NEC
+address: 04 00 00 00
+command: 09 00 00 00
+#
+name: Vol_up
+type: parsed
+protocol: NEC
+address: 04 00 00 00
+command: 02 00 00 00
+#
+name: Vol_dn
+type: parsed
+protocol: NEC
+address: 04 00 00 00
+command: 03 00 00 00

--- a/assets/resources/infrared/assets/tv.ir
+++ b/assets/resources/infrared/assets/tv.ir
@@ -1656,6 +1656,7 @@ type: parsed
 protocol: RC5
 address: 01 00 00 00
 command: 21 00 00 00
+#
 # Model: VIZIO
 name: Mute
 type: parsed


### PR DESCRIPTION
# What's new

- Add VIZIO signals to `tv.ir`
    - `Mute` signal
    - `Vol_up` signal
    - `Vol_dn` signal

# Verification 

- Navigate to Infrared -> Universal Remotes -> TVs
- Use the `Mute`, `Vol_up`, or `Vol_dn` buttons while pointed at a VIZIO TV

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
