### PR TITLE
[FL-3116, FL-3136] BadUSB UI fixes

### DIFF
--- a/applications/main/bad_usb/bad_usb_app.c
+++ b/applications/main/bad_usb/bad_usb_app.c
@@ -142,10 +142,6 @@ void bad_usb_app_free(BadUsbApp* app) {
         app->bad_usb_script = NULL;
     }
 
-    if(app->usb_if_prev) {
-        furi_check(furi_hal_usb_set_config(app->usb_if_prev, NULL));
-    }
-
     // Views
     view_dispatcher_remove_view(app->view_dispatcher, BadUsbAppViewWork);
     bad_usb_free(app->bad_usb_view);
@@ -171,6 +167,10 @@ void bad_usb_app_free(BadUsbApp* app) {
 
     furi_string_free(app->file_path);
     furi_string_free(app->keyboard_layout);
+
+    if(app->usb_if_prev) {
+        furi_check(furi_hal_usb_set_config(app->usb_if_prev, NULL));
+    }
 
     free(app);
 }

--- a/applications/main/bad_usb/scenes/bad_usb_scene_work.c
+++ b/applications/main/bad_usb/scenes/bad_usb_scene_work.c
@@ -16,7 +16,9 @@ bool bad_usb_scene_work_on_event(void* context, SceneManagerEvent event) {
 
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == InputKeyLeft) {
-            scene_manager_next_scene(app->scene_manager, BadUsbSceneConfig);
+            if(bad_usb_is_idle_state(app->bad_usb_view)) {
+                scene_manager_next_scene(app->scene_manager, BadUsbSceneConfig);
+            }
             consumed = true;
         } else if(event.event == InputKeyOk) {
             bad_usb_script_toggle(app->bad_usb_script);

--- a/applications/main/bad_usb/views/bad_usb_view.c
+++ b/applications/main/bad_usb/views/bad_usb_view.c
@@ -48,15 +48,11 @@ static void bad_usb_draw_callback(Canvas* canvas, void* _model) {
     if((model->state.state == BadUsbStateIdle) || (model->state.state == BadUsbStateDone) ||
        (model->state.state == BadUsbStateNotConnected)) {
         elements_button_center(canvas, "Run");
+        elements_button_left(canvas, "Config");
     } else if((model->state.state == BadUsbStateRunning) || (model->state.state == BadUsbStateDelay)) {
         elements_button_center(canvas, "Stop");
     } else if(model->state.state == BadUsbStateWillRun) {
         elements_button_center(canvas, "Cancel");
-    }
-
-    if((model->state.state == BadUsbStateNotConnected) ||
-       (model->state.state == BadUsbStateIdle) || (model->state.state == BadUsbStateDone)) {
-        elements_button_left(canvas, "Config");
     }
 
     if(model->state.state == BadUsbStateNotConnected) {
@@ -203,6 +199,7 @@ void bad_usb_set_layout(BadUsb* bad_usb, const char* layout) {
         { strlcpy(model->layout, layout, MAX_NAME_LEN); },
         true);
 }
+
 void bad_usb_set_state(BadUsb* bad_usb, BadUsbState* st) {
     furi_assert(st);
     with_view_model(
@@ -213,4 +210,20 @@ void bad_usb_set_state(BadUsb* bad_usb, BadUsbState* st) {
             model->anim_frame ^= 1;
         },
         true);
+}
+
+bool bad_usb_is_idle_state(BadUsb* bad_usb) {
+    bool is_idle = false;
+    with_view_model(
+        bad_usb->view,
+        BadUsbModel * model,
+        {
+            if((model->state.state == BadUsbStateIdle) ||
+               (model->state.state == BadUsbStateDone) ||
+               (model->state.state == BadUsbStateNotConnected)) {
+                is_idle = true;
+            }
+        },
+        false);
+    return is_idle;
 }

--- a/applications/main/bad_usb/views/bad_usb_view.h
+++ b/applications/main/bad_usb/views/bad_usb_view.h
@@ -19,3 +19,5 @@ void bad_usb_set_file_name(BadUsb* bad_usb, const char* name);
 void bad_usb_set_layout(BadUsb* bad_usb, const char* layout);
 
 void bad_usb_set_state(BadUsb* bad_usb, BadUsbState* st);
+
+bool bad_usb_is_idle_state(BadUsb* bad_usb);


### PR DESCRIPTION
# What's new

- Restoring USB mode only after all scenes are deleted
- Config menu is disabled if script is running

# Verification 

- Open script file and exit app
- Start script execution and try to open config menu

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
