### PR TITLE
[FL-3063] SubGhz: fix start navigation

### DIFF
--- a/applications/main/subghz/views/receiver.c
+++ b/applications/main/subghz/views/receiver.c
@@ -309,7 +309,8 @@ bool subghz_view_receiver_input(InputEvent* event, void* context) {
             subghz_receiver->view,
             SubGhzViewReceiverModel * model,
             {
-                if(model->idx != model->history_item - 1) model->idx++;
+                if((model->history_item != 0) && (model->idx != model->history_item - 1))
+                    model->idx++;
             },
             true);
     } else if(event->key == InputKeyLeft && event->type == InputTypeShort) {


### PR DESCRIPTION
# What's new

- [FL-3063] SubGhz: fix start navigation

# Verification 

- Error reproduction
https://user-images.githubusercontent.com/85568270/209299160-d58c6079-6a0b-46b5-957e-4b455ac3e3e9.mp4



# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-3063]: https://flipperzero.atlassian.net/browse/FL-3063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ