### PR TITLE
NFC: support parsing DESFire, add myki and Opal parsers

### DIFF
--- a/applications/main/nfc/scenes/nfc_scene_device_info.c
+++ b/applications/main/nfc/scenes/nfc_scene_device_info.c
@@ -52,7 +52,8 @@ void nfc_scene_device_info_on_enter(void* context) {
         }
     } else if(
         dev_data->protocol == NfcDeviceProtocolMifareClassic ||
-        dev_data->protocol == NfcDeviceProtocolMifareUl) {
+        dev_data->protocol == NfcDeviceProtocolMifareUl ||
+        dev_data->protocol == NfcDeviceProtocolMifareDesfire) {
         furi_string_set(temp_str, nfc->dev->dev_data.parsed_data);
     }
 

--- a/applications/main/nfc/scenes/nfc_scene_generate_info.c
+++ b/applications/main/nfc/scenes/nfc_scene_generate_info.c
@@ -44,6 +44,8 @@ bool nfc_scene_generate_info_on_event(void* context, SceneManagerEvent event) {
                 scene_manager_next_scene(nfc->scene_manager, NfcSceneMfClassicMenu);
             } else if(nfc->dev->dev_data.protocol == NfcDeviceProtocolMifareUl) {
                 scene_manager_next_scene(nfc->scene_manager, NfcSceneMfUltralightMenu);
+            } else if(nfc->dev->dev_data.protocol == NfcDeviceProtocolMifareDesfire) {
+                scene_manager_next_scene(nfc->scene_manager, NfcSceneMfDesfireMenu);
             }
             consumed = true;
         }

--- a/applications/main/nfc/scenes/nfc_scene_mf_desfire_read_success.c
+++ b/applications/main/nfc/scenes/nfc_scene_mf_desfire_read_success.c
@@ -20,35 +20,40 @@ void nfc_scene_mf_desfire_read_success_on_enter(void* context) {
     Widget* widget = nfc->widget;
 
     // Prepare string for data display
-    FuriString* temp_str = furi_string_alloc_printf("\e#MIFARE DESfire\n");
-    furi_string_cat_printf(temp_str, "UID:");
-    for(size_t i = 0; i < nfc_data->uid_len; i++) {
-        furi_string_cat_printf(temp_str, " %02X", nfc_data->uid[i]);
-    }
-
-    uint32_t bytes_total = 1UL << (data->version.sw_storage >> 1);
-    uint32_t bytes_free = data->free_memory ? data->free_memory->bytes : 0;
-    furi_string_cat_printf(temp_str, "\n%lu", bytes_total);
-    if(data->version.sw_storage & 1) {
-        furi_string_push_back(temp_str, '+');
-    }
-    furi_string_cat_printf(temp_str, " bytes, %lu bytes free\n", bytes_free);
-
-    uint16_t n_apps = 0;
-    uint16_t n_files = 0;
-    for(MifareDesfireApplication* app = data->app_head; app; app = app->next) {
-        n_apps++;
-        for(MifareDesfireFile* file = app->file_head; file; file = file->next) {
-            n_files++;
+    FuriString* temp_str = NULL;
+    if(furi_string_size(nfc->dev->dev_data.parsed_data)) {
+        temp_str = furi_string_alloc_set(nfc->dev->dev_data.parsed_data);
+    } else {
+        temp_str = furi_string_alloc_printf("\e#MIFARE DESfire\n");
+        furi_string_cat_printf(temp_str, "UID:");
+        for(size_t i = 0; i < nfc_data->uid_len; i++) {
+            furi_string_cat_printf(temp_str, " %02X", nfc_data->uid[i]);
         }
-    }
-    furi_string_cat_printf(temp_str, "%d Application", n_apps);
-    if(n_apps != 1) {
-        furi_string_push_back(temp_str, 's');
-    }
-    furi_string_cat_printf(temp_str, ", %d file", n_files);
-    if(n_files != 1) {
-        furi_string_push_back(temp_str, 's');
+
+        uint32_t bytes_total = 1UL << (data->version.sw_storage >> 1);
+        uint32_t bytes_free = data->free_memory ? data->free_memory->bytes : 0;
+        furi_string_cat_printf(temp_str, "\n%lu", bytes_total);
+        if(data->version.sw_storage & 1) {
+            furi_string_push_back(temp_str, '+');
+        }
+        furi_string_cat_printf(temp_str, " bytes, %lu bytes free\n", bytes_free);
+
+        uint16_t n_apps = 0;
+        uint16_t n_files = 0;
+        for(MifareDesfireApplication* app = data->app_head; app; app = app->next) {
+            n_apps++;
+            for(MifareDesfireFile* file = app->file_head; file; file = file->next) {
+                n_files++;
+            }
+        }
+        furi_string_cat_printf(temp_str, "%d Application", n_apps);
+        if(n_apps != 1) {
+            furi_string_push_back(temp_str, 's');
+        }
+        furi_string_cat_printf(temp_str, ", %d file", n_files);
+        if(n_files != 1) {
+            furi_string_push_back(temp_str, 's');
+        }
     }
 
     notification_message_block(nfc->notifications, &sequence_set_green_255);

--- a/applications/main/nfc/scenes/nfc_scene_nfc_data_info.c
+++ b/applications/main/nfc/scenes/nfc_scene_nfc_data_info.c
@@ -14,7 +14,8 @@ void nfc_scene_nfc_data_info_on_enter(void* context) {
     NfcDeviceData* dev_data = &nfc->dev->dev_data;
     NfcProtocol protocol = dev_data->protocol;
     uint8_t text_scroll_height = 0;
-    if((protocol == NfcDeviceProtocolMifareDesfire) || (protocol == NfcDeviceProtocolMifareUl)) {
+    if((protocol == NfcDeviceProtocolMifareDesfire) || (protocol == NfcDeviceProtocolMifareUl) ||
+       (protocol == NfcDeviceProtocolMifareDesfire)) {
         widget_add_button_element(
             widget, GuiButtonTypeRight, "More", nfc_scene_nfc_data_info_widget_callback, nfc);
         text_scroll_height = 52;
@@ -135,6 +136,9 @@ bool nfc_scene_nfc_data_info_on_event(void* context, SceneManagerEvent event) {
                 consumed = true;
             } else if(protocol == NfcDeviceProtocolMifareUl) {
                 scene_manager_next_scene(nfc->scene_manager, NfcSceneMfUltralightData);
+                consumed = true;
+            } else if(protocol == NfcDeviceProtocolMifareDesfire) {
+                scene_manager_next_scene(nfc->scene_manager, NfcSceneMfDesfireData);
                 consumed = true;
             }
         }

--- a/applications/main/nfc/scenes/nfc_scene_saved_menu.c
+++ b/applications/main/nfc/scenes/nfc_scene_saved_menu.c
@@ -146,7 +146,8 @@ bool nfc_scene_saved_menu_on_event(void* context, SceneManagerEvent event) {
                 application_info_present = true;
             } else if(
                 dev_data->protocol == NfcDeviceProtocolMifareClassic ||
-                dev_data->protocol == NfcDeviceProtocolMifareUl) {
+                dev_data->protocol == NfcDeviceProtocolMifareUl ||
+                dev_data->protocol == NfcDeviceProtocolMifareDesfire) {
                 application_info_present = nfc_supported_card_verify_and_parse(dev_data);
             }
 

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,11.7,,
+Version,+,11.8,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,
@@ -1916,6 +1916,7 @@ Function,-,mf_df_cat_key_settings,void,"MifareDesfireKeySettings*, FuriString*"
 Function,-,mf_df_cat_version,void,"MifareDesfireVersion*, FuriString*"
 Function,-,mf_df_check_card_type,_Bool,"uint8_t, uint8_t, uint8_t"
 Function,-,mf_df_clear,void,MifareDesfireData*
+Function,-,mf_df_find_application,MifareDesfireApplication*,"MifareDesfireData*, uint32_t"
 Function,-,mf_df_parse_get_application_ids_response,_Bool,"uint8_t*, uint16_t, MifareDesfireApplication**"
 Function,-,mf_df_parse_get_file_ids_response,_Bool,"uint8_t*, uint16_t, MifareDesfireFile**"
 Function,-,mf_df_parse_get_file_settings_response,_Bool,"uint8_t*, uint16_t, MifareDesfireFile*"

--- a/lib/nfc/nfc_worker.c
+++ b/lib/nfc/nfc_worker.c
@@ -215,13 +215,16 @@ static bool nfc_worker_read_mf_desfire(NfcWorker* nfc_worker, FuriHalNfcTxRxCont
     }
 
     do {
+        if(!furi_hal_nfc_detect(&nfc_worker->dev_data->nfc_data, 300)) break;
+        if(!mf_df_read_card(tx_rx, data)) break;
+        furi_hal_nfc_sleep();
+
         // Try to read supported card
         FURI_LOG_I(TAG, "Trying to read a supported card ...");
         for(size_t i = 0; i < NfcSupportedCardTypeEnd; i++) {
             if(nfc_supported_card[i].protocol == NfcDeviceProtocolMifareDesfire) {
                 if(nfc_supported_card[i].verify(nfc_worker, tx_rx)) {
                     if(nfc_supported_card[i].read(nfc_worker, tx_rx)) {
-                        read_success = true;
                         nfc_supported_card[i].parse(nfc_worker->dev_data);
                         break;
                     }
@@ -230,12 +233,7 @@ static bool nfc_worker_read_mf_desfire(NfcWorker* nfc_worker, FuriHalNfcTxRxCont
                 }
             }
         }
-        if(read_success) break;
-        furi_hal_nfc_sleep();
 
-        // Otherwise, try to read as usual
-        if(!furi_hal_nfc_detect(&nfc_worker->dev_data->nfc_data, 300)) break;
-        if(!mf_df_read_card(tx_rx, data)) break;
         read_success = true;
     } while(false);
 

--- a/lib/nfc/parsers/myki.c
+++ b/lib/nfc/parsers/myki.c
@@ -6,11 +6,8 @@
 
 bool myki_parser_verify(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx) {
     furi_assert(nfc_worker);
+    UNUSED(tx_rx);
     MifareDesfireData* data = &nfc_worker->dev_data->mf_df_data;
-
-    if(!furi_hal_nfc_detect(&nfc_worker->dev_data->nfc_data, 300)) return false;
-    if(!mf_df_read_card(tx_rx, data)) return false;
-
     if(mf_df_find_application(data, 0x0011f2)) {
         FURI_LOG_I("myki", "Card verified");
         return true;

--- a/lib/nfc/parsers/myki.c
+++ b/lib/nfc/parsers/myki.c
@@ -1,0 +1,104 @@
+#include "nfc_supported_card.h"
+
+#include <nfc_worker_i.h>
+
+#include "furi_hal.h"
+
+bool myki_parser_verify(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx) {
+    furi_assert(nfc_worker);
+    MifareDesfireData* data = &nfc_worker->dev_data->mf_df_data;
+
+    if(!furi_hal_nfc_detect(&nfc_worker->dev_data->nfc_data, 300)) return false;
+    if(!mf_df_read_card(tx_rx, data)) return false;
+
+    if(mf_df_find_application(data, 0x0011f2)) {
+        FURI_LOG_I("myki", "Card verified");
+        return true;
+    }
+    return false;
+}
+
+bool myki_parser_read(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx) {
+    furi_assert(nfc_worker);
+    UNUSED(tx_rx);
+    FURI_LOG_I("myki", "Card read");
+    return true;
+}
+
+uint8_t myki_calculate_luhn(uint64_t number) {
+    // https://en.wikipedia.org/wiki/Luhn_algorithm
+    // Drop existing check digit to form payload
+    uint64_t payload = number / 10;
+    int sum = 0;
+    int position = 0;
+
+    while(payload > 0) {
+        int digit = payload % 10;
+        if(position % 2 == 0) {
+            digit *= 2;
+        }
+        if(digit > 9) {
+            digit = (digit / 10) + (digit % 10);
+        }
+        sum += digit;
+        payload /= 10;
+        position++;
+    }
+
+    return (10 - (sum % 10)) % 10;
+}
+
+bool myki_parser_parse(NfcDeviceData* dev_data) {
+    // Reference: https://github.com/metrodroid/metrodroid/wiki/Myki
+    if(dev_data->protocol != NfcDeviceProtocolMifareDesfire) return false;
+    MifareDesfireApplication* app = mf_df_find_application(&dev_data->mf_df_data, 0x0011f2);
+    if(!app) return false;
+
+    uint64_t card_number = 0;
+    bool found_card = false;
+    for(MifareDesfireFile* file = app->file_head; file; file = file->next) {
+        uint8_t* data = file->contents;
+        if(file->id == 15 && data) {
+            uint64_t top = ((uint64_t)data[3] << 24) | ((uint64_t)data[2] << 16) |
+                           ((uint64_t)data[1] << 8) | (uint64_t)data[0];
+            uint64_t bottom = ((uint64_t)data[7] << 24) | ((uint64_t)data[6] << 16) |
+                              ((uint64_t)data[5] << 8) | (uint64_t)data[4];
+
+            // All myki card numbers are prefixed with "308425"
+            if(top != 308425) return false;
+            // Card numbers are always 15 digits in length
+            if(bottom < 10000000 || bottom >= 100000000) return false;
+
+            card_number = (top * 1000000000) + (bottom * 10);
+            // Stored card number doesn't include check digit
+            card_number = card_number + myki_calculate_luhn(card_number);
+            found_card = true;
+            break;
+        }
+    }
+    if(!found_card) return false;
+
+    // Stylise card number according to the physical card
+    char card_string[20];
+    snprintf(card_string, 20, "%llu", card_number);
+    furi_string_printf(
+        dev_data->parsed_data,
+        "\e#myki\n%c %c%c%c%c%c %c%c%c%c %c%c%c%c %c\n",
+        card_string[0],
+        card_string[1],
+        card_string[2],
+        card_string[3],
+        card_string[4],
+        card_string[5],
+        card_string[6],
+        card_string[7],
+        card_string[8],
+        card_string[9],
+        card_string[10],
+        card_string[11],
+        card_string[12],
+        card_string[13],
+        card_string[14]);
+
+    return true;
+}

--- a/lib/nfc/parsers/myki.h
+++ b/lib/nfc/parsers/myki.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "nfc_supported_card.h"
+
+bool myki_parser_verify(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx);
+
+bool myki_parser_read(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx);
+
+bool myki_parser_parse(NfcDeviceData* dev_data);
+
+uint8_t myki_calculate_luhn(uint64_t number);

--- a/lib/nfc/parsers/nfc_supported_card.c
+++ b/lib/nfc/parsers/nfc_supported_card.c
@@ -6,6 +6,7 @@
 #include "troika_4k_parser.h"
 #include "two_cities.h"
 #include "all_in_one.h"
+#include "myki.h"
 
 NfcSupportedCard nfc_supported_card[NfcSupportedCardTypeEnd] = {
     [NfcSupportedCardTypePlantain] =
@@ -49,6 +50,13 @@ NfcSupportedCard nfc_supported_card[NfcSupportedCardTypeEnd] = {
             .verify = all_in_one_parser_verify,
             .read = all_in_one_parser_read,
             .parse = all_in_one_parser_parse,
+        },
+    [NfcSupportedCardTypeMyki] =
+        {
+            .protocol = NfcDeviceProtocolMifareDesfire,
+            .verify = myki_parser_verify,
+            .read = myki_parser_read,
+            .parse = myki_parser_parse,
         },
 };
 

--- a/lib/nfc/parsers/nfc_supported_card.c
+++ b/lib/nfc/parsers/nfc_supported_card.c
@@ -7,6 +7,7 @@
 #include "two_cities.h"
 #include "all_in_one.h"
 #include "myki.h"
+#include "opal.h"
 
 NfcSupportedCard nfc_supported_card[NfcSupportedCardTypeEnd] = {
     [NfcSupportedCardTypePlantain] =
@@ -57,6 +58,13 @@ NfcSupportedCard nfc_supported_card[NfcSupportedCardTypeEnd] = {
             .verify = myki_parser_verify,
             .read = myki_parser_read,
             .parse = myki_parser_parse,
+        },
+    [NfcSupportedCardTypeOpal] =
+        {
+            .protocol = NfcDeviceProtocolMifareDesfire,
+            .verify = opal_parser_verify,
+            .read = opal_parser_read,
+            .parse = opal_parser_parse,
         },
 };
 

--- a/lib/nfc/parsers/nfc_supported_card.h
+++ b/lib/nfc/parsers/nfc_supported_card.h
@@ -11,6 +11,7 @@ typedef enum {
     NfcSupportedCardTypeTroika4K,
     NfcSupportedCardTypeTwoCities,
     NfcSupportedCardTypeAllInOne,
+    NfcSupportedCardTypeMyki,
 
     NfcSupportedCardTypeEnd,
 } NfcSupportedCardType;

--- a/lib/nfc/parsers/nfc_supported_card.h
+++ b/lib/nfc/parsers/nfc_supported_card.h
@@ -12,6 +12,7 @@ typedef enum {
     NfcSupportedCardTypeTwoCities,
     NfcSupportedCardTypeAllInOne,
     NfcSupportedCardTypeMyki,
+    NfcSupportedCardTypeOpal,
 
     NfcSupportedCardTypeEnd,
 } NfcSupportedCardType;

--- a/lib/nfc/parsers/opal.c
+++ b/lib/nfc/parsers/opal.c
@@ -1,0 +1,166 @@
+#include "nfc_supported_card.h"
+#include <nfc_worker_i.h>
+#include "furi_hal.h"
+#include <time.h>
+#include <locale/locale.h>
+
+static const char* opal_modes_of_transport[] = {
+    "Rail",
+    "Ferry or light rail",
+    "Bus",
+};
+
+static const char* opal_usage_types[] = {
+    "None (new, unused card)",
+    "New journey",
+    "Transfer (from same mode)",
+    "Transfer (from different mode)",
+    "New journey (Manly Ferry)",
+    "Transfer (from other ferry to Manly Ferry)",
+    "Transfer (from other mode to Manly Ferry)",
+    "Journey completed (distance fare)",
+    "Journey completed (flat-rate fare)",
+    "Journey completed (failure to tap off)",
+    "Journey completed (failure to tap on)",
+    "Tap on reversal",
+    "Tap on rejected",
+};
+
+bool opal_parser_verify(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx) {
+    furi_assert(nfc_worker);
+    MifareDesfireData* data = &nfc_worker->dev_data->mf_df_data;
+
+    if(!furi_hal_nfc_detect(&nfc_worker->dev_data->nfc_data, 300)) return false;
+    if(!mf_df_read_card(tx_rx, data)) return false;
+
+    if(mf_df_find_application(data, 0x314553)) {
+        FURI_LOG_I("opal", "Card verified");
+        return true;
+    }
+    return false;
+}
+
+bool opal_parser_read(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx) {
+    furi_assert(nfc_worker);
+    UNUSED(tx_rx);
+    FURI_LOG_I("opal", "Card read");
+    return true;
+}
+
+bool opal_parser_parse(NfcDeviceData* dev_data) {
+    UNUSED(dev_data);
+    // Reference: https://github.com/metrodroid/metrodroid/wiki/Opal
+    if(dev_data->protocol != NfcDeviceProtocolMifareDesfire) return false;
+    MifareDesfireApplication* app = mf_df_find_application(&dev_data->mf_df_data, 0x314553);
+    if(!app) return false;
+
+    FuriString* tmp = furi_string_alloc();
+
+    bool found_card = false;
+    uint8_t* data;
+    for(MifareDesfireFile* file = app->file_head; file; file = file->next) {
+        data = file->contents;
+        if(file->id == 7 && data) {
+            found_card = true;
+            break;
+        }
+    }
+    if(!found_card || !data) return false;
+
+    uint32_t serial_number = ((uint32_t)data[3] << 24) | ((uint32_t)data[2] << 16) |
+                             ((uint32_t)data[1] << 8) | (uint32_t)data[0];
+    uint8_t serial_number_check_digit = data[4] & 0x0F;
+    bool card_blocked = data[4] & 0x10;
+    uint16_t transaction_sequence_number = ((uint16_t)(data[6] & 0x1F) << 11) |
+                                           ((uint16_t)data[5] << 3) | ((uint16_t)data[4] >> 5);
+    int32_t balance_in_cents = ((uint16_t)(data[9] & 0x03) << 19) | ((int32_t)data[8] << 11) |
+                               ((int32_t)data[7] << 3) | ((int32_t)data[6] >> 5);
+    uint16_t last_tap_date_since_epoch = ((uint16_t)(data[11] & 0x01) << 14) |
+                                         ((uint16_t)data[10] << 6) | ((uint16_t)data[9] >> 2);
+    uint16_t last_tap_time_minutes = ((uint16_t)(data[12] & 0x0F) << 7) |
+                                     ((uint16_t)data[11] >> 1);
+    uint8_t last_tap_mode_of_transport = (data[12] >> 4) & 0x07;
+    uint8_t last_tap_usage_type = (data[13] & 0x07) << 1 | (data[12] >> 7);
+    bool autotopup_enabled = (data[13] >> 3) & 0x01;
+    uint8_t weekly_paid_journey_count = data[13] >> 4;
+
+    // Ignore CRC verification
+    // uint16_t crc = ((uint16_t)data[15] << 8) | ((uint16_t)data[14]);
+
+    furi_string_set(dev_data->parsed_data, "\e#Opal\n");
+    // Stylise card number according to the physical card
+    char serial_string[11];
+    snprintf(serial_string, 11, "%09lu", serial_number);
+    furi_string_cat_printf(
+        dev_data->parsed_data,
+        "3085 22%c%c %c%c%c%c %c%c%c%u\n",
+        serial_string[0],
+        serial_string[1],
+        serial_string[2],
+        serial_string[3],
+        serial_string[4],
+        serial_string[5],
+        serial_string[6],
+        serial_string[7],
+        serial_string[8],
+        serial_number_check_digit);
+
+    if(card_blocked) {
+        furi_string_cat(dev_data->parsed_data, "Card blocked\n");
+    }
+
+    furi_string_cat_printf(
+        dev_data->parsed_data,
+        "Balance: $%ld.%02d",
+        balance_in_cents / 100,
+        abs(balance_in_cents) % 100);
+    if(autotopup_enabled) {
+        furi_string_cat(dev_data->parsed_data, ", auto top-up");
+    }
+    furi_string_cat(dev_data->parsed_data, "\n");
+
+    furi_string_cat_printf(
+        dev_data->parsed_data,
+        "Rides: %u weekly, %u total\n",
+        weekly_paid_journey_count,
+        transaction_sequence_number);
+
+    furi_string_cat(dev_data->parsed_data, "Last trip: ");
+    if(last_tap_mode_of_transport < 3) {
+        furi_string_cat_printf(
+            dev_data->parsed_data, "%s, ", opal_modes_of_transport[last_tap_mode_of_transport]);
+    }
+
+    if(last_tap_usage_type < 13) {
+        furi_string_cat_printf(
+            dev_data->parsed_data, "%s ", opal_usage_types[last_tap_usage_type]);
+    }
+
+    // Calculate timestamp since 1 January 1980 epoch
+    // Stored as Australia/Sydney local time
+    struct tm last_tap = {0};
+    last_tap.tm_year = 80;
+    last_tap.tm_mon = 0;
+    last_tap.tm_mday = last_tap_date_since_epoch + 1;
+    last_tap.tm_min = last_tap_time_minutes;
+    mktime(&last_tap);
+
+    // Convert last_tap to furi format and print
+    FuriHalRtcDateTime last_tap_furi = {
+        .year = last_tap.tm_year + 1900,
+        .month = last_tap.tm_mon + 1,
+        .day = last_tap.tm_mday,
+        .hour = last_tap.tm_hour,
+        .minute = last_tap.tm_min,
+    };
+    furi_string_cat(dev_data->parsed_data, "at ");
+    locale_format_date(tmp, &last_tap_furi, locale_get_date_format(), "/");
+    furi_string_cat(dev_data->parsed_data, tmp);
+    furi_string_cat(dev_data->parsed_data, " ");
+    locale_format_time(tmp, &last_tap_furi, locale_get_time_format(), false);
+    furi_string_cat(dev_data->parsed_data, tmp);
+    furi_string_cat(dev_data->parsed_data, "\n");
+
+    furi_string_free(tmp);
+    return true;
+}

--- a/lib/nfc/parsers/opal.c
+++ b/lib/nfc/parsers/opal.c
@@ -28,11 +28,8 @@ static const char* opal_usage_types[] = {
 
 bool opal_parser_verify(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx) {
     furi_assert(nfc_worker);
+    UNUSED(tx_rx);
     MifareDesfireData* data = &nfc_worker->dev_data->mf_df_data;
-
-    if(!furi_hal_nfc_detect(&nfc_worker->dev_data->nfc_data, 300)) return false;
-    if(!mf_df_read_card(tx_rx, data)) return false;
-
     if(mf_df_find_application(data, 0x314553)) {
         FURI_LOG_I("opal", "Card verified");
         return true;

--- a/lib/nfc/parsers/opal.h
+++ b/lib/nfc/parsers/opal.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "nfc_supported_card.h"
+
+bool opal_parser_verify(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx);
+
+bool opal_parser_read(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx);
+
+bool opal_parser_parse(NfcDeviceData* dev_data);

--- a/lib/nfc/protocols/mifare_desfire.c
+++ b/lib/nfc/protocols/mifare_desfire.c
@@ -49,6 +49,19 @@ void mf_df_cat_data(MifareDesfireData* data, FuriString* out) {
     }
 }
 
+MifareDesfireApplication*
+    mf_df_find_application(MifareDesfireData* data, uint32_t application_id) {
+    uint8_t x = application_id >> 16;
+    uint8_t y = application_id >> 8;
+    uint8_t z = application_id;
+    for(MifareDesfireApplication* app = data->app_head; app; app = app->next) {
+        if(app->id[0] == x && app->id[1] == y && app->id[2] == z) {
+            return app;
+        }
+    }
+    return NULL;
+}
+
 void mf_df_cat_card_info(MifareDesfireData* data, FuriString* out) {
     mf_df_cat_version(&data->version, out);
     if(data->free_memory) {

--- a/lib/nfc/protocols/mifare_desfire.h
+++ b/lib/nfc/protocols/mifare_desfire.h
@@ -119,6 +119,8 @@ typedef struct {
 
 void mf_df_clear(MifareDesfireData* data);
 
+MifareDesfireApplication* mf_df_find_application(MifareDesfireData* data, uint32_t application_id);
+
 void mf_df_cat_data(MifareDesfireData* data, FuriString* out);
 void mf_df_cat_card_info(MifareDesfireData* data, FuriString* out);
 void mf_df_cat_version(MifareDesfireVersion* version, FuriString* out);


### PR DESCRIPTION
# What's new

- Add DESFire support for NFC card parsers
- Add parser for myki (Melbourne, Australia) [image](https://github.com/metrodroid/metrodroid/raw/master/cardimages/android/drawable-hdpi/myki_card.png)
- Add parser for Opal (Sydney, Australia) [image](https://github.com/metrodroid/metrodroid/raw/master/cardimages/android/drawable-hdpi/opal_card.png)

https://user-images.githubusercontent.com/13267947/213913551-d78e3341-86db-45d3-aebd-1883063abb7c.mov

![Screenshot-20230122-223331](https://user-images.githubusercontent.com/13267947/213913665-11ca26d8-e620-4faf-a7c3-807a55d366fa.png)
![Screenshot-20230122-223352](https://user-images.githubusercontent.com/13267947/213913668-7ac7c68f-0551-4e6c-9288-db45ccb5aaa7.png)



# Verification 

For each of the following cards:  `NFC -> Saved -> [card] -> Info`

[myki.nfc](https://github.com/flipperdevices/flipperzero-firmware/files/10474297/myki.nfc.txt)
[opal.nfc](https://github.com/flipperdevices/flipperzero-firmware/files/10474298/opal.nfc.txt)

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
