### PR TITLE
Fix incorrect type choice condition in image compressor

### DIFF
--- a/scripts/flipper/assets/icon.py
+++ b/scripts/flipper/assets/icon.py
@@ -105,7 +105,7 @@ def file2image(file):
     data_enc = bytearray([len(data_enc) & 0xFF, len(data_enc) >> 8]) + data_enc
 
     # Use encoded data only if its length less than original, including header
-    if len(data_enc) < len(data_bin) + 1:
+    if len(data_enc) + 2 < len(data_bin) + 1:
         data = b"\x01\x00" + data_enc
     else:
         data = b"\x00" + data_bin


### PR DESCRIPTION
# What's new

- Fix incorrect type choice condition in image compressor: fixes abnormally big size icon issue

# Verification 

- There will be no more icons bigger than 128*64/8+1

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
