### PR TITLE
ELF-loader: wait for notification to complete on app exit

### DIFF
--- a/applications/plugins/snake_game/snake_game.c
+++ b/applications/plugins/snake_game/snake_game.c
@@ -394,8 +394,8 @@ int32_t snake_game_app(void* p) {
         release_mutex(&state_mutex, snake_state);
     }
 
-    // Wait for all notifications to be played and return backlight to normal state
-    notification_message_block(notification, &sequence_display_backlight_enforce_auto);
+    // Return backlight to normal state
+    notification_message(notification, &sequence_display_backlight_enforce_auto);
 
     furi_timer_free(timer);
     view_port_enabled_set(view_port, false);

--- a/lib/flipper_application/flipper_application.c
+++ b/lib/flipper_application/flipper_application.c
@@ -1,5 +1,6 @@
 #include "flipper_application.h"
 #include "elf/elf_file.h"
+#include <notification/notification_messages.h>
 
 #define TAG "fapp"
 
@@ -95,6 +96,15 @@ static int32_t flipper_application_thread(void* context) {
     elf_file_pre_run(last_loaded_app->elf);
     int32_t result = elf_file_run(last_loaded_app->elf, context);
     elf_file_post_run(last_loaded_app->elf);
+
+    // wait until all notifications from RAM are completed
+    NotificationApp* notifications = furi_record_open(RECORD_NOTIFICATION);
+    const NotificationSequence sequence_empty = {
+        NULL,
+    };
+    notification_message_block(notifications, &sequence_empty);
+    furi_record_close(RECORD_NOTIFICATION);
+
     return result;
 }
 


### PR DESCRIPTION
# What's new

- Wait for notification to complete on app exit
- Fixes #2313

# Verification 

- #2313

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
