### PR TITLE
Updater visual fixes

### DIFF
--- a/applications/system/updater/scenes/updater_scene_error.c
+++ b/applications/system/updater/scenes/updater_scene_error.c
@@ -58,8 +58,12 @@ bool updater_scene_error_on_event(void* context, SceneManagerEvent event) {
 }
 
 void updater_scene_error_on_exit(void* context) {
+    furi_assert(context);
     Updater* updater = (Updater*)context;
 
     widget_reset(updater->widget);
-    free(updater->pending_update);
+
+    if(updater->loaded_manifest) {
+        update_manifest_free(updater->loaded_manifest);
+    }
 }

--- a/applications/system/updater/scenes/updater_scene_loadcfg.c
+++ b/applications/system/updater/scenes/updater_scene_loadcfg.c
@@ -99,7 +99,6 @@ void updater_scene_loadcfg_on_exit(void* context) {
 
     if(updater->pending_update) {
         update_manifest_free(updater->pending_update->manifest);
-        furi_string_free(updater->pending_update->message);
     }
 
     widget_reset(updater->widget);

--- a/applications/system/updater/scenes/updater_scene_loadcfg.c
+++ b/applications/system/updater/scenes/updater_scene_loadcfg.c
@@ -21,11 +21,9 @@ void updater_scene_loadcfg_apply_callback(GuiButtonType result, InputType type, 
 
 void updater_scene_loadcfg_on_enter(void* context) {
     Updater* updater = (Updater*)context;
-    UpdaterManifestProcessingState* pending_upd = updater->pending_update =
-        malloc(sizeof(UpdaterManifestProcessingState));
-    pending_upd->manifest = update_manifest_alloc();
+    UpdateManifest* loaded_manifest = updater->loaded_manifest = update_manifest_alloc();
 
-    if(update_manifest_init(pending_upd->manifest, furi_string_get_cstr(updater->startup_arg))) {
+    if(update_manifest_init(loaded_manifest, furi_string_get_cstr(updater->startup_arg))) {
         widget_add_string_element(
             updater->widget, 64, 12, AlignCenter, AlignCenter, FontPrimary, "Update");
 
@@ -37,7 +35,7 @@ void updater_scene_loadcfg_on_enter(void* context) {
             32,
             AlignCenter,
             AlignCenter,
-            furi_string_get_cstr(pending_upd->manifest->version),
+            furi_string_get_cstr(loaded_manifest->version),
             true);
 
         widget_add_button_element(
@@ -95,12 +93,12 @@ bool updater_scene_loadcfg_on_event(void* context, SceneManagerEvent event) {
 }
 
 void updater_scene_loadcfg_on_exit(void* context) {
+    furi_assert(context);
     Updater* updater = (Updater*)context;
 
-    if(updater->pending_update) {
-        update_manifest_free(updater->pending_update->manifest);
-    }
-
     widget_reset(updater->widget);
-    free(updater->pending_update);
+
+    if(updater->loaded_manifest) {
+        update_manifest_free(updater->loaded_manifest);
+    }
 }

--- a/applications/system/updater/updater_i.h
+++ b/applications/system/updater/updater_i.h
@@ -33,11 +33,6 @@ typedef enum {
     UpdaterCustomEventSdUnmounted,
 } UpdaterCustomEvent;
 
-typedef struct UpdaterManifestProcessingState {
-    UpdateManifest* manifest;
-    bool ready_to_be_applied;
-} UpdaterManifestProcessingState;
-
 typedef struct {
     // GUI
     Gui* gui;
@@ -48,7 +43,7 @@ typedef struct {
 
     UpdaterMainView* main_view;
 
-    UpdaterManifestProcessingState* pending_update;
+    UpdateManifest* loaded_manifest;
     UpdatePrepareResult preparation_result;
 
     UpdateTask* update_task;

--- a/applications/system/updater/updater_i.h
+++ b/applications/system/updater/updater_i.h
@@ -35,7 +35,6 @@ typedef enum {
 
 typedef struct UpdaterManifestProcessingState {
     UpdateManifest* manifest;
-    FuriString* message;
     bool ready_to_be_applied;
 } UpdaterManifestProcessingState;
 

--- a/applications/system/updater/util/update_task.c
+++ b/applications/system/updater/util/update_task.c
@@ -41,22 +41,22 @@ typedef struct {
 static const UpdateTaskStageGroupMap update_task_stage_progress[] = {
     [UpdateTaskStageProgress] = STAGE_DEF(UpdateTaskStageGroupMisc, 0),
 
-    [UpdateTaskStageReadManifest] = STAGE_DEF(UpdateTaskStageGroupPreUpdate, 5),
-    [UpdateTaskStageLfsBackup] = STAGE_DEF(UpdateTaskStageGroupPreUpdate, 15),
+    [UpdateTaskStageReadManifest] = STAGE_DEF(UpdateTaskStageGroupPreUpdate, 45),
+    [UpdateTaskStageLfsBackup] = STAGE_DEF(UpdateTaskStageGroupPreUpdate, 5),
 
     [UpdateTaskStageRadioImageValidate] = STAGE_DEF(UpdateTaskStageGroupRadio, 15),
-    [UpdateTaskStageRadioErase] = STAGE_DEF(UpdateTaskStageGroupRadio, 60),
-    [UpdateTaskStageRadioWrite] = STAGE_DEF(UpdateTaskStageGroupRadio, 80),
-    [UpdateTaskStageRadioInstall] = STAGE_DEF(UpdateTaskStageGroupRadio, 60),
-    [UpdateTaskStageRadioBusy] = STAGE_DEF(UpdateTaskStageGroupRadio, 80),
+    [UpdateTaskStageRadioErase] = STAGE_DEF(UpdateTaskStageGroupRadio, 35),
+    [UpdateTaskStageRadioWrite] = STAGE_DEF(UpdateTaskStageGroupRadio, 60),
+    [UpdateTaskStageRadioInstall] = STAGE_DEF(UpdateTaskStageGroupRadio, 30),
+    [UpdateTaskStageRadioBusy] = STAGE_DEF(UpdateTaskStageGroupRadio, 5),
 
-    [UpdateTaskStageOBValidation] = STAGE_DEF(UpdateTaskStageGroupOptionBytes, 10),
+    [UpdateTaskStageOBValidation] = STAGE_DEF(UpdateTaskStageGroupOptionBytes, 2),
 
-    [UpdateTaskStageValidateDFUImage] = STAGE_DEF(UpdateTaskStageGroupFirmware, 50),
-    [UpdateTaskStageFlashWrite] = STAGE_DEF(UpdateTaskStageGroupFirmware, 200),
-    [UpdateTaskStageFlashValidate] = STAGE_DEF(UpdateTaskStageGroupFirmware, 30),
+    [UpdateTaskStageValidateDFUImage] = STAGE_DEF(UpdateTaskStageGroupFirmware, 30),
+    [UpdateTaskStageFlashWrite] = STAGE_DEF(UpdateTaskStageGroupFirmware, 150),
+    [UpdateTaskStageFlashValidate] = STAGE_DEF(UpdateTaskStageGroupFirmware, 15),
 
-    [UpdateTaskStageLfsRestore] = STAGE_DEF(UpdateTaskStageGroupPostUpdate, 30),
+    [UpdateTaskStageLfsRestore] = STAGE_DEF(UpdateTaskStageGroupPostUpdate, 5),
 
     [UpdateTaskStageResourcesUpdate] = STAGE_DEF(UpdateTaskStageGroupResources, 255),
     [UpdateTaskStageSplashscreenInstall] = STAGE_DEF(UpdateTaskStageGroupSplashscreen, 5),

--- a/lib/toolbox/tar/tar_archive.c
+++ b/lib/toolbox/tar/tar_archive.c
@@ -106,6 +106,7 @@ void tar_archive_set_file_callback(TarArchive* archive, tar_unpack_file_cb callb
 static int tar_archive_entry_counter(mtar_t* tar, const mtar_header_t* header, void* param) {
     UNUSED(tar);
     UNUSED(header);
+    furi_assert(param);
     int32_t* counter = param;
     (*counter)++;
     return 0;

--- a/scripts/fbt_tools/pvsstudio.py
+++ b/scripts/fbt_tools/pvsstudio.py
@@ -1,6 +1,6 @@
 from SCons.Builder import Builder
 from SCons.Action import Action
-from SCons.Script import Delete, Mkdir, GetBuildFailures
+from SCons.Script import Delete, Mkdir, GetBuildFailures, Flatten
 import multiprocessing
 import webbrowser
 import atexit
@@ -30,13 +30,14 @@ def atexist_handler():
         return
 
     for bf in GetBuildFailures():
-        if bf.node.exists and bf.node.name.endswith(".html"):
-            # macOS
-            if sys.platform == "darwin":
-                subprocess.run(["open", bf.node.abspath])
-            else:
-                webbrowser.open(bf.node.abspath)
-            break
+        for node in Flatten(bf.node):
+            if node.exists and node.name.endswith(".html"):
+                # macOS
+                if sys.platform == "darwin":
+                    subprocess.run(["open", node.abspath])
+                else:
+                    webbrowser.open(node.abspath)
+                break
 
 
 def generate(env):


### PR DESCRIPTION
# What's new

- fixed progress visuals & their consistency during update
- removed obsolete code in updater and simplified its internal pre-update state
- fixed error handling in fbt

# Verification 

- run `fbt TARGET_HW=18 flash_usb` on f7 target
- check that it displays error in CLI
- open `pcbundle` folder in Flipper archive, check that is displays the same error when trying to install 

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
