### PR TITLE
Furi: getter for current thread stdout write callback

### DIFF
--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,11.8,,
+Version,+,11.9,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,
@@ -1389,8 +1389,8 @@ Function,+,furi_hal_version_uid_size,size_t,
 Function,-,furi_hal_vibro_init,void,
 Function,+,furi_hal_vibro_on,void,_Bool
 Function,-,furi_init,void,
-Function,+,furi_kernel_is_irq_or_masked,_Bool,
 Function,+,furi_kernel_get_tick_frequency,uint32_t,
+Function,+,furi_kernel_is_irq_or_masked,_Bool,
 Function,+,furi_kernel_lock,int32_t,
 Function,+,furi_kernel_restore_lock,int32_t,int32_t
 Function,+,furi_kernel_unlock,int32_t,
@@ -1515,6 +1515,7 @@ Function,+,furi_thread_get_name,const char*,FuriThreadId
 Function,+,furi_thread_get_return_code,int32_t,FuriThread*
 Function,+,furi_thread_get_stack_space,uint32_t,FuriThreadId
 Function,+,furi_thread_get_state,FuriThreadState,FuriThread*
+Function,+,furi_thread_get_stdout_callback,FuriThreadStdoutWriteCallback,
 Function,+,furi_thread_is_suspended,_Bool,FuriThreadId
 Function,+,furi_thread_join,_Bool,FuriThread*
 Function,+,furi_thread_mark_as_service,void,FuriThread*

--- a/furi/core/thread.c
+++ b/furi/core/thread.c
@@ -530,6 +530,12 @@ bool furi_thread_set_stdout_callback(FuriThreadStdoutWriteCallback callback) {
     return true;
 }
 
+FuriThreadStdoutWriteCallback furi_thread_get_stdout_callback() {
+    FuriThread* thread = furi_thread_get_current();
+
+    return thread->output.write_callback;
+}
+
 size_t furi_thread_stdout_write(const char* data, size_t size) {
     FuriThread* thread = furi_thread_get_current();
 

--- a/furi/core/thread.h
+++ b/furi/core/thread.h
@@ -227,6 +227,12 @@ const char* furi_thread_get_name(FuriThreadId thread_id);
 
 uint32_t furi_thread_get_stack_space(FuriThreadId thread_id);
 
+/** Get STDOUT callback for thead
+ *
+ * @return STDOUT callback
+ */
+FuriThreadStdoutWriteCallback furi_thread_get_stdout_callback();
+
 /** Set STDOUT callback for thread
  * 
  * @param      callback  callback or NULL to clear


### PR DESCRIPTION
# What's new

Added a getter for the current thread stdout callback

# Verification 

Try to get the current callback in an app.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
