### PR TITLE
Use InputKeyRight same way as InputKeyOk

### DIFF
--- a/applications/services/gui/modules/file_browser.c
+++ b/applications/services/gui/modules/file_browser.c
@@ -617,7 +617,7 @@ static bool file_browser_view_input_callback(InputEvent* event, void* context) {
             browser_update_offset(browser);
             consumed = true;
         }
-    } else if(event->key == InputKeyOk) {
+    } else if(event->key == InputKeyOk || event->key == InputKeyRight) {
         if(event->type == InputTypeShort) {
             BrowserItem_t* selected_item = NULL;
             int32_t select_index = 0;


### PR DESCRIPTION
this must improve UX of the file_browser (#2251):

1. file browser will use all keys events
2. left and right click now works symmetrically

# What's new

press right button will work same way like center button in file browser.

# Verification 

1. open Applications menu on flipper
3. select folder (up/down)
4. press right. -> folder opens.
5. press left for parent folder
6. repeat right click on same folder or any another
7. now right click on application. This will launch the application

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
