### PR TITLE
Delete rwfiletest.bin on exit SDcard benchmark

### DIFF
--- a/applications/settings/storage_settings/scenes/storage_settings_scene_benchmark.c
+++ b/applications/settings/storage_settings/scenes/storage_settings_scene_benchmark.c
@@ -157,6 +157,7 @@ void storage_settings_scene_benchmark_on_exit(void* context) {
     StorageSettings* app = context;
     DialogEx* dialog_ex = app->dialog_ex;
 
+    storage_common_remove(app->fs_api, BENCH_FILE);
     dialog_ex_reset(dialog_ex);
 
     furi_string_reset(app->text_string);

--- a/applications/settings/storage_settings/scenes/storage_settings_scene_benchmark.c
+++ b/applications/settings/storage_settings/scenes/storage_settings_scene_benchmark.c
@@ -103,6 +103,9 @@ static void storage_settings_scene_benchmark(StorageSettings* app) {
             break;
 
         furi_string_cat_printf(app->text_string, "R %luK", bench_r_speed[i]);
+
+        storage_common_remove(app->fs_api, BENCH_FILE);
+
         dialog_ex_set_text(
             dialog_ex, furi_string_get_cstr(app->text_string), 0, 32, AlignLeft, AlignCenter);
     }
@@ -157,7 +160,6 @@ void storage_settings_scene_benchmark_on_exit(void* context) {
     StorageSettings* app = context;
     DialogEx* dialog_ex = app->dialog_ex;
 
-    storage_common_remove(app->fs_api, BENCH_FILE);
     dialog_ex_reset(dialog_ex);
 
     furi_string_reset(app->text_string);


### PR DESCRIPTION
Delete rwfiletest.bin on exit SDcard benchmark

# What's new

Delete rwfiletest.bin on exit SDcard benchmark

# Verification 

Run benchmark and check ext dir

# Checklist (For Reviewer)

- [v] PR has description of feature/bug or link to Confluence/Jira task
- [v] Description contains actions to verify feature/bugfix
- [v] I've built this code, uploaded it to the device and verified feature/bugfix
