### PR TITLE
[FL-3085] Fix PAC/Stanley protocol name

### DIFF
--- a/documentation/file_formats/LfRfidFileFormat.md
+++ b/documentation/file_formats/LfRfidFileFormat.md
@@ -44,6 +44,6 @@ The file stores a single RFID key of the type defined by the `Key type` paramete
 | Viking      | Viking            |
 | Jablotron   | Jablotron         |
 | Paradox     | Paradox           |
-| PAC/Stanley | PAC/Stanley       |
+| PAC         | PAC/Stanley       |
 | Keri        | Keri              |
 | Gallagher   | Gallagher         |

--- a/lib/lfrfid/protocols/protocol_pac_stanley.c
+++ b/lib/lfrfid/protocols/protocol_pac_stanley.c
@@ -207,8 +207,8 @@ void protocol_pac_stanley_render_data(ProtocolPACStanley* protocol, FuriString* 
 }
 
 const ProtocolBase protocol_pac_stanley = {
-    .name = "PAC/Stanley",
-    .manufacturer = "N/A",
+    .name = "PAC",
+    .manufacturer = "Stanley",
     .data_size = PAC_STANLEY_DECODED_DATA_SIZE,
     .features = LFRFIDFeatureASK,
     .validate_count = 3,


### PR DESCRIPTION
# What's new

- Rename "PAC/Stanley" to the correct "PAC by Stanley" form.

# Verification 

- Read through the changeset

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
