### PR TITLE
Correct FAP default upload path in AppsOnSDCard.md

### DIFF
--- a/documentation/AppsOnSDCard.md
+++ b/documentation/AppsOnSDCard.md
@@ -13,7 +13,7 @@ FAPs are created and developed the same way as internal applications that are pa
 To build your application as a FAP, create a folder with your app's source code in `applications_user`, then write its code the way you'd do when creating a regular built-in application. Then configure its `application.fam` manifest, and set its _apptype_ to FlipperAppType.EXTERNAL. See [Application Manifests](./AppManifests.md#application-definition) for more details.
 
 - To build your application, run `./fbt fap_{APPID}`, where APPID is your application's ID in its manifest.
-- To build your app and upload it over USB to run on Flipper, use `./fbt launch_app APPSRC=applications/path/to/app`. This command is configured in the default [VS Code profile](../.vscode/ReadMe.md) as a "Launch App on Flipper" build action (Ctrl+Shift+B menu).
+- To build your app and upload it over USB to run on Flipper, use `./fbt launch_app APPSRC=applications_user/path/to/app`. This command is configured in the default [VS Code profile](../.vscode/ReadMe.md) as a "Launch App on Flipper" build action (Ctrl+Shift+B menu).
 - To build all FAPs, run `./fbt faps` or `./fbt fap_dist`.
 
 ## FAP assets


### PR DESCRIPTION
# What's new

Since the fap's source code is in `applications_user`, the documentation should also point to `applications_user` as the parent directory

# Verification 

Only readme change

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
