### PR TITLE
Rename "Detect reader"

### DIFF
--- a/applications/main/nfc/scenes/nfc_scene_start.c
+++ b/applications/main/nfc/scenes/nfc_scene_start.c
@@ -23,7 +23,7 @@ void nfc_scene_start_on_enter(void* context) {
 
     submenu_add_item(submenu, "Read", SubmenuIndexRead, nfc_scene_start_submenu_callback, nfc);
     submenu_add_item(
-        submenu, "Detect Reader", SubmenuIndexDetectReader, nfc_scene_start_submenu_callback, nfc);
+        submenu, "Obtain MF Classic keys", SubmenuIndexDetectReader, nfc_scene_start_submenu_callback, nfc);
     submenu_add_item(submenu, "Saved", SubmenuIndexSaved, nfc_scene_start_submenu_callback, nfc);
     submenu_add_item(
         submenu, "Extra Actions", SubmenuIndexExtraAction, nfc_scene_start_submenu_callback, nfc);


### PR DESCRIPTION
Okay, I'm not quite glad with this function being vaguely named. Obtain MiFare Classic keys seems to be a way better and more descriptive name.

# What's new

1. The MFKey32 function is now named "Obtain MF Classic keys" to avoid misunderstanding and confusion

# Verification 

1. Compile
2. Open the NFC app
3. [new value is there and fits]

# Checklist (For Reviewer)

- [Y] PR has description of feature/bug or link to Confluence/Jira task
- [Y] Description contains actions to verify feature/bugfix
- [Y] I've built this code, uploaded it to the device and verified feature/bugfix
Image below shows all of the changes this PR contains ![20230120_151516](https://user-images.githubusercontent.com/63470411/213696631-9e9cabcf-d0b2-4b7f-820d-f01867c3881f.jpg)
