### PR TITLE
IR Universal Audio Remote: Add Grundig CMS 5000

### DIFF
--- a/assets/resources/infrared/assets/audio.ir
+++ b/assets/resources/infrared/assets/audio.ir
@@ -285,3 +285,46 @@ type: parsed
 protocol: NECext
 address: 10 E7 00 00
 command: 41 BE 00 00
+# 
+# Model: Grundig CMS 5000
+name: Power
+type: parsed
+protocol: NECext
+address: 30 FC 00 00
+command: 10 EF 00 00
+# Also Pause
+name: Play
+type: parsed
+protocol: NECext
+address: 30 FC 00 00
+command: 02 FD 00 00
+#
+name: Vol_up
+type: parsed
+protocol: NECext
+address: 30 FC 00 00
+command: 0D F2 00 00
+# 
+name: Vol_dn
+type: parsed
+protocol: NECext
+address: 30 FC 00 00
+command: 17 E8 00 00
+#
+name: Next
+type: parsed
+protocol: NECext
+address: 30 FC 00 00
+command: 13 EC 00 00
+# 
+name: Prev
+type: parsed
+protocol: NECext
+address: 30 FC 00 00
+command: 11 EE 00 00
+# 
+name: Mute
+type: parsed
+protocol: NECext
+address: 30 FC 00 00
+command: 0C F3 00 00


### PR DESCRIPTION
# What's new

- Add Grundig CMS 5000 to Infrared Universal Audio Remote. The 'Play' button doubles as 'Pause' button.
- The 'Pause' button is unused.
- Issue: 'Prev' button rewinds to start of title, to skip to previous title two consecutive button presses in a short time are required, however the timing is not satisfied.

# Verification 

- Load the file onto a Flipper Zero and use the Infrared Universal Audio Remote on a Grundig CMS 5000 as intended.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
