### PR TITLE
[FL-3113] BadUSB: disable CDC mode, USB mode switch fix

### DIFF
--- a/applications/main/bad_usb/bad_usb_app.c
+++ b/applications/main/bad_usb/bad_usb_app.c
@@ -115,8 +115,12 @@ BadUsbApp* bad_usb_app_alloc(char* arg) {
 
     if(furi_hal_usb_is_locked()) {
         app->error = BadUsbAppErrorCloseRpc;
+        app->usb_if_prev = NULL;
         scene_manager_next_scene(app->scene_manager, BadUsbSceneError);
     } else {
+        app->usb_if_prev = furi_hal_usb_get_config();
+        furi_check(furi_hal_usb_set_config(NULL, NULL));
+
         if(!furi_string_empty(app->file_path)) {
             app->bad_usb_script = bad_usb_script_open(app->file_path);
             bad_usb_script_set_keyboard_layout(app->bad_usb_script, app->keyboard_layout);
@@ -136,6 +140,10 @@ void bad_usb_app_free(BadUsbApp* app) {
     if(app->bad_usb_script) {
         bad_usb_script_close(app->bad_usb_script);
         app->bad_usb_script = NULL;
+    }
+
+    if(app->usb_if_prev) {
+        furi_check(furi_hal_usb_set_config(app->usb_if_prev, NULL));
     }
 
     // Views

--- a/applications/main/bad_usb/bad_usb_app_i.h
+++ b/applications/main/bad_usb/bad_usb_app_i.h
@@ -14,6 +14,7 @@
 #include <gui/modules/variable_item_list.h>
 #include <gui/modules/widget.h>
 #include "views/bad_usb_view.h"
+#include <furi_hal_usb.h>
 
 #define BAD_USB_APP_BASE_FOLDER ANY_PATH("badusb")
 #define BAD_USB_APP_PATH_LAYOUT_FOLDER BAD_USB_APP_BASE_FOLDER "/assets/layouts"
@@ -39,6 +40,8 @@ struct BadUsbApp {
     FuriString* keyboard_layout;
     BadUsb* bad_usb_view;
     BadUsbScript* bad_usb_script;
+
+    FuriHalUsbInterface* usb_if_prev;
 };
 
 typedef enum {

--- a/applications/main/bad_usb/bad_usb_script.c
+++ b/applications/main/bad_usb/bad_usb_script.c
@@ -490,8 +490,6 @@ static int32_t bad_usb_worker(void* context) {
     BadUsbWorkerState worker_state = BadUsbStateInit;
     int32_t delay_val = 0;
 
-    FuriHalUsbInterface* usb_mode_prev = furi_hal_usb_get_config();
-
     FURI_LOG_I(WORKER_TAG, "Init");
     File* script_file = storage_file_alloc(furi_record_open(RECORD_STORAGE));
     bad_usb->line = furi_string_alloc();
@@ -641,8 +639,6 @@ static int32_t bad_usb_worker(void* context) {
     }
 
     furi_hal_hid_set_state_callback(NULL, NULL);
-
-    furi_hal_usb_set_config(usb_mode_prev, NULL);
 
     storage_file_close(script_file);
     storage_file_free(script_file);

--- a/firmware/targets/f7/furi_hal/furi_hal_usb.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_usb.c
@@ -340,7 +340,7 @@ static void usb_process_mode_start(FuriHalUsbInterface* interface, void* context
 }
 
 static void usb_process_mode_change(FuriHalUsbInterface* interface, void* context) {
-    if(interface != usb.interface) {
+    if((interface != usb.interface) || (context != usb.interface_context)) {
         if(usb.enabled) {
             // Disable current interface
             susp_evt(&udev, 0, 0);


### PR DESCRIPTION
# What's new

- USB CDC is disabled in BadUSB app to avoid USB mode switch lock if companion app is connected
- furi_hal_usb: Allowing USB mode switch if init_context is different

# Verification 

- Check BadUSB app with running qFlipper

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
