### PR TITLE
[FL-3067] WeatherStation: fix incorrect history index increment

### DIFF
--- a/applications/plugins/weather_station/views/weather_station_receiver.c
+++ b/applications/plugins/weather_station/views/weather_station_receiver.c
@@ -303,7 +303,7 @@ bool ws_view_receiver_input(InputEvent* event, void* context) {
             ws_receiver->view,
             WSReceiverModel * model,
             {
-                if(model->idx != model->history_item - 1) model->idx++;
+                if(model->history_item && model->idx != model->history_item - 1) model->idx++;
             },
             true);
     } else if(event->key == InputKeyLeft && event->type == InputTypeShort) {


### PR DESCRIPTION
# What's new

- WeatherStation: fix incorrect history index increment

# Verification 

- Compile and upload
- Run Weather Station app
- Go to read, press down, read signal, press ok.
- Ensure that app is working and history item correctly selected 

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
