### PR TITLE
Fix SD card CID parsing

### DIFF
--- a/firmware/targets/f7/fatfs/sd_spi_io.c
+++ b/firmware/targets/f7/fatfs/sd_spi_io.c
@@ -585,6 +585,8 @@ static SdSpiStatus sd_spi_get_cid(SD_CID* Cid) {
             Cid->ProdSN |= cid_data[12];
             Cid->Reserved1 = (cid_data[13] & 0xF0) >> 4;
             Cid->ManufactYear = (cid_data[13] & 0x0F) << 4;
+            Cid->ManufactYear |= (cid_data[14] & 0xF0) >> 4;
+            Cid->ManufactMonth = (cid_data[14] & 0x0F);
             Cid->CID_CRC = (cid_data[15] & 0xFE) >> 1;
             Cid->Reserved2 = 1;
 


### PR DESCRIPTION
The recent SD rewrite dropped a couple of lines from the CID parsing function resulting in zero manufacturing date displayed.

# What's new

- Manufacturing date in SD storage info is non-zero

# Verification 

- `storage info /ext` returns non-zero month

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
