### PR TITLE
[no_ticket] Bandwidth, Datarate and Macnhester Enable decoding configuration

### DIFF
--- a/applications/debug/unit_tests/subghz/subghz_test.c
+++ b/applications/debug/unit_tests/subghz/subghz_test.c
@@ -6,6 +6,7 @@
 #include <lib/subghz/subghz_keystore.h>
 #include <lib/subghz/subghz_file_encoder_worker.h>
 #include <lib/subghz/protocols/protocol_items.h>
+#include <lib/subghz/helpers/subghz_config_preset_custom.h>
 #include <flipper_format/flipper_format_i.h>
 
 #define TAG "SubGhz TEST"
@@ -201,6 +202,132 @@ static bool subghz_encoder_test(const char* path) {
     furi_string_free(temp_str);
 
     return subghz_test_decoder_count ? true : false;
+}
+
+static bool subghz_custom_preset_test(void) {
+    static const uint8_t preset_data[][2] = {
+        {CC1101_MDMCFG0, 0},
+        {CC1101_MDMCFG1, 0},
+        {CC1101_MDMCFG2, 0},
+        {CC1101_MDMCFG3, 0},
+        {CC1101_MDMCFG4, 0},
+    };
+
+    static uint8_t test_data[sizeof(preset_data)] = {0};
+    memcpy(test_data, preset_data, sizeof(preset_data));
+
+    uint8_t* test_data_ptr = &test_data[0];
+
+    { // CHEKING BANDWIDTH SET
+        for(uint32_t i = 0; i < CH_BANDWIDTH_NUM; ++i) {
+            uint8_t bw_value = subghz_preset_custom_bandwidth_values[i];
+
+            bool result =
+                subghz_preset_custom_set_bandwidth(test_data_ptr, sizeof(test_data), bw_value);
+            if(!result) {
+                FURI_LOG_E(TAG, "Failed to set BW value: %hhu", bw_value);
+                return false;
+            }
+
+            uint8_t get_bw_value =
+                subghz_preset_custom_get_bandwidth(test_data_ptr, sizeof(test_data));
+            if(get_bw_value != bw_value) {
+                FURI_LOG_E(
+                    TAG,
+                    "BW value from preset: %hhu is not equal expected value: %hhu",
+                    get_bw_value,
+                    bw_value);
+                return false;
+            }
+
+            FURI_LOG_T(TAG, "Bandwidth check OK: %hhu", bw_value);
+        }
+    }
+
+    { // CHEKING MACHESTER SET
+        bool result =
+            subghz_preset_custom_set_machester_enable(test_data_ptr, sizeof(test_data), false);
+        if(!result) {
+            FURI_LOG_E(TAG, "Failed to set manchester enable flag");
+            return false;
+        }
+        bool flag = subghz_preset_custom_get_machester_enable(test_data_ptr, sizeof(test_data));
+        if(flag != false) {
+            FURI_LOG_E(TAG, "Manchester disable flag setup failed!");
+            return false;
+        }
+
+        subghz_preset_custom_set_machester_enable(test_data_ptr, sizeof(test_data), true);
+        flag = subghz_preset_custom_get_machester_enable(test_data_ptr, sizeof(test_data));
+        if(flag != true) {
+            FURI_LOG_E(TAG, "Manchester enable flag setup failed!");
+            return false;
+        }
+
+        FURI_LOG_T(TAG, "Manchester flag check OK");
+    }
+    { // CHEKING DATARATE SET
+        const float datarateRoughMax = 1600000.0f; // bauds
+        const float datarateRoughStep = 5000.0f;
+
+        const float datarateFineMax = 30000.0f;
+        const float datarateFineStep = 50.0f;
+
+        bool result = false;
+        char datarate_set_str[16] = {0};
+        char datarate_get_str[16] = {0};
+
+        float datarate_set = datarateRoughMax;
+        float datarate_get = -1.0f;
+        while(datarate_set > 0) {
+            subghz_preset_custom_printf_datarate(
+                datarate_set, datarate_set_str, sizeof(datarate_set_str));
+
+            result =
+                subghz_preset_custom_set_datarate(test_data_ptr, sizeof(test_data), datarate_set);
+            if(!result) {
+                FURI_LOG_E(TAG, "Failed to set datarate: %s!", datarate_set_str);
+                return false;
+            }
+
+            datarate_get = subghz_preset_custom_get_datarate(test_data_ptr, sizeof(test_data));
+            subghz_preset_custom_printf_datarate(
+                datarate_get, datarate_get_str, sizeof(datarate_get_str));
+
+            if(datarate_get < 0) {
+                FURI_LOG_E(TAG, "Failed to get datarate!");
+                return false;
+            }
+
+            if(datarate_set > datarateFineMax) {
+                result = fabsf(datarate_get - datarate_set) <= datarateRoughStep;
+                datarate_set -= datarateRoughStep;
+            } else {
+                result = fabsf(datarate_get - datarate_set) <= datarateFineStep;
+                datarate_set -= datarateFineStep;
+            }
+
+            if(result) {
+                FURI_LOG_T(
+                    TAG,
+                    "Datarate check OK: Set: %s - Get: %s",
+                    datarate_set_str,
+                    datarate_get_str);
+            } else {
+                FURI_LOG_E(
+                    TAG,
+                    "Datarate check failed!: %s is way to diff %s! DRATE_E: %hhu DRATE_M: %hhu",
+                    datarate_set_str,
+                    datarate_get_str,
+                    test_data[4 * 2 + 1] & 0b00001111,
+                    test_data[3 * 2 + 1]);
+                return false;
+            }
+        }
+    }
+
+    FURI_LOG_I(TAG, "Sub GHz custom preset test: OK");
+    return true;
 }
 
 MU_TEST(subghz_keystore_test) {
@@ -747,6 +874,10 @@ MU_TEST(subghz_random_test) {
     mu_assert(subghz_decode_random_test(TEST_RANDOM_DIR_NAME), "Random test error\r\n");
 }
 
+MU_TEST(subghz_preset_test) {
+    mu_assert(subghz_custom_preset_test(), "Custom preset logic error\r\n");
+}
+
 MU_TEST_SUITE(subghz) {
     subghz_test_init();
     MU_RUN_TEST(subghz_keystore_test);
@@ -817,7 +948,16 @@ MU_TEST_SUITE(subghz) {
     subghz_test_deinit();
 }
 
+MU_TEST_SUITE(subghz_app) {
+    MU_RUN_TEST(subghz_preset_test);
+}
+
 int run_minunit_test_subghz() {
     MU_RUN_SUITE(subghz);
+    return MU_EXIT_CODE;
+}
+
+int run_minunit_test_subghz_app() {
+    MU_RUN_SUITE(subghz_app);
     return MU_EXIT_CODE;
 }

--- a/applications/debug/unit_tests/test_index.c
+++ b/applications/debug/unit_tests/test_index.c
@@ -5,6 +5,7 @@
 #include <notification/notification_messages.h>
 #include <cli/cli.h>
 #include <loader/loader.h>
+#include <lib/toolbox/args.h>
 
 #define TAG "UnitTests"
 
@@ -18,6 +19,7 @@ int run_minunit_test_flipper_format_string();
 int run_minunit_test_stream();
 int run_minunit_test_storage();
 int run_minunit_test_subghz();
+int run_minunit_test_subghz_app();
 int run_minunit_test_dirwalk();
 int run_minunit_test_power();
 int run_minunit_test_protocol_dict();
@@ -45,6 +47,7 @@ const UnitTest unit_tests[] = {
     {.name = "flipper_format_string", .entry = run_minunit_test_flipper_format_string},
     {.name = "rpc", .entry = run_minunit_test_rpc},
     {.name = "subghz", .entry = run_minunit_test_subghz},
+    {.name = "subghz_app", .entry = run_minunit_test_subghz_app},
     {.name = "infrared", .entry = run_minunit_test_infrared},
     {.name = "nfc", .entry = run_minunit_test_nfc},
     {.name = "power", .entry = run_minunit_test_power},
@@ -71,6 +74,72 @@ void minunit_print_fail(const char* str) {
     printf(FURI_LOG_CLR_E "%s\r\n" FURI_LOG_CLR_RESET, str);
 }
 
+void unit_tests_cli_logs_puts(const char* str) {
+    printf(str);
+}
+
+// by default there is no output from unit tests
+// you have to enable them with this function
+void unit_tests_cli_enable_logs(FuriLogLevel logLevel) {
+    furi_log_init();
+    furi_log_set_level(logLevel);
+    furi_log_set_puts(unit_tests_cli_logs_puts);
+}
+
+void unit_tests_cli_print_help() {
+    printf(
+        "Usage:\r\n"
+        "   unit_tests [log level] [test_suit_name]\r\n"
+        "     Arguments:\r\n"
+        "       [log level]: optional, enables printing output from FURI_LOG_* macro in unit_tests\r\n"
+        "       [test_suit_name]: a specific test suit to run. If not specified runs all tests\r\n"
+        "                         Warning: supports only 1 test suit to launch\r\n"
+        "     Example:\r\n"
+        "       unit_tests                  - run ALL tests wihtout log printing\r\n"
+        "       unit_tests bt               - run bt tests wihtout log printing\r\n"
+        "       unit_tests log debug subghz - run subghz tests with logs at debug level abd above\r\n\r\n"
+        "   unit_tests help [?]\r\n"
+        "           prints this help\r\n");
+}
+
+bool unit_tests_cli_parse_log_level(FuriString* args) {
+    bool result = true;
+    FuriString* level = furi_string_alloc();
+    if(args_read_string_and_trim(args, level)) {
+        if(furi_string_cmpi_str(level, "default") == 0) {
+            unit_tests_cli_enable_logs(FuriLogLevelDefault);
+        } else if(furi_string_cmpi_str(level, "none") == 0) {
+            unit_tests_cli_enable_logs(FuriLogLevelNone);
+        } else if(furi_string_cmpi_str(level, "error") == 0) {
+            unit_tests_cli_enable_logs(FuriLogLevelError);
+        } else if(furi_string_cmpi_str(level, "warn") == 0) {
+            unit_tests_cli_enable_logs(FuriLogLevelWarn);
+        } else if(furi_string_cmpi_str(level, "info") == 0) {
+            unit_tests_cli_enable_logs(FuriLogLevelInfo);
+        } else if(furi_string_cmpi_str(level, "debug") == 0) {
+            unit_tests_cli_enable_logs(FuriLogLevelDebug);
+        } else if(furi_string_cmpi_str(level, "trace") == 0) {
+            unit_tests_cli_enable_logs(FuriLogLevelTrace);
+        } else {
+            printf("Error: Invalid log level: %s\r\n", furi_string_get_cstr(level));
+            result = false;
+        }
+    }
+    furi_string_free(level);
+    return result;
+}
+
+FuriString* unit_tests_cli_parse_test_suit(FuriString* args) {
+    FuriString* test_suit = furi_string_alloc();
+
+    if(!args_read_string_and_trim(args, test_suit)) {
+        furi_string_free(test_suit);
+        return NULL;
+    }
+
+    return test_suit;
+}
+
 void unit_tests_cli(Cli* cli, FuriString* args, void* context) {
     UNUSED(cli);
     UNUSED(args);
@@ -79,6 +148,34 @@ void unit_tests_cli(Cli* cli, FuriString* args, void* context) {
     minunit_assert = 0;
     minunit_fail = 0;
     minunit_status = 0;
+
+    if(furi_string_cmp_str(args, "help") == 0 || furi_string_cmp_str(args, "?") == 0) {
+        unit_tests_cli_print_help();
+        return;
+    }
+
+    FuriString* test_suit_to_run = NULL;
+
+    if(furi_string_size(args)) {
+        FuriString* arg = furi_string_alloc();
+        if(args_read_string_and_trim(args, arg)) {
+            if(furi_string_cmp_str(arg, "log") == 0) {
+                // read next argument - log level, if fail - show help and return
+                if(!unit_tests_cli_parse_log_level(args)) {
+                    unit_tests_cli_print_help();
+                    furi_string_free(arg);
+                    return;
+                }
+
+                // next argument might be test suit
+                test_suit_to_run = unit_tests_cli_parse_test_suit(args);
+            } else {
+                // if first argument wasn't log - it was exact test suit to run
+                test_suit_to_run = unit_tests_cli_parse_test_suit(arg);
+            }
+        }
+        furi_string_free(arg);
+    }
 
     Loader* loader = furi_record_open(RECORD_LOADER);
     NotificationApp* notification = furi_record_open(RECORD_NOTIFICATION);
@@ -98,8 +195,8 @@ void unit_tests_cli(Cli* cli, FuriString* args, void* context) {
                 break;
             }
 
-            if(furi_string_size(args)) {
-                if(furi_string_cmp_str(args, unit_tests[i].name) == 0) {
+            if(test_suit_to_run) {
+                if(furi_string_cmp_str(test_suit_to_run, unit_tests[i].name) == 0) {
                     unit_tests[i].entry();
                 } else {
                     printf("Skipping %s\r\n", unit_tests[i].name);
@@ -130,6 +227,10 @@ void unit_tests_cli(Cli* cli, FuriString* args, void* context) {
                 printf("Status: FAILED\r\n");
             }
         }
+    }
+
+    if(test_suit_to_run) {
+        furi_string_free(test_suit_to_run);
     }
 
     furi_record_close(RECORD_NOTIFICATION);

--- a/applications/main/subghz/helpers/subghz_custom_event.h
+++ b/applications/main/subghz/helpers/subghz_custom_event.h
@@ -42,6 +42,7 @@ typedef enum {
     SubGhzCustomEventSceneAnalyzerLock,
     SubGhzCustomEventSceneAnalyzerUnlock,
     SubGhzCustomEventSceneSettingLock,
+    SubGhzCustomEventSceneSettingError,
 
     SubGhzCustomEventSceneExit,
     SubGhzCustomEventSceneStay,

--- a/applications/main/subghz/scenes/subghz_scene_receiver_config.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver_config.c
@@ -39,6 +39,35 @@ const float raw_theshold_rssi_value[RAW_THRESHOLD_RSSI_COUNT] = {
     -40.0f,
 };
 
+#define BANDWIDTH_COUNT 16
+const char* const bandwidth_labels[BANDWIDTH_COUNT] = {
+    "58 kHz",
+    "68 kHz",
+    "81 kHz",
+    "102 kHz",
+    "116 kHz",
+    "135 kHz",
+    "162 kHz",
+    "203 kHz",
+    "232 kHz",
+    "270 kHz",
+    "325 kHz",
+    "406 kHz",
+    "464 kHz",
+    "541 kHz",
+    "650 kHz",
+    "812 kHz",
+};
+
+// Bandwidths values are ordered from F (58kHz) to 0 (812kHz)
+#define BANDWIDTH_INDEX(value) ((uint8_t)15 - ((uint8_t)(value >> 4) & 0x0F))
+
+#define MANCHESTER_FLAG_COUNT 2
+const char* const manchester_flag_text[MANCHESTER_FLAG_COUNT] = {
+    "OFF",
+    "ON",
+};
+
 #define HOPPING_COUNT 2
 const char* const hopping_text[HOPPING_COUNT] = {
     "OFF",
@@ -58,6 +87,18 @@ const uint32_t speaker_value[SPEAKER_COUNT] = {
     SubGhzSpeakerStateShutdown,
     SubGhzSpeakerStateEnable,
 };
+
+// Allow advanced edit only on specific preset
+bool subghz_scene_receiver_config_can_edit_current_preset(SubGhz* subghz) {
+    SubGhzRadioPreset* preset = subghz->txrx->preset;
+
+    bool preset_name_allow_edit =
+        !strcmp(furi_string_get_cstr(preset->name), ADVANCED_AM_PRESET_NAME) ||
+        !strcmp(furi_string_get_cstr(preset->name), "CUSTOM");
+
+    return preset && preset_name_allow_edit &&
+           subghz_preset_custom_is_ook_modulation(preset->data, preset->data_size);
+}
 
 uint8_t subghz_scene_receiver_config_next_frequency(const uint32_t value, void* context) {
     furi_assert(context);
@@ -87,6 +128,52 @@ uint8_t subghz_scene_receiver_config_next_preset(const char* preset_name, void* 
         }
     }
     return index;
+}
+
+// Advanced settings of preset may change if preset was changed.
+// In that case - update values
+static void subghz_scene_receiver_config_update_advanced(SubGhz* subghz) {
+    uint8_t value_index;
+
+    if(subghz->variable_item_bandwidth) {
+        value_index = BANDWIDTH_INDEX(subghz->txrx->raw_bandwidth);
+        variable_item_set_current_value_index(subghz->variable_item_bandwidth, value_index);
+        variable_item_set_current_value_text(
+            subghz->variable_item_bandwidth, bandwidth_labels[value_index]);
+    }
+
+    if(subghz->variable_item_datarate) {
+        variable_item_set_current_value_index(subghz->variable_item_datarate, 0);
+
+        char datarate_str[16] = {0};
+        subghz_preset_custom_printf_datarate(
+            subghz->txrx->raw_datarate, datarate_str, sizeof(datarate_str));
+        variable_item_set_current_value_text(subghz->variable_item_datarate, datarate_str);
+    }
+
+    if(subghz->variable_item_manchester) {
+        value_index = subghz->txrx->raw_manchester_enabled ? 1 : 0;
+
+        variable_item_set_current_value_index(subghz->variable_item_manchester, value_index);
+        variable_item_set_current_value_text(
+            subghz->variable_item_manchester, manchester_flag_text[value_index]);
+    }
+}
+
+// Apply advanced configuration to advanced am preset
+static void subghz_scene_receiver_config_apply_advanced(SubGhz* subghz) {
+    if(subghz_scene_receiver_config_can_edit_current_preset(subghz)) {
+        SubGhzRadioPreset* preset = subghz->txrx->preset;
+
+        subghz_preset_custom_set_bandwidth(
+            preset->data, preset->data_size, subghz->txrx->raw_bandwidth);
+
+        subghz_preset_custom_set_machester_enable(
+            preset->data, preset->data_size, subghz->txrx->raw_manchester_enabled);
+
+        subghz_preset_custom_set_datarate(
+            preset->data, preset->data_size, subghz->txrx->raw_datarate);
+    }
 }
 
 uint8_t subghz_scene_receiver_config_hopper_value_index(
@@ -140,6 +227,8 @@ static void subghz_scene_receiver_config_set_preset(VariableItem* item) {
         subghz->txrx->preset->frequency,
         subghz_setting_get_preset_data(subghz->setting, index),
         subghz_setting_get_preset_data_size(subghz->setting, index));
+
+    subghz_scene_receiver_config_update_advanced(subghz);
 }
 
 static void subghz_scene_receiver_config_set_hopping_running(VariableItem* item) {
@@ -192,6 +281,107 @@ static void subghz_scene_receiver_config_set_raw_threshold_rssi(VariableItem* it
 
     variable_item_set_current_value_text(item, raw_theshold_rssi_text[index]);
     subghz->txrx->raw_threshold_rssi = raw_theshold_rssi_value[index];
+}
+
+static void subghz_scene_receiver_config_set_raw_ook_bandwidth(VariableItem* item) {
+    SubGhz* subghz = variable_item_get_context(item);
+    if(subghz_scene_receiver_config_can_edit_current_preset(subghz)) {
+        // update bandwidth value from selected index
+        uint8_t index = variable_item_get_current_value_index(item);
+        subghz->txrx->raw_bandwidth = subghz_preset_custom_bandwidth_values[index];
+
+        subghz_scene_receiver_config_update_advanced(subghz);
+    } else {
+        furi_string_set(
+            subghz->error_str, "Read-only\nsetting!\nUse '" ADVANCED_AM_PRESET_NAME "'\npreset.");
+        view_dispatcher_send_custom_event(
+            subghz->view_dispatcher, SubGhzCustomEventSceneSettingError);
+    }
+}
+
+static void subghz_scene_receiver_config_set_manchester_flag(VariableItem* item) {
+    SubGhz* subghz = variable_item_get_context(item);
+    if(subghz_scene_receiver_config_can_edit_current_preset(subghz)) {
+        // update enable flag from view
+        uint8_t index = variable_item_get_current_value_index(item);
+        subghz->txrx->raw_manchester_enabled = index == 0 ? false : true;
+
+        subghz_scene_receiver_config_update_advanced(subghz);
+    } else {
+        furi_string_set(
+            subghz->error_str, "Read-only\nsetting!\nUse '" ADVANCED_AM_PRESET_NAME "'\npreset.");
+        view_dispatcher_send_custom_event(
+            subghz->view_dispatcher, SubGhzCustomEventSceneSettingError);
+    }
+}
+
+static void subghz_scene_receiver_config_datarate_input_callback(void* context) {
+    furi_assert(context);
+    SubGhz* subghz = context;
+
+    float value = atoff(subghz->datarate_input_str);
+    if(value != 0 && value > 0) {
+        subghz->txrx->raw_datarate = value;
+        subghz_scene_receiver_config_update_advanced(subghz);
+    }
+
+    // show list view
+    view_dispatcher_switch_to_view(subghz->view_dispatcher, SubGhzViewIdVariableItemList);
+}
+
+static bool subghz_scene_receiver_config_datarate_input_validate(
+    const char* text,
+    FuriString* error,
+    void* context) {
+    UNUSED(context);
+
+    float value = atoff(text);
+    if(value == 0) {
+        furi_string_printf(error, "Cannot parse\r\nvalue");
+    } else if(value < 0) {
+        furi_string_printf(error, "Value\r\nshould be\r\ngreater\r\nthan 0");
+    } else {
+        return true;
+    }
+
+    return false;
+}
+
+static void subghz_scene_receiver_config_show_datarate_input(SubGhz* subghz) {
+    TextInput* text_input = subghz->text_input;
+
+    snprintf(
+        subghz->datarate_input_str,
+        sizeof(subghz->datarate_input_str),
+        "%.2f",
+        (double)subghz->txrx->raw_datarate);
+
+    text_input_set_header_text(text_input, "Datarate bauds (not kBauds)");
+    text_input_set_result_callback(
+        text_input,
+        subghz_scene_receiver_config_datarate_input_callback,
+        subghz,
+        subghz->datarate_input_str,
+        sizeof(subghz->datarate_input_str),
+        false);
+
+    text_input_set_validator(
+        text_input, subghz_scene_receiver_config_datarate_input_validate, NULL);
+    view_dispatcher_switch_to_view(subghz->view_dispatcher, SubGhzViewIdTextInput);
+}
+
+static void subghz_scene_receiver_config_set_datarate(VariableItem* item) {
+    SubGhz* subghz = variable_item_get_context(item);
+    if(subghz_scene_receiver_config_can_edit_current_preset(subghz)) {
+        // reset value index in order to show '>' symbol always
+        variable_item_set_current_value_index(item, 0);
+        subghz_scene_receiver_config_show_datarate_input(subghz);
+    } else {
+        furi_string_set(
+            subghz->error_str, "Read-only\nsetting!\nUse '" ADVANCED_AM_PRESET_NAME "'\npreset.");
+        view_dispatcher_send_custom_event(
+            subghz->view_dispatcher, SubGhzCustomEventSceneSettingError);
+    }
 }
 
 static void subghz_scene_receiver_config_var_list_enter_callback(void* context, uint32_t index) {
@@ -284,6 +474,33 @@ void subghz_scene_receiver_config_on_enter(void* context) {
             subghz->txrx->raw_threshold_rssi, raw_theshold_rssi_value, RAW_THRESHOLD_RSSI_COUNT);
         variable_item_set_current_value_index(item, value_index);
         variable_item_set_current_value_text(item, raw_theshold_rssi_text[value_index]);
+
+        // Advanced MODEM settings. RW only for ADVANCED_AM_PRESET_NAME
+        // Bandwidth
+        subghz->variable_item_bandwidth = variable_item_list_add(
+            subghz->variable_item_list,
+            "Bandwidth:",
+            BANDWIDTH_COUNT,
+            subghz_scene_receiver_config_set_raw_ook_bandwidth,
+            subghz);
+
+        // Data rate (editable via OK click)
+        subghz->variable_item_datarate = variable_item_list_add(
+            subghz->variable_item_list,
+            "Data rate:",
+            2,
+            subghz_scene_receiver_config_set_datarate,
+            subghz);
+
+        // Manchester codec flag
+        subghz->variable_item_manchester = variable_item_list_add(
+            subghz->variable_item_list,
+            "Manch. Enc.:",
+            MANCHESTER_FLAG_COUNT,
+            subghz_scene_receiver_config_set_manchester_flag,
+            subghz);
+
+        subghz_scene_receiver_config_update_advanced(subghz);
     }
     view_dispatcher_switch_to_view(subghz->view_dispatcher, SubGhzViewIdVariableItemList);
 }
@@ -297,6 +514,11 @@ bool subghz_scene_receiver_config_on_event(void* context, SceneManagerEvent even
             subghz->lock = SubGhzLockOn;
             scene_manager_previous_scene(subghz->scene_manager);
             consumed = true;
+        } else if(event.event == SubGhzCustomEventSceneSettingError) {
+            scene_manager_next_scene(subghz->scene_manager, SubGhzSceneShowErrorSub);
+            scene_manager_set_scene_state(
+                subghz->scene_manager, SubGhzSceneShowErrorSub, event.event);
+            consumed = true;
         }
     }
     return consumed;
@@ -304,6 +526,16 @@ bool subghz_scene_receiver_config_on_event(void* context, SceneManagerEvent even
 
 void subghz_scene_receiver_config_on_exit(void* context) {
     SubGhz* subghz = context;
+
+    // reset UI variable list items (next scene may be not RAW config)
+    subghz->variable_item_bandwidth = NULL;
+    subghz->variable_item_datarate = NULL;
+    subghz->variable_item_manchester = NULL;
+    text_input_set_validator(subghz->text_input, NULL, NULL);
+
+    // apply advanced preset variables (if applicable)
+    subghz_scene_receiver_config_apply_advanced(subghz);
+
     variable_item_list_set_selected_item(subghz->variable_item_list, 0);
     variable_item_list_reset(subghz->variable_item_list);
     scene_manager_set_scene_state(

--- a/applications/main/subghz/scenes/subghz_scene_show_error_sub.c
+++ b/applications/main/subghz/scenes/subghz_scene_show_error_sub.c
@@ -26,8 +26,16 @@ bool subghz_scene_show_error_sub_on_event(void* context, SceneManagerEvent event
     SubGhz* subghz = context;
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == SubGhzCustomEventSceneShowErrorSub) {
-            scene_manager_search_and_switch_to_previous_scene(
-                subghz->scene_manager, SubGhzSceneStart);
+            if(scene_manager_get_scene_state(subghz->scene_manager, SubGhzSceneShowErrorSub) ==
+               SubGhzCustomEventSceneSettingError) {
+                scene_manager_set_scene_state(
+                    subghz->scene_manager, SubGhzSceneReadRAW, SubGhzCustomEventManagerSet);
+                scene_manager_search_and_switch_to_previous_scene(
+                    subghz->scene_manager, SubGhzSceneReceiverConfig);
+            } else {
+                scene_manager_search_and_switch_to_previous_scene(
+                    subghz->scene_manager, SubGhzSceneStart);
+            }
             return true;
         }
     }

--- a/applications/main/subghz/subghz.c
+++ b/applications/main/subghz/subghz.c
@@ -167,6 +167,12 @@ SubGhz* subghz_alloc() {
     subghz->setting = subghz_setting_alloc();
     subghz_setting_load(subghz->setting, EXT_PATH("subghz/assets/setting_user"));
 
+    // Load custom advanced AM preset with configurable CFGMDM settings
+    FlipperFormat* advanced_am_preset = subghz_preset_custom_advanced_am_preset_alloc();
+    subghz_setting_load_custom_preset(
+        subghz->setting, ADVANCED_AM_PRESET_NAME, advanced_am_preset);
+    flipper_format_free(advanced_am_preset);
+
     //init Worker & Protocol & History & KeyBoard
     subghz->lock = SubGhzLockOff;
     subghz->txrx = malloc(sizeof(SubGhzTxRx));

--- a/applications/main/subghz/subghz_i.c
+++ b/applications/main/subghz/subghz_i.c
@@ -30,6 +30,12 @@ void subghz_preset_init(
     subghz->txrx->preset->frequency = frequency;
     subghz->txrx->preset->data = preset_data;
     subghz->txrx->preset->data_size = preset_data_size;
+
+    subghz->txrx->raw_bandwidth =
+        subghz_preset_custom_get_bandwidth(preset_data, preset_data_size);
+    subghz->txrx->raw_manchester_enabled =
+        subghz_preset_custom_get_machester_enable(preset_data, preset_data_size);
+    subghz->txrx->raw_datarate = subghz_preset_custom_get_datarate(preset_data, preset_data_size);
 }
 
 bool subghz_set_preset(SubGhz* subghz, const char* preset) {

--- a/applications/main/subghz/subghz_i.h
+++ b/applications/main/subghz/subghz_i.h
@@ -3,6 +3,7 @@
 #include "helpers/subghz_types.h"
 #include "helpers/subghz_error_type.h"
 #include <lib/subghz/types.h>
+#include <lib/subghz/helpers/subghz_config_preset_custom.h>
 #include "subghz.h"
 #include "views/receiver.h"
 #include "views/transmitter.h"
@@ -60,6 +61,13 @@ struct SubGhzTxRx {
 
     float raw_threshold_rssi;
     uint8_t raw_threshold_rssi_low_count;
+
+    // one of the 16 possible bandwidth values
+    uint8_t raw_bandwidth;
+    // datarate in bauds
+    float raw_datarate;
+    // flag if manchester encoding/decoding enabled
+    bool raw_manchester_enabled;
 };
 
 typedef struct SubGhzTxRx SubGhzTxRx;
@@ -86,6 +94,13 @@ struct SubGhz {
     SubGhzViewReceiver* subghz_receiver;
     SubGhzViewTransmitter* subghz_transmitter;
     VariableItemList* variable_item_list;
+
+    // Advanced config items
+    VariableItem* variable_item_bandwidth; // specific config list view item: bandwidth
+    VariableItem* variable_item_datarate; // specific config list view item: data rate
+    VariableItem* variable_item_manchester; // specific config list view item: manchester enc flag
+    // Advanced config strings
+    char datarate_input_str[16];
 
     SubGhzFrequencyAnalyzer* subghz_frequency_analyzer;
     SubGhzReadRAW* subghz_read_raw;

--- a/lib/subghz/helpers/subghz_config_preset_custom.c
+++ b/lib/subghz/helpers/subghz_config_preset_custom.c
@@ -1,0 +1,326 @@
+#include "subghz_config_preset_custom.h"
+
+#include <stdio.h>
+#include <core/log.h>
+#include <core/core_defines.h> // UNUSED()
+#include <core/check.h> // furi_assert()
+#include <math.h> // log2(), floor()
+
+#include <flipper_format/flipper_format.h>
+
+// https://www.ti.com/lit/ds/symlink/cc1101.pdf?ts=1671943815135
+// page 35.
+// 12 Data Rate Programming
+//
+#define DATARATE_FUNC_CHIP_FOSC 26000000.0 /* 26MHz */
+#define DATARATE_FUNC_DIVIDER (1 << 28) /* 2 pow 28 */
+#define DATARATE_FUNC_MULTIPLIER \
+    (DATARATE_FUNC_CHIP_FOSC / DATARATE_FUNC_DIVIDER) /* should be 0.09685754 */
+
+#define DATARATE_EXP_FORMULA_DIVISIBLE (1 << 20) /* 2 pow 20 */
+#define DATARATE_EXP_FORMULA_MULTIPLIER \
+    (DATARATE_EXP_FORMULA_DIVISIBLE / DATARATE_FUNC_CHIP_FOSC) /* should be 0.04032984 */
+
+#define DATARATE_MNT_FORMULA_DIVISIBLE (1 << 28) /* 2 pow 28 */
+#define DATARATE_MNT_FORMULA_MULTIPLIER \
+    (DATARATE_MNT_FORMULA_DIVISIBLE / DATARATE_FUNC_CHIP_FOSC) /* should be 10.3244406 */
+//
+
+#define SUGHZ_CONFIG_TAG "SubGHz_Config"
+
+uint8_t furi_hal_subghz_preset_ook_custom_async_regs[PRESET_OOK_CUSTOM_ADVANCED_AM_SIZE] = {0};
+
+/** Check if cursom preset is AM (OOK) modulation
+ *
+ * This will check MOD_FORMAT bits in CC1101_MDMCFG2 register
+ * If preset data doesn have this register - will return false.
+ * This function will not fail in any case
+ *
+ * @param      preset_data  Custom preset data (registers and patable)
+ * @param      data_len     Data length
+ */
+bool subghz_preset_custom_is_ook_modulation(const uint8_t* preset_data, uint8_t data_len) {
+    if(preset_data != NULL) {
+        for(uint8_t i = 2; i <= data_len; i += 2) {
+            if(preset_data[i - 2] == CC1101_MDMCFG2) {
+                return (preset_data[i - 1] & 0b01110000) == 0x30;
+            }
+        }
+    }
+    return false;
+}
+
+/** Get bandwidth value from preset data.
+ *
+ * This will get HIGHER bits in CC1101_MDMCFG4 register
+ * If CC1101_MDMCFG4 is not found in preset data - will return
+ * CH_BANDWIDTH_INVALID (0xFF)
+ * If there is ANY low 4 bits in returned value - the value is invalid
+ *
+ * @param      preset_data  Custom preset data (registers and patable)
+ * @param      data_len     Data length
+ */
+uint8_t subghz_preset_custom_get_bandwidth(const uint8_t* preset_data, uint8_t data_len) {
+    if(preset_data != NULL) {
+        for(uint8_t i = 2; i <= data_len; i += 2) {
+            if(preset_data[i - 2] == CC1101_MDMCFG4) {
+                return (preset_data[i - 1] & 0b11110000);
+            }
+        }
+    }
+    return CH_BANDWIDTH_INVALID;
+}
+
+/** Set bandwidth value to preset data.
+ *
+ * This will set HIGHER bits in CC1101_MDMCFG4 register
+ * If CC1101_MDMCFG4 is not found in preset data - will do nothing and return false
+ * If there are ANY low 4 bits in provided value - they will be ignored
+ *
+ * @param      preset_data  Custom preset data (registers and patable)
+ * @param      data_len     Data length
+ * @param      value        New bandwidth value. See macros definition for possible values
+ */
+bool subghz_preset_custom_set_bandwidth(uint8_t* preset_data, uint8_t data_len, uint8_t value) {
+    if(preset_data != NULL) {
+        for(uint8_t i = 2; i <= data_len; i += 2) {
+            if(preset_data[i - 2] == CC1101_MDMCFG4) {
+                preset_data[i - 1] = (preset_data[i - 1] & 0b00001111) | (0b11110000 & value);
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/** Get data rate value from preset data.
+ *
+ * This will get DRATE_M and DRATE_E bits from CC1101_MDMCFG3 and CC1101_MDMCFG4 registers
+ * and calculate the value for 26MHz chip oscillator by formula from datasheet.
+ *
+ * If CC1101_MDMCFG[3:4] are not found in preset data - will return `-1`
+ *
+ * @param      preset_data  Custom preset data (registers and patable)
+ * @param      data_len     Data length
+ */
+float subghz_preset_custom_get_datarate(const uint8_t* preset_data, uint8_t data_len) {
+    if(preset_data != NULL) {
+        uint8_t mantissa = 0xFF;
+        uint8_t exponent = 0xFF; // Invalid, only 4 lower bits are singificant
+
+        uint8_t step = 0;
+
+        for(uint8_t i = 2; i <= data_len && step < 2; i += 2) {
+            if(preset_data[i - 2] == CC1101_MDMCFG4) {
+                exponent = preset_data[i - 1] & 0b00001111;
+                step++;
+            } else if(preset_data[i - 2] == CC1101_MDMCFG3) {
+                mantissa = preset_data[i - 1];
+                step++;
+            }
+        }
+
+        if(step == 2) {
+            return (float)((256 + mantissa) * (1 << exponent) * DATARATE_FUNC_MULTIPLIER);
+        }
+    }
+    return -1;
+}
+
+/** Set data rate value to preset data.
+ *
+ * This will update DRATE_M and DRATE_E bits from CC1101_MDMCFG3 and CC1101_MDMCFG4 registers
+ * with calculated values for 26MHz chip oscillator by formula from datasheet.
+ *
+ * If CC1101_MDMCFG[3:4] are not found in preset data - will return false
+ *
+ * @param      preset_data  Custom preset data (registers and patable)
+ * @param      data_len     Data length
+ * @param      value        value in kBaud
+ */
+bool subghz_preset_custom_set_datarate(uint8_t* preset_data, uint8_t data_len, float value) {
+    if(preset_data != NULL) {
+        uint8_t* pMantissa = NULL;
+        uint8_t* pExponent = NULL;
+
+        uint8_t step = 0;
+        for(uint8_t i = 2; i <= data_len && step < 2; i += 2) {
+            if(preset_data[i - 2] == CC1101_MDMCFG4) {
+                pExponent = &preset_data[i - 1];
+                step++;
+            } else if(preset_data[i - 2] == CC1101_MDMCFG3) {
+                pMantissa = &preset_data[i - 1];
+                step++;
+            }
+        }
+
+        // Has both registers in data - calculate values
+        if(step == 2) {
+            //            │      value * 2^20  │
+            //  DRATE_E = │log2(──────────────)│
+            //            └          Fosc      ┘
+
+            double exponent = floor(log2(value * DATARATE_EXP_FORMULA_MULTIPLIER));
+            uint8_t datarate_e = (uint8_t)exponent;
+
+            //                 value * 2^28
+            //  DRATE_M = (────────────────────) - 256
+            //               Fosc *  2^DRATE_E
+            double mantissa =
+                floor((value * DATARATE_MNT_FORMULA_MULTIPLIER) / (1 << datarate_e) + 0.5) - 256;
+
+            // If DRATE_M is rounded to the nearest integer and becomes 256, increment DRATE_E and use DRATE_M = 0.
+            if(mantissa >= 256) {
+                mantissa = 0;
+                datarate_e += 1;
+            }
+            uint8_t datarate_m = (uint8_t)mantissa;
+
+            *pExponent = (*pExponent & 0b11110000) | (datarate_e & 0b00001111);
+            *pMantissa = datarate_m;
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/** Print datarate value to string
+ *
+ * This is just convenience function
+ *
+ * @param      datarate datarate obtained from `subghz_preset_custom_get_datarate` function
+ * @param      string   Target print buffer
+ * @param      size     Target print buffer size
+ */
+void subghz_preset_custom_printf_datarate(float datarate, char* string, uint8_t size) {
+    float kBaudRate = datarate / 1000.0f;
+    snprintf(
+        string,
+        size,
+        "%lu.%02lu kBd",
+        (uint32_t)(kBaudRate), // decimal part
+        (uint32_t)((kBaudRate - (uint32_t)kBaudRate) * 100) // fractional part multiplied by 100
+    );
+}
+
+/** Get Manchester encoding/decoding flag value from preset data.
+ *
+ * This will get MANCHESTER_EN (3-rd) bit in CC1101_MDMCFG2 register
+ * If CC1101_MDMCFG2 is not found in preset data - will return false
+ *
+ * @param      preset_data  Custom preset data (registers and patable)
+ * @param      data_len     Data length
+ */
+bool subghz_preset_custom_get_machester_enable(const uint8_t* preset_data, uint8_t data_len) {
+    if(preset_data != NULL) {
+        for(uint8_t i = 2; i <= data_len; i += 2) {
+            if(preset_data[i - 2] == CC1101_MDMCFG2) {
+                return (preset_data[i - 1] & 0b00001000);
+            }
+        }
+    }
+    return false;
+}
+
+/** Set Manchester encoding/decoding flag value to preset data.
+ *
+ * This will set MANCHESTER_EN (3-rd) bit in CC1101_MDMCFG2 register
+ * If CC1101_MDMCFG2 is not found in preset data - will return false
+ *
+ * @param      preset_data  Custom preset data (registers and patable)
+ * @param      data_len     Data length
+ */
+bool subghz_preset_custom_set_machester_enable(uint8_t* preset_data, uint8_t data_len, bool value) {
+    if(preset_data != NULL) {
+        for(uint8_t i = 2; i <= data_len; i += 2) {
+            if(preset_data[i - 2] == CC1101_MDMCFG2) {
+                preset_data[i - 1] = (preset_data[i - 1] & 0b11110111) | (0b00001000 * value);
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * Initialize custom preset data
+ */
+void subghz_preset_custom_init_advanced_am_preset() {
+    FURI_LOG_D(SUGHZ_CONFIG_TAG, "Initializing AM preset with custom Modem configuration");
+
+    if(furi_hal_subghz_preset_ook_custom_async_regs[0]) {
+        // already initialized
+        FURI_LOG_D(SUGHZ_CONFIG_TAG, "Already initialized");
+        return;
+    }
+
+    // Copy default AM270 preset
+    memcpy(
+        &furi_hal_subghz_preset_ook_custom_async_regs,
+        &furi_hal_subghz_preset_ook_270khz_async_regs,
+        sizeof(furi_hal_subghz_preset_ook_270khz_async_regs));
+
+    const uint8_t ModemConfigStart = 4;
+
+#if FURI_DEBUG
+    const uint8_t ModemConfigEnd = ModemConfigStart + MODEM_CONFIG_REGISTERS_COUNT;
+    for(uint8_t i = ModemConfigStart; i < ModemConfigEnd; ++i) {
+        // Check we'll overwrite correct settings
+        furi_assert(
+            furi_hal_subghz_preset_ook_custom_async_regs[i * 2 + 0] ==
+            furi_hal_subghz_custom_modulation_regs[i - ModemConfigStart][0]);
+    }
+#endif
+
+    // Copy CUSTOM Modem preset
+    memcpy(
+        &furi_hal_subghz_preset_ook_custom_async_regs[ModemConfigStart * 2],
+        &furi_hal_subghz_custom_modulation_regs,
+        sizeof(furi_hal_subghz_custom_modulation_regs));
+
+    // Copy default AM270 patable
+    memcpy(
+        &furi_hal_subghz_preset_ook_custom_async_regs[sizeof(
+            furi_hal_subghz_preset_ook_270khz_async_regs)],
+        &furi_hal_subghz_preset_ook_async_patable,
+        sizeof(furi_hal_subghz_preset_ook_async_patable));
+
+    // Here at the end we should have
+    // <AM270 bytes> <CFGMDM regs> <AM270 bytes> 00 00 <AM270 patable>
+
+#if FURI_DEBUG
+    FURI_LOG_D(SUGHZ_CONFIG_TAG, "Custom OOK preset created");
+
+    for(uint8_t i = 0; i < PRESET_OOK_CUSTOM_ADVANCED_AM_SIZE; i += 2) {
+        FURI_LOG_D(
+            SUGHZ_CONFIG_TAG,
+            "Register: 0x%hhX, Value: 0x%hhX",
+            furi_hal_subghz_preset_ook_custom_async_regs[i * 2 + 0],
+            furi_hal_subghz_preset_ook_custom_async_regs[i * 2 + 1]);
+    }
+#endif
+
+    FURI_LOG_D(SUGHZ_CONFIG_TAG, "Done");
+}
+
+/**
+ * Create subghz preset file with custom am preset
+ * this is used for preset initialization if subghz app
+ */
+FlipperFormat* subghz_preset_custom_advanced_am_preset_alloc() {
+    FlipperFormat* advanced_am_preset = flipper_format_string_alloc();
+
+    subghz_preset_custom_init_advanced_am_preset();
+
+    flipper_format_write_hex(
+        advanced_am_preset,
+        (const char*)"Custom_preset_data",
+        (const uint8_t*)&furi_hal_subghz_preset_ook_custom_async_regs[0],
+        sizeof(furi_hal_subghz_preset_ook_custom_async_regs));
+
+    flipper_format_rewind(advanced_am_preset);
+
+    return advanced_am_preset;
+}

--- a/lib/subghz/helpers/subghz_config_preset_custom.h
+++ b/lib/subghz/helpers/subghz_config_preset_custom.h
@@ -1,0 +1,193 @@
+#pragma once
+
+#include <furi_hal_subghz_configs.h>
+#include <string.h> /* memcpy() */
+
+#define ADVANCED_AM_PRESET_NAME "AM*"
+
+// Awailable bandwidth values
+// Setup in MDMCFG4 register
+#define CH_BANDWIDTH_058 0b11110000
+#define CH_BANDWIDTH_068 0b11100000
+#define CH_BANDWIDTH_081 0b11010000
+#define CH_BANDWIDTH_102 0b11000000
+
+#define CH_BANDWIDTH_116 0b10110000
+#define CH_BANDWIDTH_135 0b10100000
+#define CH_BANDWIDTH_162 0b10010000
+#define CH_BANDWIDTH_203 0b10000000
+
+#define CH_BANDWIDTH_232 0b01110000
+#define CH_BANDWIDTH_270 0b01100000
+#define CH_BANDWIDTH_325 0b01010000
+#define CH_BANDWIDTH_406 0b01000000
+
+#define CH_BANDWIDTH_464 0b00110000
+#define CH_BANDWIDTH_541 0b00100000
+#define CH_BANDWIDTH_650 0b00010000
+#define CH_BANDWIDTH_812 0b00000000
+
+#define CH_BANDWIDTH_INVALID 0xFF
+
+static const uint8_t subghz_preset_custom_bandwidth_values[] = {
+    CH_BANDWIDTH_058,
+    CH_BANDWIDTH_068,
+    CH_BANDWIDTH_081,
+    CH_BANDWIDTH_102,
+
+    CH_BANDWIDTH_116,
+    CH_BANDWIDTH_135,
+    CH_BANDWIDTH_162,
+    CH_BANDWIDTH_203,
+
+    CH_BANDWIDTH_232,
+    CH_BANDWIDTH_270,
+    CH_BANDWIDTH_325,
+    CH_BANDWIDTH_406,
+
+    CH_BANDWIDTH_464,
+    CH_BANDWIDTH_541,
+    CH_BANDWIDTH_650,
+    CH_BANDWIDTH_812,
+};
+#define CH_BANDWIDTH_NUM (sizeof(subghz_preset_custom_bandwidth_values) / sizeof(uint8_t))
+
+#define DATARATE_EXPONENT_3_79_kBaud 0b00000111 // 7
+#define DATARATE_MANTISSA_3_79_kBaud 0x32
+
+#define CHANNEL_SPACING_25_EXPONENT 0b00000000 /* last bit */
+#define CHANNEL_SPACING_25_MANTISSA 0x00
+
+#define MODEM_CONFIG_REGISTERS_COUNT 5
+#define PRESET_OOK_CUSTOM_ADVANCED_AM_SIZE                 \
+    sizeof(furi_hal_subghz_preset_ook_270khz_async_regs) + \
+        sizeof(furi_hal_subghz_preset_ook_async_patable)
+
+extern uint8_t furi_hal_subghz_preset_ook_custom_async_regs[PRESET_OOK_CUSTOM_ADVANCED_AM_SIZE];
+
+static const uint8_t furi_hal_subghz_custom_modulation_regs[MODEM_CONFIG_REGISTERS_COUNT][2] = {
+    // Channel spacing is 25kHz, no Forward Error Correction, 2 preamble bytes (will be ignored)
+    {CC1101_MDMCFG0, CHANNEL_SPACING_25_MANTISSA},
+    {CC1101_MDMCFG1, 0x00 | CHANNEL_SPACING_25_EXPONENT},
+
+    // [0:2] SYNC_MODE      = 00    // No preamble/sync
+    // [3:3] MANCHESTER_EN  = 0     // Disable
+    // [4:6] MOD_FORMAT     = 03    // Format ASK/OOK
+    // [7:7] DEM_DCFILT_OFF = 0     // Enable
+    {CC1101_MDMCFG2, 0x30},
+
+    // 3.79 kBaud data rate (mantissa in 3rd register)
+    {CC1101_MDMCFG3, DATARATE_MANTISSA_3_79_kBaud},
+
+    // 270.8333 kHz Rx BW filer (hi) and 3.79 kBaud data rate (exponent in 4th register)
+    {CC1101_MDMCFG4, DATARATE_EXPONENT_3_79_kBaud | CH_BANDWIDTH_270},
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Check if cursom preset is AM (OOK) modulation
+ *
+ * This will check MOD_FORMAT bits in CC1101_MDMCFG2 register
+ * If preset data doesn have this register - will return false.
+ * This function will not fail in any case
+ *
+ * @param      preset_data  Custom preset data (registers and patable)
+ * @param      data_len     Data length
+ */
+bool subghz_preset_custom_is_ook_modulation(const uint8_t* preset_data, uint8_t data_len);
+
+/** Get bandwidth value from preset data.
+ *
+ * This will get HIGHER bits in CC1101_MDMCFG4 register
+ * If CC1101_MDMCFG4 is not found in preset data - will return
+ * CH_BANDWIDTH_INVALID (0xFF)
+ * If there is ANY low 4 bits in returned value - the value is invalid
+ *
+ * @param      preset_data  Custom preset data (registers and patable)
+ * @param      data_len     Data length
+ */
+uint8_t subghz_preset_custom_get_bandwidth(const uint8_t* preset_data, uint8_t data_len);
+
+/** Set bandwidth value to preset data.
+ *
+ * This will set HIGHER bits in CC1101_MDMCFG4 register
+ * If CC1101_MDMCFG4 is not found in preset data - will do nothing and return false
+ * If there are ANY low 4 bits in provided value - they will be ignored
+ *
+ * @param      preset_data  Custom preset data (registers and patable)
+ * @param      data_len     Data length
+ * @param      value        New bandwidth value. See macros definition for possible values
+ */
+bool subghz_preset_custom_set_bandwidth(uint8_t* preset_data, uint8_t data_len, uint8_t value);
+
+/** Get data rate value from preset data.
+ *
+ * This will get DRATE_M and DRATE_E bits from CC1101_MDMCFG3 and CC1101_MDMCFG4 registers
+ * and calculate the value for 26MHz chip oscillator by formula from datasheet.
+ *
+ * If CC1101_MDMCFG[3:4] are not found in preset data - will return `-1`
+ *
+ * @param      preset_data  Custom preset data (registers and patable)
+ * @param      data_len     Data length
+ */
+float subghz_preset_custom_get_datarate(const uint8_t* preset_data, uint8_t data_len);
+
+/** Set data rate value to preset data.
+ *
+ * This will update DRATE_M and DRATE_E bits from CC1101_MDMCFG3 and CC1101_MDMCFG4 registers
+ * with calculated values for 26MHz chip oscillator by formula from datasheet.
+ *
+ * If CC1101_MDMCFG[3:4] are not found in preset data - will return false
+ *
+ * @param      preset_data  Custom preset data (registers and patable)
+ * @param      data_len     Data length
+ * @param      value        value in kBaud
+ */
+bool subghz_preset_custom_set_datarate(uint8_t* preset_data, uint8_t data_len, float value);
+
+/** Print datarate value to string
+ *
+ * This is just conviniece function
+ *
+ * @param      datarate datarate obtained from `subghz_preset_custom_get_datarate` function
+ * @param      string   Target print buffer
+ * @param      size     Target print buffer size
+ */
+void subghz_preset_custom_printf_datarate(float datarate, char* string, uint8_t size);
+
+/** Get Manchester encoding/decoding flag value from preset data.
+ *
+ * This will get MANCHESTER_EN (3-rd) bit in CC1101_MDMCFG2 register
+ * If CC1101_MDMCFG2 is not found in preset data - will return false
+ *
+ * @param      preset_data  Custom preset data (registers and patable)
+ * @param      data_len     Data length
+ */
+bool subghz_preset_custom_get_machester_enable(const uint8_t* preset_data, uint8_t data_len);
+
+/** Set Manchester encoding/decoding flag value to preset data.
+ *
+ * This will set MANCHESTER_EN (3-rd) bit in CC1101_MDMCFG2 register
+ * If CC1101_MDMCFG2 is not found in preset data - will return false
+ *
+ * @param      preset_data  Custom preset data (registers and patable)
+ * @param      data_len     Data length
+ */
+bool subghz_preset_custom_set_machester_enable(uint8_t* preset_data, uint8_t data_len, bool value);
+
+/**
+ * Initialize advanced am custom preset
+ */
+void subghz_preset_custom_init_advanced_am_preset();
+
+/**
+ * Create subghz preset file with custom am preset
+ * this is used for preset initialization if subghz app
+ */
+struct FlipperFormat* subghz_preset_custom_advanced_am_preset_alloc();
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
# What's new

- [SubGhz] 
   -  [Receiver]
      Special preset `AM*` introduced. This preset allows to modify `Bandwidth`, `Datarate` and `Macnhester decoding` parameters of `CC1101` chip.
      This PR also allows to get information about these fields from default (or other custom) modulation presets
      
- [unit_tests]
  - Minor improvement to unit_tests app - allows to set desired log level before running unit_tests

## Abstract
Some transmitters may have non-standard transmission params. So in order to get pulses more accurate you might need to have options to adjust some `CC1101` settings manually.

This PR also could be a basement for other configurable parameters of `CC1101` chip editing.

# Verification 

- Open SubGHz App and enter *read raw* mode:
  ![0000](https://user-images.githubusercontent.com/5215122/210118045-63c6108a-adf0-4aaa-81ba-455ed7b6783c.png)
- Select modulation preset `AM*`
  ![0001](https://user-images.githubusercontent.com/5215122/210118048-148e6679-c630-4ec4-895a-61a44a8ddc88.png)
  ![0002](https://user-images.githubusercontent.com/5215122/210118047-5ebe3866-3c91-4b1f-b791-14fd3a2660ba.png)
  > Please note: default preset `AM650` will show invalid `Bandwidth`, `Datarate` and `Manchester decoding` params because this preset was initialized with `NULL` as it `CC1101`'s registers data
- Setup desired configuration and test it
  ![0003](https://user-images.githubusercontent.com/5215122/210118046-12733715-d1c6-4f05-8da9-64934903a57b.png) 
- Recorded RAW file will contain `CC1101` registers configuration according to your setup
- Loading this RAW file should setup exact configuration
  > Please note: `CUSTOM` presets also allowed to be modified, so once you load your RAW file, you may change the advanced configuration of custom preset for RAW file

# Checklist (For Reviewer)
- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
