### PR TITLE
nfc: Fix crash when using debug PCAP trace

### DIFF
--- a/lib/nfc/helpers/reader_analyzer.c
+++ b/lib/nfc/helpers/reader_analyzer.c
@@ -159,6 +159,7 @@ void reader_analyzer_stop(ReaderAnalyzer* instance) {
     }
     if(instance->pcap) {
         nfc_debug_pcap_free(instance->pcap);
+        instance->pcap = NULL;
     }
 }
 


### PR DESCRIPTION
# What's new

I was experimenting with the PCAP trace feature when debugging some reader communication problems and discovered that it causes the NFC app to crash on exit when used. This PR fixes that.

# Verification 

- Enable the debug PCAP feature 
  - this has to be done by modifying the code, since the format was changed to the text one in 1853359d78f11428d48290cef89edb7c4558f372 and there is no other way to enable pcap variant
  - replace `ReaderAnalyzerModeDebugLog` with `ReaderAnalyzerModeDebugPcap` in `nfc_worker.c`
- Run any operation that captures the trace, e.g. read a card
- Exit the NFC app
- The app should no longer crash

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
