### PR TITLE
emv: parse track1&2 equivalent data

### DIFF
--- a/lib/nfc/nfc_worker.c
+++ b/lib/nfc/nfc_worker.c
@@ -282,14 +282,6 @@ static bool nfc_worker_read_bank_card(NfcWorker* nfc_worker, FuriHalNfcTxRxConte
     if(emv_app.currency_code) {
         result->currency_code = emv_app.currency_code;
     }
-    if(emv_app.track_1_equiv_len) {
-        result->track_1_equiv_len = emv_app.track_1_equiv_len;
-        memcpy(result->track_1_equiv, emv_app.track_1_equiv, emv_app.track_1_equiv_len);
-    }
-    if(emv_app.track_2_equiv_len) {
-        result->track_2_equiv_len = emv_app.track_2_equiv_len;
-        memcpy(result->track_2_equiv, emv_app.track_2_equiv, emv_app.track_2_equiv_len);
-    }
 
     if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagDebug)) {
         reader_analyzer_stop(nfc_worker->reader_analyzer);

--- a/lib/nfc/nfc_worker.c
+++ b/lib/nfc/nfc_worker.c
@@ -282,6 +282,14 @@ static bool nfc_worker_read_bank_card(NfcWorker* nfc_worker, FuriHalNfcTxRxConte
     if(emv_app.currency_code) {
         result->currency_code = emv_app.currency_code;
     }
+    if(emv_app.track_1_equiv_len) {
+        result->track_1_equiv_len = emv_app.track_1_equiv_len;
+        memcpy(result->track_1_equiv, emv_app.track_1_equiv, emv_app.track_1_equiv_len);
+    }
+    if(emv_app.track_2_equiv_len) {
+        result->track_2_equiv_len = emv_app.track_2_equiv_len;
+        memcpy(result->track_2_equiv, emv_app.track_2_equiv, emv_app.track_2_equiv_len);
+    }
 
     if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagDebug)) {
         reader_analyzer_stop(nfc_worker->reader_analyzer);

--- a/lib/nfc/protocols/emv.c
+++ b/lib/nfc/protocols/emv.c
@@ -155,6 +155,8 @@ static bool emv_decode_response(uint8_t* buff, uint16_t len, EmvApplication* app
                     if(buff[i + x + 1] > 0xD0) {
                         memcpy(app->card_number, &buff[i], x + 1);
                         app->card_number_len = x + 1;
+                        app->exp_year = (buff[i + x + 1] << 4) | (buff[i + x + 2] >> 4);
+                        app->exp_month = (buff[i + x + 2] << 4) | (buff[i + x + 3] >> 4);
                         break;
                     }
                 }

--- a/lib/nfc/protocols/emv.c
+++ b/lib/nfc/protocols/emv.c
@@ -142,14 +142,15 @@ static bool emv_decode_response(uint8_t* buff, uint16_t len, EmvApplication* app
                 success = true;
                 FURI_LOG_T(TAG, "found EMV_TAG_AFL %x (len=%d)", tag, tlen);
                 break;
-            case EMV_TAG_TRACK_1_EQUIV:
-                memcpy(app->track_1_equiv, &buff[i], tlen);
-                app->track_1_equiv[tlen] = '\0';
-                app->track_1_equiv_len = tlen;
+            case EMV_TAG_TRACK_1_EQUIV: {
+                char track_1_equiv[80];
+                memcpy(track_1_equiv, &buff[i], tlen);
+                track_1_equiv[tlen] = '\0';
                 success = true;
-                FURI_LOG_T(TAG, "found EMV_TAG_TRACK_1_EQUIV %x : %s", tag, app->track_1_equiv);
+                FURI_LOG_T(TAG, "found EMV_TAG_TRACK_1_EQUIV %x : %s", tag, track_1_equiv);
                 break;
-            case EMV_TAG_TRACK_2_EQUIV:
+            }
+            case EMV_TAG_TRACK_2_EQUIV: {
                 // 0xD0 delimits PAN from expiry (YYMM)
                 for(int x = 1; x < tlen; x++) {
                     if(buff[i + x + 1] > 0xD0) {
@@ -162,20 +163,23 @@ static bool emv_decode_response(uint8_t* buff, uint16_t len, EmvApplication* app
                 }
 
                 // Convert 4-bit to ASCII representation
+                char track_2_equiv[41];
+                uint8_t track_2_equiv_len = 0;
                 for(int x = 0; x < tlen; x++) {
                     char top = (buff[i + x] >> 4) + '0';
                     char bottom = (buff[i + x] & 0x0F) + '0';
-                    app->track_2_equiv[x * 2] = top;
-                    app->track_2_equiv_len++;
+                    track_2_equiv[x * 2] = top;
+                    track_2_equiv_len++;
                     if(top == '?') break;
-                    app->track_2_equiv[x * 2 + 1] = bottom;
-                    app->track_2_equiv_len++;
+                    track_2_equiv[x * 2 + 1] = bottom;
+                    track_2_equiv_len++;
                     if(bottom == '?') break;
                 }
-                app->track_2_equiv[app->track_2_equiv_len] = '\0';
+                track_2_equiv[track_2_equiv_len] = '\0';
                 success = true;
-                FURI_LOG_T(TAG, "found EMV_TAG_TRACK_2_EQUIV %x : %s", tag, app->track_2_equiv);
+                FURI_LOG_T(TAG, "found EMV_TAG_TRACK_2_EQUIV %x : %s", tag, track_2_equiv);
                 break;
+            }
             case EMV_TAG_PAN:
                 memcpy(app->card_number, &buff[i], tlen);
                 app->card_number_len = tlen;

--- a/lib/nfc/protocols/emv.h
+++ b/lib/nfc/protocols/emv.h
@@ -30,10 +30,6 @@ typedef struct {
     uint8_t exp_year;
     uint16_t country_code;
     uint16_t currency_code;
-    char track_1_equiv[80];
-    uint8_t track_1_equiv_len;
-    char track_2_equiv[41];
-    uint8_t track_2_equiv_len;
 } EmvData;
 
 typedef struct {
@@ -61,10 +57,6 @@ typedef struct {
     uint16_t currency_code;
     APDU pdol;
     APDU afl;
-    char track_1_equiv[80];
-    uint8_t track_1_equiv_len;
-    char track_2_equiv[41];
-    uint8_t track_2_equiv_len;
 } EmvApplication;
 
 /** Read bank card data

--- a/lib/nfc/protocols/emv.h
+++ b/lib/nfc/protocols/emv.h
@@ -11,7 +11,8 @@
 #define EMV_TAG_CARD_NAME 0x50
 #define EMV_TAG_FCI 0xBF0C
 #define EMV_TAG_LOG_CTRL 0x9F4D
-#define EMV_TAG_CARD_NUM 0x57
+#define EMV_TAG_TRACK_1_EQUIV 0x56
+#define EMV_TAG_TRACK_2_EQUIV 0x57
 #define EMV_TAG_PAN 0x5A
 #define EMV_TAG_AFL 0x94
 #define EMV_TAG_EXP_DATE 0x5F24
@@ -29,6 +30,10 @@ typedef struct {
     uint8_t exp_year;
     uint16_t country_code;
     uint16_t currency_code;
+    char track_1_equiv[80];
+    uint8_t track_1_equiv_len;
+    char track_2_equiv[41];
+    uint8_t track_2_equiv_len;
 } EmvData;
 
 typedef struct {
@@ -56,6 +61,10 @@ typedef struct {
     uint16_t currency_code;
     APDU pdol;
     APDU afl;
+    char track_1_equiv[80];
+    uint8_t track_1_equiv_len;
+    char track_2_equiv[41];
+    uint8_t track_2_equiv_len;
 } EmvApplication;
 
 /** Read bank card data


### PR DESCRIPTION
# What's new

- Expose Track 1 and Track 2 magnetic stripe equivalent data if available
  - May be handy as an input method for magspoof! (cc @zacharyweiss)
- Use track 2 as an additional source for card expiry in case `EMV_TAG_EXP_DATE` isn't supported

References:
- EMV 4.4 Book 3: Application Specification, Annex A
- https://iso8583.info/lib/MasterCard/M_Chip/4/TLVs
- https://iso8583.info/lib/VISA/VCPS/TLVs

# Verification 

- Scan a debit/credit card
- `NFC -> Read -> Info` should display Track 2 data for most EMV cards
- MasterCard's are also known to provide Track 1 data

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
