### PR TITLE
Infrared: Fix not enough repeats for parsed protocols in brute mode

### DIFF
--- a/applications/main/infrared/infrared_signal.c
+++ b/applications/main/infrared/infrared_signal.c
@@ -295,6 +295,6 @@ void infrared_signal_transmit(InfraredSignal* signal) {
             raw_signal->duty_cycle);
     } else {
         InfraredMessage* message = &signal->payload.message;
-        infrared_send(message, 3);
+        infrared_send(message, 2);
     }
 }

--- a/applications/main/infrared/infrared_signal.c
+++ b/applications/main/infrared/infrared_signal.c
@@ -295,6 +295,6 @@ void infrared_signal_transmit(InfraredSignal* signal) {
             raw_signal->duty_cycle);
     } else {
         InfraredMessage* message = &signal->payload.message;
-        infrared_send(message, 1);
+        infrared_send(message, 3);
     }
 }


### PR DESCRIPTION

# What's new

- Fixes SIRC protocol now works fine with sony tvs in universal remote
- May fix other `parsed` protocols that was sent and not received due to too short signal

# Verification 

- Remove RAW recordings from infrared/assets/tv.ir file (some of them are just not parsed SIRC)
- Make sure to have parsed SIRC buttons for Sony Bravia TV in file
- Verify that bruteforce now actually works (we tested it on 2 Sony tv's with SIRC protocol)

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
