### PR TITLE
Add lockable capability to Submenu module

### DIFF
--- a/applications/services/gui/modules/submenu.c
+++ b/applications/services/gui/modules/submenu.c
@@ -263,6 +263,15 @@ void submenu_add_item(
     const char* label,
     uint32_t index,
     SubmenuItemCallback callback,
+    void* callback_context) {
+    submenu_add_lockable_item(submenu, label, index, callback, callback_context, false, NULL);
+}
+
+void submenu_add_lockable_item(
+    Submenu* submenu,
+    const char* label,
+    uint32_t index,
+    SubmenuItemCallback callback,
     void* callback_context,
     bool locked,
     const char* locked_message) {

--- a/applications/services/gui/modules/submenu.h
+++ b/applications/services/gui/modules/submenu.h
@@ -51,7 +51,9 @@ void submenu_add_item(
     const char* label,
     uint32_t index,
     SubmenuItemCallback callback,
-    void* callback_context);
+    void* callback_context,
+    bool locked,
+    const char* locked_message);
 
 /** Remove all items from submenu
  *

--- a/applications/services/gui/modules/submenu.h
+++ b/applications/services/gui/modules/submenu.h
@@ -51,6 +51,24 @@ void submenu_add_item(
     const char* label,
     uint32_t index,
     SubmenuItemCallback callback,
+    void* callback_context);
+
+/** Add lockable item to submenu
+ *
+ * @param      submenu           Submenu instance
+ * @param      label             menu item label
+ * @param      index             menu item index, used for callback, may be
+ *                               the same with other items
+ * @param      callback          menu item callback
+ * @param      callback_context  menu item callback context
+ * @param      locked            menu item locked status
+ * @param      locked_message    menu item locked message
+ */
+void submenu_add_lockable_item(
+    Submenu* submenu,
+    const char* label,
+    uint32_t index,
+    SubmenuItemCallback callback,
     void* callback_context,
     bool locked,
     const char* locked_message);

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,11.6,,
+Version,+,11.7,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,
@@ -2652,6 +2652,7 @@ Function,+,subghz_worker_set_pair_callback,void,"SubGhzWorker*, SubGhzWorkerPair
 Function,+,subghz_worker_start,void,SubGhzWorker*
 Function,+,subghz_worker_stop,void,SubGhzWorker*
 Function,+,submenu_add_item,void,"Submenu*, const char*, uint32_t, SubmenuItemCallback, void*"
+Function,+,submenu_add_lockable_item,void,"Submenu*, const char*, uint32_t, SubmenuItemCallback, void*, _Bool, const char*"
 Function,+,submenu_alloc,Submenu*,
 Function,+,submenu_free,void,Submenu*
 Function,+,submenu_get_view,View*,Submenu*


### PR DESCRIPTION
# What's new

- Submenu items can now be locked. When clicked, they will display a help message.

# Verification 

- Read new code (or write a simple app that uses this new function)

# Screenshots

![lockable1](https://user-images.githubusercontent.com/1778595/211685341-a30b4196-6738-4640-ba9d-c74640c7ab39.png)
![lock3](https://user-images.githubusercontent.com/1778595/211685484-6f6effac-3693-4f0c-92f1-91448c5f2b09.png)
![lockable2](https://user-images.githubusercontent.com/1778595/211685351-422b4b0e-6c17-41ca-b71f-67c6f9baebeb.png)


# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
