### PR TITLE
crypto: Erase key from RAM after storing into enclave

### DIFF
--- a/applications/services/crypto/crypto_cli.c
+++ b/applications/services/crypto/crypto_cli.c
@@ -276,6 +276,7 @@ void crypto_cli_store_key(Cli* cli, FuriString* args) {
         }
     } while(0);
 
+    explicit_bzero(data, sizeof(data));
     furi_string_free(key_type);
 }
 

--- a/firmware/targets/f7/furi_hal/furi_hal_crypto.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_crypto.c
@@ -80,9 +80,11 @@ static bool furi_hal_crypto_generate_unique_keys(uint8_t start_slot, uint8_t end
         key.data = key_data;
         furi_hal_random_fill_buf(key_data, 32);
         if(!furi_hal_crypto_store_add_key(&key, &slot)) {
+            explicit_bzero(key_data, sizeof(key_data));
             FURI_LOG_E(TAG, "Error writing key to slot %u", slot);
             return false;
         }
+        explicit_bzero(key_data, sizeof(key_data));
     }
     return true;
 }
@@ -176,6 +178,7 @@ bool furi_hal_crypto_store_add_key(FuriHalCryptoKey* key, uint8_t* slot) {
     memcpy(pParam.KeyData, key->data, key_data_size);
 
     SHCI_CmdStatus_t shci_state = SHCI_C2_FUS_StoreUsrKey(&pParam, slot);
+    explicit_bzero(&pParam, sizeof(pParam));
     furi_check(furi_mutex_release(furi_hal_crypto_mutex) == FuriStatusOk);
     return (shci_state == SHCI_Success);
 }


### PR DESCRIPTION
When storing a new unique secret key in the secure enclave, it is temporarily stored in a stack buffer accessible by CPU1. Since it is a secret key, it should not be kept in memory as it could be leaked.

This commit calls the `explicit_bzero()` function from the libc to ensure that the buffer containing the key is cleared. Unlike with `bzero()` and `memset()`, the compiler won't optimize away calls to `explicit_bzero()`.

# What's new

- This commit ensures that the buffer containing the secret key is cleared after use.

# Verification 

- In furi_hal_crypto_store_add_key() comment out the call to `SHCI_C2_FUS_StoreUsrKey()` and return `SHCI_Success` instead, so you do not perform unwanted permanent modification to the enclave slots.
- Add `FURI_LOG_I()` calls to dump the contents of the key buffer after the calls to `explicit_bzero()`.
- Create an external FAP which calls `furi_hal_crypto_store_add_key()` and `furi_hal_crypto_verify_key()`
- Flash the new firmware
- Run the `log` command on the serial console to display the log messages
- Run the test FAP
- Ensure that the keys buffers dumped in the logs are all 0's.
- To double-check, comment the calls to `explicit_bzero()`, rebuild and flash the firmware, and notice that the key buffer content is not all 0's.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
