### PR TITLE
ibutton: Add read and emulate support for DS2502 (Dell charger chip)

### DIFF
--- a/documentation/file_formats/iButtonFileFormat.md
+++ b/documentation/file_formats/iButtonFileFormat.md
@@ -29,7 +29,8 @@ Changelog:
 | Protocol    | string | Currently supported: DS1990, DS1992, DS1996, DS1997, DSGeneric*, Cyfral, Metakom |
 | Rom Data    | hex    | Read-only memory data (Dallas protocols only) |
 | Sram Data   | hex    | Static RAM data (DS1992 and DS1996 only)
-| Eeprom Data | hex    | EEPROM data (DS1971 only)
+| Eeprom Data | hex    | EEPROM data (DS1971 only) |
+| Otp Data    | hex    | OTP (One Time Programmable) data (DS2502 and its variants only) |
 | Data        | hex    | Key data (Cyfral & Metakom only)              |
 
 NOTE 1: DSGeneric is a catch-all protocol for all unknown 1-Wire devices. It reads only the ROM and does not perform any checks on the read data. 

--- a/lib/one_wire/ibutton/protocols/dallas/dallas_common.c
+++ b/lib/one_wire/ibutton/protocols/dallas/dallas_common.c
@@ -91,8 +91,8 @@ bool dallas_common_read_mem(
     size_t data_size,
     bool handle_leading_crc) {
     onewire_host_write(host, DALLAS_COMMON_CMD_READ_MEM);
-    uint8_t address_buf[2] = {address & 0xff, address >> BITS_IN_BYTE};
 
+    uint8_t address_buf[2] = {address & 0xff, address >> BITS_IN_BYTE};
     onewire_host_write_bytes(host, address_buf, sizeof(address_buf));
 
     // Some chips (namely DS2502) sends a leading checksum of the read command and address.

--- a/lib/one_wire/ibutton/protocols/dallas/dallas_common.h
+++ b/lib/one_wire/ibutton/protocols/dallas/dallas_common.h
@@ -68,7 +68,12 @@ bool dallas_common_copy_scratchpad(
     const DallasCommonAddressRegs* regs,
     uint32_t timeout_us);
 
-bool dallas_common_read_mem(OneWireHost* host, uint16_t address, uint8_t* data, size_t data_size);
+bool dallas_common_read_mem(
+    OneWireHost* host,
+    uint16_t address,
+    uint8_t* data,
+    size_t data_size,
+    bool handle_leading_crc);
 
 /* Combined operations */
 bool dallas_common_write_mem(
@@ -83,7 +88,11 @@ bool dallas_common_emulate_search_rom(OneWireSlave* bus, const DallasCommonRomDa
 
 bool dallas_common_emulate_read_rom(OneWireSlave* bus, const DallasCommonRomData* rom_data);
 
-bool dallas_common_emulate_read_mem(OneWireSlave* bus, const uint8_t* data, size_t data_size);
+bool dallas_common_emulate_read_mem(
+    OneWireSlave* bus,
+    const uint8_t* data,
+    size_t data_size,
+    bool add_leading_crc);
 
 /* Save & Load */
 bool dallas_common_save_rom_data(FlipperFormat* ff, const DallasCommonRomData* rom_data);

--- a/lib/one_wire/ibutton/protocols/dallas/protocol_ds1992.c
+++ b/lib/one_wire/ibutton/protocols/dallas/protocol_ds1992.c
@@ -68,7 +68,7 @@ const iButtonProtocolDallasBase ibutton_protocol_ds1992 = {
 bool dallas_ds1992_read(OneWireHost* host, iButtonProtocolData* protocol_data) {
     DS1992ProtocolData* data = protocol_data;
     return onewire_host_reset(host) && dallas_common_read_rom(host, &data->rom_data) &&
-           dallas_common_read_mem(host, 0, data->sram_data, DS1992_SRAM_DATA_SIZE);
+           dallas_common_read_mem(host, 0, data->sram_data, DS1992_SRAM_DATA_SIZE, false);
 }
 
 bool dallas_ds1992_write_blank(OneWireHost* host, iButtonProtocolData* protocol_data) {
@@ -106,7 +106,7 @@ static bool dallas_ds1992_command_callback(uint8_t command, void* context) {
 
         } else if(data->state.command_state == DallasCommonCommandStateRomCmd) {
             data->state.command_state = DallasCommonCommandStateMemCmd;
-            dallas_common_emulate_read_mem(bus, data->sram_data, DS1992_SRAM_DATA_SIZE);
+            dallas_common_emulate_read_mem(bus, data->sram_data, DS1992_SRAM_DATA_SIZE, false);
             return false;
 
         } else {

--- a/lib/one_wire/ibutton/protocols/dallas/protocol_ds1996.c
+++ b/lib/one_wire/ibutton/protocols/dallas/protocol_ds1996.c
@@ -64,7 +64,7 @@ const iButtonProtocolDallasBase ibutton_protocol_ds1996 = {
 bool dallas_ds1996_read(OneWireHost* host, iButtonProtocolData* protocol_data) {
     DS1996ProtocolData* data = protocol_data;
     return onewire_host_reset(host) && dallas_common_read_rom(host, &data->rom_data) &&
-           dallas_common_read_mem(host, 0, data->sram_data, DS1996_SRAM_DATA_SIZE);
+           dallas_common_read_mem(host, 0, data->sram_data, DS1996_SRAM_DATA_SIZE, false);
 }
 
 bool dallas_ds1996_write_copy(OneWireHost* host, iButtonProtocolData* protocol_data) {
@@ -96,7 +96,7 @@ static bool dallas_ds1996_command_callback(uint8_t command, void* context) {
 
         } else if(data->state.command_state == DallasCommonCommandStateRomCmd) {
             data->state.command_state = DallasCommonCommandStateMemCmd;
-            dallas_common_emulate_read_mem(bus, data->sram_data, DS1996_SRAM_DATA_SIZE);
+            dallas_common_emulate_read_mem(bus, data->sram_data, DS1996_SRAM_DATA_SIZE, false);
             return false;
 
         } else {

--- a/lib/one_wire/ibutton/protocols/dallas/protocol_ds2502.c
+++ b/lib/one_wire/ibutton/protocols/dallas/protocol_ds2502.c
@@ -1,0 +1,222 @@
+#include "protocol_ds2502.h"
+
+#include <core/core_defines.h>
+#include <toolbox/pretty_format.h>
+
+#include "dallas_common.h"
+
+#define DS2502_FAMILY_CODE 0x09U
+#define DS2502_DELL_FAMILY_CODE 0x28U
+#define DS2502_FAMILY_NAME "DS2502"
+
+#define DS2502_OTP_DATA_SIZE 128U
+#define DS2502_OTP_PAGE_SIZE 4U
+#define DS2502_COPY_SCRATCH_TIMEOUT_US 100U
+
+#define DS2502_DATA_BYTE_COUNT 4U
+
+#define DS2502_OTP_DATA_KEY "Otp Data"
+#define DS2502_MEMORY_TYPE "OTP"
+
+typedef struct {
+    OneWireSlave* bus;
+    DallasCommonCommandState command_state;
+} DS2502ProtocolState;
+
+typedef struct {
+    DallasCommonRomData rom_data;
+    uint8_t otp_data[DS2502_OTP_DATA_SIZE];
+    DS2502ProtocolState state;
+} DS2502ProtocolData;
+
+static bool dallas_ds2502_read(OneWireHost*, void*);
+static void dallas_ds2502_emulate(OneWireSlave*, iButtonProtocolData*);
+static bool dallas_ds2502_load(FlipperFormat*, uint32_t, iButtonProtocolData*);
+static bool dallas_ds2502_save(FlipperFormat*, const iButtonProtocolData*);
+static void dallas_ds2502_render_data(FuriString*, const iButtonProtocolData*);
+static void dallas_ds2502_render_brief_data(FuriString*, const iButtonProtocolData*);
+static void dallas_ds2502_render_error(FuriString*, const iButtonProtocolData*);
+static bool dallas_ds2502_is_data_valid(const iButtonProtocolData*);
+static void dallas_ds2502_get_editable_data(iButtonEditableData*, iButtonProtocolData*);
+static void dallas_ds2502_apply_edits(iButtonProtocolData*);
+
+const iButtonProtocolDallasBase ibutton_protocol_ds2502 = {
+    .family_code = DS2502_FAMILY_CODE,
+    .features = iButtonProtocolFeatureExtData,
+    .data_size = sizeof(DS2502ProtocolData),
+    .manufacturer = DALLAS_COMMON_MANUFACTURER_NAME,
+    .name = DS2502_FAMILY_NAME,
+
+    .read = dallas_ds2502_read,
+    // DS2502 is OTP and requires high voltage to program which Flipper doesn't support.
+    .write_blank = NULL,
+    .write_copy = NULL,
+    .emulate = dallas_ds2502_emulate,
+    .save = dallas_ds2502_save,
+    .load = dallas_ds2502_load,
+    .render_data = dallas_ds2502_render_data,
+    .render_brief_data = dallas_ds2502_render_brief_data,
+    .render_error = dallas_ds2502_render_error,
+    .is_valid = dallas_ds2502_is_data_valid,
+    .get_editable_data = dallas_ds2502_get_editable_data,
+    .apply_edits = dallas_ds2502_apply_edits,
+};
+
+const iButtonProtocolDallasBase ibutton_protocol_ds2502_dell = {
+    // Some Dell chargers reportedly use FC 0x28 but they seem to just be DS2502
+    // https://github.com/orgua/OneWireHub#implemented-slaves
+    .family_code = DS2502_DELL_FAMILY_CODE,
+    .features = iButtonProtocolFeatureExtData,
+    .data_size = sizeof(DS2502ProtocolData),
+    .manufacturer = DALLAS_COMMON_MANUFACTURER_NAME,
+    .name = DS2502_FAMILY_NAME,
+
+    .read = dallas_ds2502_read,
+    // DS2502 is OTP and requires high voltage to program which Flipper doesn't support.
+    .write_blank = NULL,
+    .write_copy = NULL,
+    .emulate = dallas_ds2502_emulate,
+    .save = dallas_ds2502_save,
+    .load = dallas_ds2502_load,
+    .render_data = dallas_ds2502_render_data,
+    .render_brief_data = dallas_ds2502_render_brief_data,
+    .render_error = dallas_ds2502_render_error,
+    .is_valid = dallas_ds2502_is_data_valid,
+    .get_editable_data = dallas_ds2502_get_editable_data,
+    .apply_edits = dallas_ds2502_apply_edits,
+};
+
+bool dallas_ds2502_read(OneWireHost* host, iButtonProtocolData* protocol_data) {
+    DS2502ProtocolData* data = protocol_data;
+    return onewire_host_reset(host) && dallas_common_read_rom(host, &data->rom_data) &&
+           dallas_common_read_mem(host, 0, data->otp_data, DS2502_OTP_DATA_SIZE);
+}
+
+static void dallas_ds2502_reset_callback(void* context) {
+    furi_assert(context);
+    DS2502ProtocolData* data = context;
+    data->state.command_state = DallasCommonCommandStateIdle;
+}
+
+static bool dallas_ds2502_command_callback(uint8_t command, void* context) {
+    furi_assert(context);
+    DS2502ProtocolData* data = context;
+    OneWireSlave* bus = data->state.bus;
+
+    switch(command) {
+    case DALLAS_COMMON_CMD_SEARCH_ROM:
+        if(data->state.command_state == DallasCommonCommandStateIdle) {
+            data->state.command_state = DallasCommonCommandStateRomCmd;
+            return dallas_common_emulate_search_rom(bus, &data->rom_data);
+
+        } else if(data->state.command_state == DallasCommonCommandStateRomCmd) {
+            data->state.command_state = DallasCommonCommandStateMemCmd;
+            dallas_common_emulate_read_mem(bus, data->otp_data, DS2502_OTP_DATA_SIZE);
+            return false;
+
+        } else {
+            return false;
+        }
+
+    case DALLAS_COMMON_CMD_READ_ROM:
+        if(data->state.command_state == DallasCommonCommandStateIdle) {
+            data->state.command_state = DallasCommonCommandStateRomCmd;
+            return dallas_common_emulate_read_rom(bus, &data->rom_data);
+        } else {
+            return false;
+        }
+
+    case DALLAS_COMMON_CMD_SKIP_ROM:
+        if(data->state.command_state == DallasCommonCommandStateIdle) {
+            data->state.command_state = DallasCommonCommandStateRomCmd;
+            return true;
+        } else {
+            return false;
+        }
+
+    default:
+        return false;
+    }
+}
+
+void dallas_ds2502_emulate(OneWireSlave* bus, iButtonProtocolData* protocol_data) {
+    DS2502ProtocolData* data = protocol_data;
+    data->state.bus = bus;
+
+    onewire_slave_set_reset_callback(bus, dallas_ds2502_reset_callback, protocol_data);
+    onewire_slave_set_command_callback(bus, dallas_ds2502_command_callback, protocol_data);
+}
+
+bool dallas_ds2502_load(
+    FlipperFormat* ff,
+    uint32_t format_version,
+    iButtonProtocolData* protocol_data) {
+    DS2502ProtocolData* data = protocol_data;
+    bool success = false;
+
+    do {
+        if(format_version < 2) break;
+        if(!dallas_common_load_rom_data(ff, format_version, &data->rom_data)) break;
+        if(!flipper_format_read_hex(ff, DS2502_OTP_DATA_KEY, data->otp_data, DS2502_OTP_DATA_SIZE))
+            break;
+        success = true;
+    } while(false);
+
+    return success;
+}
+
+bool dallas_ds2502_save(FlipperFormat* ff, const iButtonProtocolData* protocol_data) {
+    const DS2502ProtocolData* data = protocol_data;
+    bool success = false;
+
+    do {
+        if(!dallas_common_save_rom_data(ff, &data->rom_data)) break;
+        if(!flipper_format_write_hex(ff, DS2502_OTP_DATA_KEY, data->otp_data, DS2502_OTP_DATA_SIZE))
+            break;
+        success = true;
+    } while(false);
+
+    return success;
+}
+
+void dallas_ds2502_render_data(FuriString* result, const iButtonProtocolData* protocol_data) {
+    const DS2502ProtocolData* data = protocol_data;
+    pretty_format_bytes_hex_canonical(
+        result,
+        DS2502_DATA_BYTE_COUNT,
+        PRETTY_FORMAT_FONT_MONOSPACE,
+        data->otp_data,
+        DS2502_OTP_DATA_SIZE);
+}
+
+void dallas_ds2502_render_brief_data(FuriString* result, const iButtonProtocolData* protocol_data) {
+    const DS2502ProtocolData* data = protocol_data;
+    dallas_common_render_brief_data(
+        result, &data->rom_data, data->otp_data, DS2502_OTP_DATA_SIZE, DS2502_MEMORY_TYPE);
+}
+
+void dallas_ds2502_render_error(FuriString* result, const iButtonProtocolData* protocol_data) {
+    const DS2502ProtocolData* data = protocol_data;
+
+    if(!dallas_common_is_valid_crc(&data->rom_data)) {
+        dallas_common_render_crc_error(result, &data->rom_data);
+    }
+}
+
+bool dallas_ds2502_is_data_valid(const iButtonProtocolData* protocol_data) {
+    const DS2502ProtocolData* data = protocol_data;
+    return dallas_common_is_valid_crc(&data->rom_data);
+}
+
+void dallas_ds2502_get_editable_data(
+    iButtonEditableData* editable_data,
+    iButtonProtocolData* protocol_data) {
+    DS2502ProtocolData* data = protocol_data;
+    editable_data->ptr = data->rom_data.bytes;
+    editable_data->size = sizeof(DallasCommonRomData);
+}
+
+void dallas_ds2502_apply_edits(iButtonProtocolData* protocol_data) {
+    DS2502ProtocolData* data = protocol_data;
+    dallas_common_apply_edits(&data->rom_data, DS2502_FAMILY_CODE);
+}

--- a/lib/one_wire/ibutton/protocols/dallas/protocol_ds2502.h
+++ b/lib/one_wire/ibutton/protocols/dallas/protocol_ds2502.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "protocol_dallas_base.h"
+
+extern const iButtonProtocolDallasBase ibutton_protocol_ds2502;
+extern const iButtonProtocolDallasBase ibutton_protocol_ds2502_dell;

--- a/lib/one_wire/ibutton/protocols/dallas/protocol_group_dallas_defs.c
+++ b/lib/one_wire/ibutton/protocols/dallas/protocol_group_dallas_defs.c
@@ -4,6 +4,7 @@
 #include "protocol_ds1992.h"
 #include "protocol_ds1996.h"
 #include "protocol_ds1971.h"
+#include "protocol_ds2502.h"
 #include "protocol_ds_generic.h"
 
 const iButtonProtocolDallasBase* ibutton_protocols_dallas[] = {
@@ -11,6 +12,8 @@ const iButtonProtocolDallasBase* ibutton_protocols_dallas[] = {
     [iButtonProtocolDS1992] = &ibutton_protocol_ds1992,
     [iButtonProtocolDS1996] = &ibutton_protocol_ds1996,
     [iButtonProtocolDS1971] = &ibutton_protocol_ds1971,
+    [iButtonProtocolDS2502] = &ibutton_protocol_ds2502,
+    [iButtonProtocolDS2502Dell] = &ibutton_protocol_ds2502_dell,
     /* Add new 1-Wire protocols here */
 
     /* Default catch-all 1-Wire protocol */

--- a/lib/one_wire/ibutton/protocols/dallas/protocol_group_dallas_defs.h
+++ b/lib/one_wire/ibutton/protocols/dallas/protocol_group_dallas_defs.h
@@ -7,6 +7,8 @@ typedef enum {
     iButtonProtocolDS1992,
     iButtonProtocolDS1996,
     iButtonProtocolDS1971,
+    iButtonProtocolDS2502,
+    iButtonProtocolDS2502Dell,
     /* Add new 1-Wire protocols here */
 
     /* Default catch-all 1-Wire protocol */


### PR DESCRIPTION
# What's new

- Read and emulate DS2502 (write is not supported since the device is OTP and requires a special writing voltage to be able to write.)
- A way for `dallas_common` to handle the leading checksum when reading and emulating DS2502.
- Introduce a new key `Otp Data` for dumped OTP data.
- Fix a typo in `dallas_common`

# Verification 

- Connect 2 Flipper's 1W and GND together. Emulate [dell.txt](https://github.com/flipperdevices/flipperzero-firmware/files/10997245/dell.txt) on Flipper A and read on Flipper B.
  - The Flipper B should now have a dump identical to `dell.txt`.
- (If one can source the old Dell barrel jack chargers) Connect the center pin to Flipper 's `1W` pin and **outer** barrel to `GND` and go to `iButton -> Read`.
  - I highly recommend to NOT power on the charger when testing so a slippery probe won't kill the Flipper. OneWire ROMs are self powered so this shouldn't affect the result.
  - Should be able to read the OTP content (a string starting with `DELL00AC`)

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
