### PR TITLE
Fix "Music player" path for Dummy mode

### DIFF
--- a/applications/services/desktop/scenes/desktop_scene_main.c
+++ b/applications/services/desktop/scenes/desktop_scene_main.c
@@ -12,7 +12,7 @@
 
 #define TAG "DesktopSrv"
 
-#define MUSIC_PLAYER_APP EXT_PATH("/apps/Misc/music_player.fap")
+#define MUSIC_PLAYER_APP EXT_PATH("/apps/Media/music_player.fap")
 #define SNAKE_GAME_APP EXT_PATH("/apps/Games/snake_game.fap")
 #define CLOCK_APP EXT_PATH("/apps/Tools/clock.fap")
 


### PR DESCRIPTION
Music player path changed to Media folder #2450

# What's new

- fix

# Verification 

- build firmware, manually tested

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
