### PR TITLE
NFC: Fix 0 block write possibility in Mifare Classic emulation

### DIFF
--- a/lib/nfc/protocols/mifare_classic.c
+++ b/lib/nfc/protocols/mifare_classic.c
@@ -291,6 +291,10 @@ bool mf_classic_is_allowed_access_data_block(
     uint8_t* sector_trailer =
         data->block[mf_classic_get_sector_trailer_num_by_block(block_num)].value;
 
+    if(block_num == 0 && action == MfClassicActionDataWrite) {
+        return false;
+    }
+
     uint8_t sector_block;
     if(block_num <= 128) {
         sector_block = block_num & 0x03;


### PR DESCRIPTION
# What's new

- NFC: Fix 0 block write possibility in Mifare Classic emulation (fixes https://t.me/flipperzero/103919/164897)

# Verification 

- Try writing to 0 block while emulating Mifare Classic tag

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
