### PR TITLE
github: check API versions for all targets to match on gh build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,10 @@ jobs:
 
       - name: 'Check API versions'
         run: |
+          set -e
           N_API_HEADER_SIGNATURES=`ls -1 firmware/targets/f*/api_symbols.csv | xargs -I {} sh -c "head -n2 {} | md5sum" | sort -u | wc -l`
           if [ $N_API_HEADER_SIGNATURES != 1 ] ; then
-            echo API versions aren't matching for available targets. Please update!
+            echo API versions aren\'t matching for available targets. Please update!
             head -n2 firmware/targets/f*/api_symbols.csv
             exit 1
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,15 @@ jobs:
           echo random_hash=$(openssl rand -base64 40 | shasum -a 256 | awk '{print $1}') >> $GITHUB_OUTPUT
           echo "event_type=$TYPE" >> $GITHUB_OUTPUT
 
+      - name: 'Check API versions'
+        run: |
+          N_API_HEADER_SIGNATURES=`ls -1 firmware/targets/f*/api_symbols.csv | xargs -I {} sh -c "head -n2 {} | md5sum" | sort -u | wc -l`
+          if [ $N_API_HEADER_SIGNATURES != 1 ] ; then
+            echo API versions aren't matching for available targets. Please update!
+            head -n2 firmware/targets/f*/api_symbols.csv
+            exit 1
+          fi
+
       - name: 'Make artifacts directory'
         run: |
           rm -rf artifacts

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,17.0,,
+Version,+,17.1,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,17.1,,
+Version,+,17.0,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,


### PR DESCRIPTION
# What's new

-  Github builds should fail when there are API version mismatches for known targets

# Verification 

- See runner results 

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
