### PR TITLE
fbt: explicitly set dist suffix length

### DIFF
--- a/scripts/version.py
+++ b/scripts/version.py
@@ -9,11 +9,16 @@ from datetime import date, datetime
 
 
 class GitVersion:
+    REVISION_SUFFIX_LENGTH = 8
+
     def __init__(self, source_dir):
         self.source_dir = source_dir
 
     def get_version_info(self):
-        commit = self._exec_git("rev-parse --short HEAD") or "unknown"
+        commit = (
+            self._exec_git(f"rev-parse --short={self.REVISION_SUFFIX_LENGTH} HEAD")
+            or "unknown"
+        )
 
         dirty = False
         try:


### PR DESCRIPTION


# What's new

- fbt: explicitly set dist suffix length , not depending on environment settings. See https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---shortlength

# Verification 

- Check out artifact naming

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
