### PR TITLE
Picopass standard KDF dictionary

### DIFF
--- a/applications/external/picopass/helpers/iclass_elite_dict.c
+++ b/applications/external/picopass/helpers/iclass_elite_dict.c
@@ -5,6 +5,7 @@
 
 #define ICLASS_ELITE_DICT_FLIPPER_NAME APP_DATA_PATH("assets/iclass_elite_dict.txt")
 #define ICLASS_ELITE_DICT_USER_NAME APP_DATA_PATH("assets/iclass_elite_dict_user.txt")
+#define ICLASS_STANDARD_DICT_FLIPPER_NAME APP_DATA_PATH("assets/iclass_standard_dict.txt")
 
 #define TAG "IclassEliteDict"
 
@@ -25,6 +26,9 @@ bool iclass_elite_dict_check_presence(IclassEliteDictType dict_type) {
             (storage_common_stat(storage, ICLASS_ELITE_DICT_FLIPPER_NAME, NULL) == FSE_OK);
     } else if(dict_type == IclassEliteDictTypeUser) {
         dict_present = (storage_common_stat(storage, ICLASS_ELITE_DICT_USER_NAME, NULL) == FSE_OK);
+    } else if(dict_type == IclassStandardDictTypeFlipper) {
+        dict_present =
+            (storage_common_stat(storage, ICLASS_STANDARD_DICT_FLIPPER_NAME, NULL) == FSE_OK);
     }
 
     furi_record_close(RECORD_STORAGE);
@@ -49,6 +53,15 @@ IclassEliteDict* iclass_elite_dict_alloc(IclassEliteDictType dict_type) {
         } else if(dict_type == IclassEliteDictTypeUser) {
             if(!buffered_file_stream_open(
                    dict->stream, ICLASS_ELITE_DICT_USER_NAME, FSAM_READ_WRITE, FSOM_OPEN_ALWAYS)) {
+                buffered_file_stream_close(dict->stream);
+                break;
+            }
+        } else if(dict_type == IclassStandardDictTypeFlipper) {
+            if(!buffered_file_stream_open(
+                   dict->stream,
+                   ICLASS_STANDARD_DICT_FLIPPER_NAME,
+                   FSAM_READ,
+                   FSOM_OPEN_EXISTING)) {
                 buffered_file_stream_close(dict->stream);
                 break;
             }

--- a/applications/external/picopass/helpers/iclass_elite_dict.h
+++ b/applications/external/picopass/helpers/iclass_elite_dict.h
@@ -9,6 +9,7 @@
 typedef enum {
     IclassEliteDictTypeUser,
     IclassEliteDictTypeFlipper,
+    IclassStandardDictTypeFlipper,
 } IclassEliteDictType;
 
 typedef struct IclassEliteDict IclassEliteDict;

--- a/applications/external/picopass/picopass_worker.c
+++ b/applications/external/picopass/picopass_worker.c
@@ -172,14 +172,18 @@ ReturnCode picopass_read_preauth(PicopassBlock* AA1) {
     return ERR_NONE;
 }
 
-static ReturnCode picopass_auth_dict(
-    uint8_t* csn,
-    PicopassPacs* pacs,
-    uint8_t* div_key,
-    IclassEliteDictType dict_type) {
+static ReturnCode
+    picopass_auth_dict(PicopassWorker* picopass_worker, IclassEliteDictType dict_type) {
     rfalPicoPassReadCheckRes rcRes;
     rfalPicoPassCheckRes chkRes;
     bool elite = (dict_type != IclassStandardDictTypeFlipper);
+
+    PicopassDeviceData* dev_data = picopass_worker->dev_data;
+    PicopassBlock* AA1 = dev_data->AA1;
+    PicopassPacs* pacs = &dev_data->pacs;
+
+    uint8_t* csn = AA1[PICOPASS_CSN_BLOCK_INDEX].data;
+    uint8_t* div_key = AA1[PICOPASS_KD_BLOCK_INDEX].data;
 
     ReturnCode err = ERR_PARAM;
 
@@ -204,7 +208,8 @@ static ReturnCode picopass_auth_dict(
     while(iclass_elite_dict_get_next_key(dict, key)) {
         FURI_LOG_D(
             TAG,
-            "Try to auth with key %zu %02x%02x%02x%02x%02x%02x%02x%02x",
+            "Try to %s auth with key %zu %02x%02x%02x%02x%02x%02x%02x%02x",
+            elite ? "elite" : "standard",
             index++,
             key[0],
             key[1],
@@ -230,6 +235,8 @@ static ReturnCode picopass_auth_dict(
             memcpy(pacs->key, key, PICOPASS_BLOCK_LEN);
             break;
         }
+
+        if(picopass_worker->state != PicopassWorkerStateDetect) break;
     }
 
     iclass_elite_dict_free(dict);
@@ -237,35 +244,23 @@ static ReturnCode picopass_auth_dict(
     return err;
 }
 
-ReturnCode picopass_auth(PicopassBlock* AA1, PicopassPacs* pacs) {
+ReturnCode picopass_auth(PicopassWorker* picopass_worker) {
     ReturnCode err;
 
     FURI_LOG_I(TAG, "Starting system dictionary attack [Standard KDF]");
-    err = picopass_auth_dict(
-        AA1[PICOPASS_CSN_BLOCK_INDEX].data,
-        pacs,
-        AA1[PICOPASS_KD_BLOCK_INDEX].data,
-        IclassStandardDictTypeFlipper);
+    err = picopass_auth_dict(picopass_worker, IclassStandardDictTypeFlipper);
     if(err == ERR_NONE) {
         return ERR_NONE;
     }
 
     FURI_LOG_I(TAG, "Starting user dictionary attack [Elite KDF]");
-    err = picopass_auth_dict(
-        AA1[PICOPASS_CSN_BLOCK_INDEX].data,
-        pacs,
-        AA1[PICOPASS_KD_BLOCK_INDEX].data,
-        IclassEliteDictTypeUser);
+    err = picopass_auth_dict(picopass_worker, IclassEliteDictTypeUser);
     if(err == ERR_NONE) {
         return ERR_NONE;
     }
 
     FURI_LOG_I(TAG, "Starting system dictionary attack [Elite KDF]");
-    err = picopass_auth_dict(
-        AA1[PICOPASS_CSN_BLOCK_INDEX].data,
-        pacs,
-        AA1[PICOPASS_KD_BLOCK_INDEX].data,
-        IclassEliteDictTypeFlipper);
+    err = picopass_auth_dict(picopass_worker, IclassEliteDictTypeFlipper);
     if(err == ERR_NONE) {
         return ERR_NONE;
     }
@@ -517,7 +512,7 @@ void picopass_worker_detect(PicopassWorker* picopass_worker) {
             }
 
             if(nextState == PicopassWorkerEventSuccess) {
-                err = picopass_auth(AA1, pacs);
+                err = picopass_auth(picopass_worker);
                 if(err != ERR_NONE) {
                     FURI_LOG_E(TAG, "picopass_try_auth error %d", err);
                     nextState = PicopassWorkerEventFail;

--- a/applications/external/picopass/picopass_worker.c
+++ b/applications/external/picopass/picopass_worker.c
@@ -176,10 +176,10 @@ static ReturnCode picopass_auth_dict(
     uint8_t* csn,
     PicopassPacs* pacs,
     uint8_t* div_key,
-    IclassEliteDictType dict_type,
-    bool elite) {
+    IclassEliteDictType dict_type) {
     rfalPicoPassReadCheckRes rcRes;
     rfalPicoPassCheckRes chkRes;
+    bool elite = (dict_type != IclassStandardDictTypeFlipper);
 
     ReturnCode err = ERR_PARAM;
 
@@ -245,8 +245,7 @@ ReturnCode picopass_auth(PicopassBlock* AA1, PicopassPacs* pacs) {
         AA1[PICOPASS_CSN_BLOCK_INDEX].data,
         pacs,
         AA1[PICOPASS_KD_BLOCK_INDEX].data,
-        IclassEliteDictTypeFlipper,
-        false);
+        IclassStandardDictTypeFlipper);
     if(err == ERR_NONE) {
         return ERR_NONE;
     }
@@ -256,8 +255,7 @@ ReturnCode picopass_auth(PicopassBlock* AA1, PicopassPacs* pacs) {
         AA1[PICOPASS_CSN_BLOCK_INDEX].data,
         pacs,
         AA1[PICOPASS_KD_BLOCK_INDEX].data,
-        IclassEliteDictTypeUser,
-        true);
+        IclassEliteDictTypeUser);
     if(err == ERR_NONE) {
         return ERR_NONE;
     }
@@ -267,8 +265,7 @@ ReturnCode picopass_auth(PicopassBlock* AA1, PicopassPacs* pacs) {
         AA1[PICOPASS_CSN_BLOCK_INDEX].data,
         pacs,
         AA1[PICOPASS_KD_BLOCK_INDEX].data,
-        IclassEliteDictTypeFlipper,
-        true);
+        IclassEliteDictTypeFlipper);
     if(err == ERR_NONE) {
         return ERR_NONE;
     }

--- a/assets/resources/apps_data/picopass/assets/iclass_standard_dict.txt
+++ b/assets/resources/apps_data/picopass/assets/iclass_standard_dict.txt
@@ -1,10 +1,16 @@
 
 ## From https://github.com/RfidResearchGroup/proxmark3/blob/master/client/dictionaries/iclass_default_keys.dic
 
+# AA1
+AEA684A6DAB23278
 # key1/Kc from PicoPass 2k documentation
 7665544332211000
 # SAGEM
 0123456789ABCDEF
+# from loclass demo file.
+5b7c62c491c11b39
+# Kd from PicoPass 2k documentation
+F0E1D2C3B4A59687
 # PicoPass Default Exchange Key
 5CBCF1DA45D5FB4F
 # From HID multiclassSE reader
@@ -12,6 +18,12 @@
 # From pastebin: https://pastebin.com/uHqpjiuU
 6EFD46EFCBB3C875
 E033CA419AEE43F9
+
+# iCopy-x DRM keys
+# iCL tags
+2020666666668888
+# iCS tags reversed from the SOs
+6666202066668888
 
 # default picopass KD / Page 0 / Book 1
 FDCB5A52EA8F3090
@@ -33,5 +45,3 @@ C1B74D7478053AE2
 
 # default iCLASS RFIDeas
 6B65797374726B72
-
-5C100DF7042EAE64


### PR DESCRIPTION
# What's new

- Breaks up dictionary based on KDF (I want to use this more later when elite dictionary grows)
- Pass worker down further so the state can be detected and cancelled while keys are being tested

# Verification 

- Read card and hit back button: notice that is doesn't get stuck reading and consistently exited quickly to original menu

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
