### PR TITLE
Mifare Mini behavior fix

### DIFF
--- a/lib/nfc/nfc_types.c
+++ b/lib/nfc/nfc_types.c
@@ -59,6 +59,8 @@ const char* nfc_mf_classic_type(MfClassicType type) {
         return "Mifare Classic 1K";
     } else if(type == MfClassicType4k) {
         return "Mifare Classic 4K";
+    } else if(type == MfMini) {
+        return "Mifare Mini";
     } else {
         return "Mifare Classic";
     }

--- a/lib/nfc/protocols/mifare_classic.c
+++ b/lib/nfc/protocols/mifare_classic.c
@@ -17,6 +17,8 @@ const char* mf_classic_get_type_str(MfClassicType type) {
         return "MIFARE Classic 1K";
     } else if(type == MfClassicType4k) {
         return "MIFARE Classic 4K";
+    } else if(type == MfMini){
+        return "MIFARE Mini";
     } else {
         return "Unknown";
     }
@@ -77,6 +79,8 @@ uint8_t mf_classic_get_total_sectors_num(MfClassicType type) {
         return MF_CLASSIC_1K_TOTAL_SECTORS_NUM;
     } else if(type == MfClassicType4k) {
         return MF_CLASSIC_4K_TOTAL_SECTORS_NUM;
+    } else if(type == MfMini){
+        return MF_MINI_TOTAL_SECTORS_NUM;
     } else {
         return 0;
     }
@@ -87,6 +91,8 @@ uint16_t mf_classic_get_total_block_num(MfClassicType type) {
         return 64;
     } else if(type == MfClassicType4k) {
         return 256;
+    } else if(type == MfMini){
+        return 20;
     } else {
         return 0;
     }
@@ -349,12 +355,12 @@ static bool mf_classic_is_allowed_access(
 
 bool mf_classic_check_card_type(uint8_t ATQA0, uint8_t ATQA1, uint8_t SAK) {
     UNUSED(ATQA1);
-    if((ATQA0 == 0x44 || ATQA0 == 0x04) && (SAK == 0x08 || SAK == 0x88 || SAK == 0x09)) {
+    if((ATQA0 == 0x44 || ATQA0 == 0x04) && (SAK == 0x08 || SAK == 0x88 || SAK == 0x09 || SAK == 0x89)) { //MIFARE Mini; 1k
         return true;
     } else if((ATQA0 == 0x01) && (ATQA1 == 0x0F) && (SAK == 0x01)) {
         //skylanders support
         return true;
-    } else if((ATQA0 == 0x42 || ATQA0 == 0x02) && (SAK == 0x18)) {
+    } else if((ATQA0 == 0x42 || ATQA0 == 0x02) && (SAK == 0x18)) { // MIFARE 4k
         return true;
     } else {
         return false;
@@ -363,13 +369,15 @@ bool mf_classic_check_card_type(uint8_t ATQA0, uint8_t ATQA1, uint8_t SAK) {
 
 MfClassicType mf_classic_get_classic_type(int8_t ATQA0, uint8_t ATQA1, uint8_t SAK) {
     UNUSED(ATQA1);
-    if((ATQA0 == 0x44 || ATQA0 == 0x04) && (SAK == 0x08 || SAK == 0x88 || SAK == 0x09)) {
+    if((ATQA0 == 0x44 || ATQA0 == 0x04) && (SAK == 0x08 || SAK == 0x88)) {
         return MfClassicType1k;
     } else if((ATQA0 == 0x01) && (ATQA1 == 0x0F) && (SAK == 0x01)) {
         //skylanders support
         return MfClassicType1k;
     } else if((ATQA0 == 0x42 || ATQA0 == 0x02) && (SAK == 0x18)) {
         return MfClassicType4k;
+    } else if((ATQA0 == 0x04) && (SAK == 0x09 || SAK == 0x89)) { //So my only genuine MFMini returns 0x09 as info, and stores 0x89. Perhaps this could help.
+        return MfMini;
     }
     return MfClassicType1k;
 }

--- a/lib/nfc/protocols/mifare_classic.h
+++ b/lib/nfc/protocols/mifare_classic.h
@@ -8,6 +8,7 @@
 #define MF_CLASSIC_TOTAL_BLOCKS_MAX (256)
 #define MF_CLASSIC_1K_TOTAL_SECTORS_NUM (16)
 #define MF_CLASSIC_4K_TOTAL_SECTORS_NUM (40)
+#define MF_MINI_TOTAL_SECTORS_NUM (5)
 
 #define MF_CLASSIC_SECTORS_MAX (40)
 #define MF_CLASSIC_BLOCKS_IN_SECTOR_MAX (16)
@@ -20,6 +21,7 @@
 typedef enum {
     MfClassicType1k,
     MfClassicType4k,
+    MfMini,
 } MfClassicType;
 
 typedef enum {


### PR DESCRIPTION
# What's new

Flipper's behavior after identifying Mifare Mini was changed to reading only 5 sectors instead of 16 which was the case for Mifare Mini because it was defined being the same as Mifare Classic 1K. 
![image](https://user-images.githubusercontent.com/63470411/214621542-dc6793d2-1ebd-40e8-84c2-5e3f45c9f86c.png)

Some comments have been added

# Verification 

1. Attempt reading an NFC tag with SAK: 0x09 ATQA: 0x0004. Flipper will read only 5 sectors.
![20230125_175406](https://user-images.githubusercontent.com/63470411/214621118-885da005-f493-4e2d-a66c-8bc015485cd7.jpg)

Extra tag info is below 
![image](https://user-images.githubusercontent.com/63470411/214627126-f755b57c-4ed2-4501-8b8c-ac5ecc1f6c02.png)

# Checklist (For Reviewer)

- [Y] PR has description of feature/bug or link to Confluence/Jira task
- [Y] Description contains actions to verify feature/bugfix
- [Y] I've built this code, uploaded it to the device and verified feature/bugfix
