### PR TITLE
Updater: handle storage errors when removing files, fix folder remove routine, prevent unused services from starting

### DIFF
--- a/applications/services/bt/bt_service/bt.c
+++ b/applications/services/bt/bt_service/bt.c
@@ -373,7 +373,7 @@ int32_t bt_srv(void* p) {
     Bt* bt = bt_alloc();
 
     if(furi_hal_rtc_get_boot_mode() != FuriHalRtcBootModeNormal) {
-        FURI_LOG_W(TAG, "Skipped BT init: device in special startup mode");
+        FURI_LOG_W(TAG, "Skipping start in special boot mode");
         ble_glue_wait_for_c2_start(FURI_HAL_BT_C2_START_TIMEOUT);
         furi_record_create(RECORD_BT, bt);
         return 0;

--- a/applications/services/cli/cli.c
+++ b/applications/services/cli/cli.c
@@ -461,7 +461,7 @@ int32_t cli_srv(void* p) {
     if(furi_hal_rtc_get_boot_mode() == FuriHalRtcBootModeNormal) {
         cli_session_open(cli, &cli_vcp);
     } else {
-        FURI_LOG_W(TAG, "Skipped CLI session open: device in special startup mode");
+        FURI_LOG_W(TAG, "Skipping start in special boot mode");
     }
 
     while(1) {

--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -321,6 +321,12 @@ static bool desktop_check_file_flag(const char* flag_path) {
 
 int32_t desktop_srv(void* p) {
     UNUSED(p);
+
+    FuriHalRtcBootMode mode = furi_hal_rtc_get_boot_mode();
+    if((mode == FuriHalRtcBootModePreUpdate) || (mode == FuriHalRtcBootModePostUpdate)) {
+        return 0;
+    }
+
     Desktop* desktop = desktop_alloc();
 
     bool loaded = DESKTOP_SETTINGS_LOAD(&desktop->settings);

--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -17,6 +17,8 @@
 #include "helpers/pin_lock.h"
 #include "helpers/slideshow_filename.h"
 
+#define TAG "Desktop"
+
 static void desktop_auto_lock_arm(Desktop*);
 static void desktop_auto_lock_inhibit(Desktop*);
 static void desktop_start_auto_lock_timer(Desktop*);

--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -322,8 +322,8 @@ static bool desktop_check_file_flag(const char* flag_path) {
 int32_t desktop_srv(void* p) {
     UNUSED(p);
 
-    FuriHalRtcBootMode mode = furi_hal_rtc_get_boot_mode();
-    if((mode == FuriHalRtcBootModePreUpdate) || (mode == FuriHalRtcBootModePostUpdate)) {
+    if(furi_hal_rtc_get_boot_mode() != FuriHalRtcBootModeNormal) {
+        FURI_LOG_W(TAG, "Skipping start in special boot mode");
         return 0;
     }
 

--- a/applications/services/dolphin/dolphin.c
+++ b/applications/services/dolphin/dolphin.c
@@ -154,6 +154,12 @@ static void dolphin_update_clear_limits_timer_period(Dolphin* dolphin) {
 
 int32_t dolphin_srv(void* p) {
     UNUSED(p);
+
+    FuriHalRtcBootMode mode = furi_hal_rtc_get_boot_mode();
+    if((mode == FuriHalRtcBootModePreUpdate) || (mode == FuriHalRtcBootModePostUpdate)) {
+        return 0;
+    }
+
     Dolphin* dolphin = dolphin_alloc();
     furi_record_create(RECORD_DOLPHIN, dolphin);
 

--- a/applications/services/dolphin/dolphin.c
+++ b/applications/services/dolphin/dolphin.c
@@ -155,8 +155,8 @@ static void dolphin_update_clear_limits_timer_period(Dolphin* dolphin) {
 int32_t dolphin_srv(void* p) {
     UNUSED(p);
 
-    FuriHalRtcBootMode mode = furi_hal_rtc_get_boot_mode();
-    if((mode == FuriHalRtcBootModePreUpdate) || (mode == FuriHalRtcBootModePostUpdate)) {
+    if(furi_hal_rtc_get_boot_mode() != FuriHalRtcBootModeNormal) {
+        FURI_LOG_W(TAG, "Skipping start in special boot mode");
         return 0;
     }
 

--- a/applications/services/power/power_service/power.c
+++ b/applications/services/power/power_service/power.c
@@ -218,8 +218,8 @@ static void power_check_battery_level_change(Power* power) {
 int32_t power_srv(void* p) {
     UNUSED(p);
 
-    FuriHalRtcBootMode mode = furi_hal_rtc_get_boot_mode();
-    if((mode == FuriHalRtcBootModePreUpdate) || (mode == FuriHalRtcBootModePostUpdate)) {
+    if(furi_hal_rtc_get_boot_mode() != FuriHalRtcBootModeNormal) {
+        FURI_LOG_W(TAG, "Skipping start in special boot mode");
         return 0;
     }
 

--- a/applications/services/power/power_service/power.c
+++ b/applications/services/power/power_service/power.c
@@ -217,6 +217,12 @@ static void power_check_battery_level_change(Power* power) {
 
 int32_t power_srv(void* p) {
     UNUSED(p);
+
+    FuriHalRtcBootMode mode = furi_hal_rtc_get_boot_mode();
+    if((mode == FuriHalRtcBootModePreUpdate) || (mode == FuriHalRtcBootModePostUpdate)) {
+        return 0;
+    }
+
     Power* power = power_alloc();
     power_update_info(power);
     furi_record_create(RECORD_POWER, power);

--- a/applications/services/power/power_service/power.c
+++ b/applications/services/power/power_service/power.c
@@ -4,6 +4,7 @@
 #include <furi_hal.h>
 
 #define POWER_OFF_TIMEOUT 90
+#define TAG "Power"
 
 void power_draw_battery_callback(Canvas* canvas, void* context) {
     furi_assert(context);

--- a/applications/system/updater/util/update_task_worker_backup.c
+++ b/applications/system/updater/util/update_task_worker_backup.c
@@ -102,7 +102,10 @@ static void update_task_cleanup_resources(UpdateTask* update_task, const uint32_
                     storage_common_remove(update_task->storage, furi_string_get_cstr(file_path));
                 if(result != FSE_OK && result != FSE_EXIST) {
                     FURI_LOG_E(
-                        TAG, "%s remove failed, cause %u", furi_string_get_cstr(file_path), result);
+                        TAG,
+                        "%s remove failed, cause %s",
+                        furi_string_get_cstr(file_path),
+                        storage_error_get_desc(result));
                 }
                 furi_string_free(file_path);
             } else if(entry_ptr->type == ResourceManifestEntryTypeDirectory) {
@@ -122,7 +125,6 @@ static void update_task_cleanup_resources(UpdateTask* update_task, const uint32_
                             n_dir_entries);
 
                 FuriString* folder_path = furi_string_alloc();
-                File* folder_file = storage_file_alloc(update_task->storage);
 
                 do {
                     path_concat(
@@ -131,32 +133,19 @@ static void update_task_cleanup_resources(UpdateTask* update_task, const uint32_
                         folder_path);
 
                     FURI_LOG_D(TAG, "Removing folder %s", furi_string_get_cstr(folder_path));
-                    if(!storage_dir_open(folder_file, furi_string_get_cstr(folder_path))) {
-                        FURI_LOG_W(
-                            TAG,
-                            "%s can't be opened, skipping",
-                            furi_string_get_cstr(folder_path));
-                        break;
-                    }
-
-                    if(storage_dir_read(folder_file, NULL, NULL, 0)) {
-                        FURI_LOG_I(
-                            TAG, "%s is not empty, skipping", furi_string_get_cstr(folder_path));
-                        break;
-                    }
-
                     FS_Error result = storage_common_remove(
                         update_task->storage, furi_string_get_cstr(folder_path));
                     if(result != FSE_OK && result != FSE_EXIST) {
+                        FS_Error result = storage_common_remove(
+                            update_task->storage, furi_string_get_cstr(folder_path));
                         FURI_LOG_E(
                             TAG,
-                            "%s remove failed, cause %u",
+                            "%s remove failed, cause %s",
                             furi_string_get_cstr(folder_path),
-                            result);
+                            storage_error_get_desc(result));
                     }
                 } while(false);
 
-                storage_file_free(folder_file);
                 furi_string_free(folder_path);
             }
         }

--- a/applications/system/updater/util/update_task_worker_backup.c
+++ b/applications/system/updater/util/update_task_worker_backup.c
@@ -136,8 +136,6 @@ static void update_task_cleanup_resources(UpdateTask* update_task, const uint32_
                     FS_Error result = storage_common_remove(
                         update_task->storage, furi_string_get_cstr(folder_path));
                     if(result != FSE_OK && result != FSE_EXIST) {
-                        FS_Error result = storage_common_remove(
-                            update_task->storage, furi_string_get_cstr(folder_path));
                         FURI_LOG_E(
                             TAG,
                             "%s remove failed, cause %s",

--- a/applications/system/updater/util/update_task_worker_backup.c
+++ b/applications/system/updater/util/update_task_worker_backup.c
@@ -97,7 +97,13 @@ static void update_task_cleanup_resources(UpdateTask* update_task, const uint32_
                 path_concat(
                     STORAGE_EXT_PATH_PREFIX, furi_string_get_cstr(entry_ptr->name), file_path);
                 FURI_LOG_D(TAG, "Removing %s", furi_string_get_cstr(file_path));
-                storage_simply_remove(update_task->storage, furi_string_get_cstr(file_path));
+
+                FS_Error result =
+                    storage_common_remove(update_task->storage, furi_string_get_cstr(file_path));
+                if(result != FSE_OK && result != FSE_EXIST) {
+                    FURI_LOG_E(
+                        TAG, "%s remove failed, cause %u", furi_string_get_cstr(file_path), result);
+                }
                 furi_string_free(file_path);
             } else if(entry_ptr->type == ResourceManifestEntryTypeDirectory) {
                 n_dir_entries++;
@@ -139,7 +145,15 @@ static void update_task_cleanup_resources(UpdateTask* update_task, const uint32_
                         break;
                     }
 
-                    storage_simply_remove(update_task->storage, furi_string_get_cstr(folder_path));
+                    FS_Error result = storage_common_remove(
+                        update_task->storage, furi_string_get_cstr(folder_path));
+                    if(result != FSE_OK && result != FSE_EXIST) {
+                        FURI_LOG_E(
+                            TAG,
+                            "%s remove failed, cause %u",
+                            furi_string_get_cstr(folder_path),
+                            result);
+                    }
                 } while(false);
 
                 storage_file_free(folder_file);

--- a/furi/core/thread.c
+++ b/furi/core/thread.c
@@ -96,9 +96,9 @@ static void furi_thread_body(void* context) {
     furi_assert(thread->state == FuriThreadStateRunning);
 
     if(thread->is_service) {
-        FURI_LOG_E(
+        FURI_LOG_W(
             TAG,
-            "%s service thread exited. Thread memory cannot be reclaimed.",
+            "%s service thread TCB memory will not be reclaimed",
             thread->name ? thread->name : "<unknown service>");
     }
 

--- a/furi/flipper.c
+++ b/furi/flipper.c
@@ -3,6 +3,7 @@
 #include <furi.h>
 #include <furi_hal_version.h>
 #include <furi_hal_memory.h>
+#include <furi_hal_rtc.h>
 
 #define TAG "Flipper"
 
@@ -29,10 +30,10 @@ static void flipper_print_version(const char* target, const Version* version) {
 void flipper_init() {
     flipper_print_version("Firmware", furi_hal_version_get_firmware_version());
 
-    FURI_LOG_I(TAG, "starting services");
+    FURI_LOG_I(TAG, "Boot mode %d, starting services", furi_hal_rtc_get_boot_mode());
 
     for(size_t i = 0; i < FLIPPER_SERVICES_COUNT; i++) {
-        FURI_LOG_I(TAG, "starting service %s", FLIPPER_SERVICES[i].name);
+        FURI_LOG_I(TAG, "Starting service %s", FLIPPER_SERVICES[i].name);
 
         FuriThread* thread = furi_thread_alloc_ex(
             FLIPPER_SERVICES[i].name,
@@ -44,7 +45,7 @@ void flipper_init() {
         furi_thread_start(thread);
     }
 
-    FURI_LOG_I(TAG, "services startup complete");
+    FURI_LOG_I(TAG, "Startup complete");
 }
 
 void vApplicationGetIdleTaskMemory(


### PR DESCRIPTION
# What's new

- Updater: notify on storage errors in post-update stage
- Updater: properly handle folder removal in post update cleanup stage
- Prevent power, desktop and dolphin services from starting on update

# Verification 

- Do full update, check logs, ensure that empty folders are removed

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
