### PR TITLE
Fixed picopass load save file overrun

### DIFF
--- a/applications/plugins/picopass/picopass_device.c
+++ b/applications/plugins/picopass/picopass_device.c
@@ -168,7 +168,7 @@ static bool picopass_device_load_data(PicopassDevice* dev, FuriString* path, boo
 
         size_t app_limit = AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[0];
         // Fix for unpersonalized cards that have app_limit set to 0xFF
-        if (app_limit > PICOPASS_MAX_APP_LIMIT) app_limit = PICOPASS_MAX_APP_LIMIT;
+        if(app_limit > PICOPASS_MAX_APP_LIMIT) app_limit = PICOPASS_MAX_APP_LIMIT;
         for(size_t i = 6; i < app_limit; i++) {
             furi_string_printf(temp_str, "Block %d", i);
             if(!flipper_format_read_hex(

--- a/applications/plugins/picopass/picopass_device.c
+++ b/applications/plugins/picopass/picopass_device.c
@@ -167,6 +167,8 @@ static bool picopass_device_load_data(PicopassDevice* dev, FuriString* path, boo
         }
 
         size_t app_limit = AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[0];
+        // Fix for unpersonalized cards that have app_limit set to 0xFF
+        if (app_limit > PICOPASS_MAX_APP_LIMIT) app_limit = PICOPASS_MAX_APP_LIMIT;
         for(size_t i = 6; i < app_limit; i++) {
             furi_string_printf(temp_str, "Block %d", i);
             if(!flipper_format_read_hex(


### PR DESCRIPTION
# What's new

When reading and saving an unpersonalized picopass tag, the config block app limit is set to 0xFF.  This causes an issue when subsequently loading the save file, as the code tries to parses the unusually large app limit size.  I have therefore modified the code to limit it to the lesser of the block app limit or PICOPASS_MAX_APP_LIMIT constant.

# Verification 

Read and save a picopass card containing a configuration app limit > 32 (0x20).  Then, try to re-load that saved file.  Prior to this correction, it would error out with "Can not parse file"

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
