### PR TITLE
Change broken BadUSB link to Hak5 duckyscript quick reference webpage

### DIFF
--- a/assets/resources/badusb/demo_macos.txt
+++ b/assets/resources/badusb/demo_macos.txt
@@ -79,7 +79,7 @@ STRING Flipper Zero BadUSB feature is compatible with USB Rubber Ducky script fo
 ENTER
 STRING More information about script syntax can be found here:
 ENTER
-STRING https://github.com/hak5darren/USB-Rubber-Ducky/wiki/Duckyscript
+STRING https://docs.hak5.org/hak5-usb-rubber-ducky/duckyscript-tm-quick-reference
 ENTER
 
 STRING EOF

--- a/assets/resources/badusb/demo_macos.txt
+++ b/assets/resources/badusb/demo_macos.txt
@@ -79,7 +79,7 @@ STRING Flipper Zero BadUSB feature is compatible with USB Rubber Ducky script fo
 ENTER
 STRING More information about script syntax can be found here:
 ENTER
-STRING https://docs.hak5.org/hak5-usb-rubber-ducky/duckyscript-tm-quick-reference
+STRING https://github.com/flipperdevices/flipperzero-firmware/blob/dev/documentation/file_formats/BadUsbScriptFormat.md
 ENTER
 
 STRING EOF

--- a/assets/resources/badusb/demo_windows.txt
+++ b/assets/resources/badusb/demo_windows.txt
@@ -80,5 +80,5 @@ STRING Flipper Zero BadUSB feature is compatible with USB Rubber Ducky script fo
 ENTER
 STRING More information about script syntax can be found here:
 ENTER
-STRING https://docs.hak5.org/hak5-usb-rubber-ducky/duckyscript-tm-quick-reference
+STRING https://github.com/flipperdevices/flipperzero-firmware/blob/dev/documentation/file_formats/BadUsbScriptFormat.md
 ENTER

--- a/assets/resources/badusb/demo_windows.txt
+++ b/assets/resources/badusb/demo_windows.txt
@@ -80,5 +80,5 @@ STRING Flipper Zero BadUSB feature is compatible with USB Rubber Ducky script fo
 ENTER
 STRING More information about script syntax can be found here:
 ENTER
-STRING https://github.com/hak5darren/USB-Rubber-Ducky/wiki/Duckyscript
+STRING https://docs.hak5.org/hak5-usb-rubber-ducky/duckyscript-tm-quick-reference
 ENTER


### PR DESCRIPTION
# What's new

Previously both windows and mac badusb demo scripts included this dead link: 
https://github.com/hak5darren/USB-Rubber-Ducky/wiki/Duckyscript

This has now been switched for ~~Hak5's~~ Flipper's current quick reference at:
~~https://docs.hak5.org/hak5-usb-rubber-ducky/duckyscript-tm-quick-reference~~
https://github.com/flipperdevices/flipperzero-firmware/blob/dev/documentation/file_formats/BadUsbScriptFormat.md

# Verification 

Build & upload to a Flipper. Run both windows and mac demos and observe the correct link being typed out. 
Alternately, view the .txt script file to observe the correct link.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
