### PR TITLE
Fix typos in source code

### DIFF
--- a/applications/services/gui/modules/text_input.c
+++ b/applications/services/gui/modules/text_input.c
@@ -29,7 +29,7 @@ typedef struct {
     TextInputValidatorCallback validator_callback;
     void* validator_callback_context;
     FuriString* validator_text;
-    bool valadator_message_visible;
+    bool validator_message_visible;
 } TextInputModel;
 
 static const uint8_t keyboard_origin_x = 1;
@@ -254,7 +254,7 @@ static void text_input_view_draw_callback(Canvas* canvas, void* _model) {
             }
         }
     }
-    if(model->valadator_message_visible) {
+    if(model->validator_message_visible) {
         canvas_set_font(canvas, FontSecondary);
         canvas_set_color(canvas, ColorWhite);
         canvas_draw_box(canvas, 8, 10, 110, 48);
@@ -319,7 +319,7 @@ static void text_input_handle_ok(TextInput* text_input, TextInputModel* model, b
         if(model->validator_callback &&
            (!model->validator_callback(
                model->text_buffer, model->validator_text, model->validator_callback_context))) {
-            model->valadator_message_visible = true;
+            model->validator_message_visible = true;
             furi_timer_start(text_input->timer, furi_kernel_get_tick_frequency() * 4);
         } else if(model->callback != 0 && text_length > 0) {
             model->callback(model->callback_context);
@@ -348,8 +348,8 @@ static bool text_input_view_input_callback(InputEvent* event, void* context) {
     TextInputModel* model = view_get_model(text_input->view);
 
     if((!(event->type == InputTypePress) && !(event->type == InputTypeRelease)) &&
-       model->valadator_message_visible) {
-        model->valadator_message_visible = false;
+       model->validator_message_visible) {
+        model->validator_message_visible = false;
         consumed = true;
     } else if(event->type == InputTypeShort) {
         consumed = true;
@@ -435,7 +435,7 @@ void text_input_timer_callback(void* context) {
     with_view_model(
         text_input->view,
         TextInputModel * model,
-        { model->valadator_message_visible = false; },
+        { model->validator_message_visible = false; },
         true);
 }
 
@@ -495,7 +495,7 @@ void text_input_reset(TextInput* text_input) {
             model->validator_callback = NULL;
             model->validator_callback_context = NULL;
             furi_string_reset(model->validator_text);
-            model->valadator_message_visible = false;
+            model->validator_message_visible = false;
         },
         true);
 }

--- a/applications/services/gui/modules/widget.h
+++ b/applications/services/gui/modules/widget.h
@@ -91,7 +91,7 @@ void widget_add_string_element(
  * @param[in]  text             Formatted text. The following formats are available:
  *                               "\e#Bold text\e#" - bold font is used
  *                               "\e*Monospaced text\e*" - monospaced font is used
- *                               "\e#Inversed text\e#" - white text on black background
+ *                               "\e!Inversed text\e!" - white text on black background
  * @param      strip_to_dots    Strip text to ... if does not fit to width
  */
 void widget_add_text_box_element(

--- a/applications/services/input/input.h
+++ b/applications/services/input/input.h
@@ -19,7 +19,7 @@ extern "C" {
 typedef enum {
     InputTypePress, /**< Press event, emitted after debounce */
     InputTypeRelease, /**< Release event, emitted after debounce */
-    InputTypeShort, /**< Short event, emitted after InputTypeRelease done withing INPUT_LONG_PRESS interval */
+    InputTypeShort, /**< Short event, emitted after InputTypeRelease done within INPUT_LONG_PRESS interval */
     InputTypeLong, /**< Long event, emitted after INPUT_LONG_PRESS_COUNTS interval, asynchronous to InputTypeRelease  */
     InputTypeRepeat, /**< Repeat event, emitted with INPUT_LONG_PRESS_COUNTS period after InputTypeLong event */
     InputTypeMAX, /**< Special value for exceptional */


### PR DESCRIPTION
The code already works with "!", but the comment was wrong.

# What's new

- Changed one comment from `#` to `!`
- Changed typo `valadator_message_visible` to `validator_message_visible`

# Verification 

- Confirm that text prefixed with `\e!` becomes inverted.
- Read other changes

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
