### PR TITLE
Attach FW (blackmagic) Windows configuration for vscode

### DIFF
--- a/.vscode/example/launch.json
+++ b/.vscode/example/launch.json
@@ -16,6 +16,19 @@
                 "command": "./fbt get_blackmagic",
                 "description": "Get Blackmagic device",
             }
+        },
+        {
+            "id": "BLACKMAGIC_WIN",
+            "type": "command",
+            "command": "shellCommand.execute",
+            "args": {
+                "useSingleResult": true,
+                "env": {
+                    "PATH": "${workspaceFolder};${env:PATH}"
+                },
+                "command": "fbt.cmd get_blackmagic",
+                "description": "Get Blackmagic device",
+            }
         }
     ],
     "configurations": [
@@ -52,6 +65,27 @@
             "type": "cortex-debug",
             "servertype": "external",
             "gdbTarget": "${input:BLACKMAGIC}",
+            "svdFile": "./debug/STM32WB55_CM4.svd",
+            "rtos": "FreeRTOS",
+            "postAttachCommands": [
+                "monitor swdp_scan",
+                "attach 1",
+                "set confirm off",
+                "set mem inaccessible-by-default off",
+                "source debug/flipperapps.py",
+                "fap-set-debug-elf-root build/latest/.extapps",
+                // "compare-sections",
+            ]
+            // "showDevDebugOutput": "raw",
+        },
+        {
+            "name": "Attach FW (blackmagic) Windows",
+            "cwd": "${workspaceFolder}",
+            "executable": "./build/latest/firmware.elf",
+            "request": "attach",
+            "type": "cortex-debug",
+            "servertype": "external",
+            "gdbTarget": "${input:BLACKMAGIC_WIN}",
             "svdFile": "./debug/STM32WB55_CM4.svd",
             "rtos": "FreeRTOS",
             "postAttachCommands": [


### PR DESCRIPTION
# What's new

Vscode blackmagic configuration for windows. 

Existing one do not work as it requires `BLACKMAGIC` input calling `./fbt get_blackmagic` ending up with exception in `cmd`.

![изображение](https://user-images.githubusercontent.com/15075638/211416319-5ab51308-9a1a-4b04-af84-91ccb0506a6a.png)

# Verification 

Run `Attach FW (blackmagic) Windows` in vscode using Windows.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
