### PR TITLE
Fixed typo in nfc_magic_scene_wrong_card.c

### DIFF
--- a/applications/plugins/nfc_magic/scenes/nfc_magic_scene_wrong_card.c
+++ b/applications/plugins/nfc_magic/scenes/nfc_magic_scene_wrong_card.c
@@ -26,7 +26,7 @@ void nfc_magic_scene_wrong_card_on_enter(void* context) {
         AlignLeft,
         AlignTop,
         FontSecondary,
-        "Writing is supported\nonly for 4 bytes UID\nMifare CLassic 1k");
+        "Writing is supported\nonly for 4 bytes UID\nMifare Classic 1k");
     widget_add_button_element(
         widget, GuiButtonTypeLeft, "Retry", nfc_magic_scene_wrong_card_widget_callback, nfc_magic);
 


### PR DESCRIPTION
# What's new

- Fixed a small typo, where `Classic` was spelled `CLassic`.

# Verification 

- Check [nfc_magic_scene_wrong_card.c](https://github.com/flipperdevices/flipperzero-firmware/compare/dev...Pierce01:flipperzero-firmware:dev#diff-e4407bb398f30f1f6dc65900147ef580b893d04c4bf1350d7ce7ce625d74b0e3)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
