### PR TITLE
BadUSB: added WAIT_FOR_BUTTON_PRESS functionality

### DIFF
--- a/applications/main/bad_usb/helpers/ducky_script.h
+++ b/applications/main/bad_usb/helpers/ducky_script.h
@@ -15,6 +15,7 @@ typedef enum {
     BadUsbStateRunning,
     BadUsbStateDelay,
     BadUsbStateStringDelay,
+    BadUsbStateWaitForBtn,
     BadUsbStateDone,
     BadUsbStateScriptError,
     BadUsbStateFileError,

--- a/applications/main/bad_usb/helpers/ducky_script_commands.c
+++ b/applications/main/bad_usb/helpers/ducky_script_commands.c
@@ -143,6 +143,14 @@ static int32_t ducky_fnc_release(BadUsbScript* bad_usb, const char* line, int32_
     return 0;
 }
 
+static int32_t ducky_fnc_waitforbutton(BadUsbScript* bad_usb, const char* line, int32_t param) {
+    UNUSED(param);
+    UNUSED(bad_usb);
+    UNUSED(line);
+
+    return SCRIPT_STATE_WAIT_FOR_BTN;
+}
+
 static const DuckyCmd ducky_commands[] = {
     {"REM ", NULL, -1},
     {"ID ", NULL, -1},
@@ -160,7 +168,11 @@ static const DuckyCmd ducky_commands[] = {
     {"ALTCODE ", ducky_fnc_altstring, -1},
     {"HOLD ", ducky_fnc_hold, -1},
     {"RELEASE ", ducky_fnc_release, -1},
+    {"WAIT_FOR_BUTTON_PRESS", ducky_fnc_waitforbutton, -1},
 };
+
+#define TAG "BadUSB"
+#define WORKER_TAG TAG "Worker"
 
 int32_t ducky_execute_cmd(BadUsbScript* bad_usb, const char* line) {
     for(size_t i = 0; i < COUNT_OF(ducky_commands); i++) {

--- a/applications/main/bad_usb/helpers/ducky_script_i.h
+++ b/applications/main/bad_usb/helpers/ducky_script_i.h
@@ -13,6 +13,7 @@ extern "C" {
 #define SCRIPT_STATE_NEXT_LINE (-3)
 #define SCRIPT_STATE_CMD_UNKNOWN (-4)
 #define SCRIPT_STATE_STRING_START (-5)
+#define SCRIPT_STATE_WAIT_FOR_BTN (-6)
 
 #define FILE_BUFFER_LEN 16
 

--- a/applications/main/bad_usb/views/bad_usb_view.c
+++ b/applications/main/bad_usb/views/bad_usb_view.c
@@ -51,6 +51,8 @@ static void bad_usb_draw_callback(Canvas* canvas, void* _model) {
         elements_button_left(canvas, "Config");
     } else if((model->state.state == BadUsbStateRunning) || (model->state.state == BadUsbStateDelay)) {
         elements_button_center(canvas, "Stop");
+    } else if(model->state.state == BadUsbStateWaitForBtn) {
+        elements_button_center(canvas, "Press to continue");
     } else if(model->state.state == BadUsbStateWillRun) {
         elements_button_center(canvas, "Cancel");
     }

--- a/documentation/file_formats/BadUsbScriptFormat.md
+++ b/documentation/file_formats/BadUsbScriptFormat.md
@@ -77,6 +77,13 @@ Up to 5 keys can be hold simultaneously.
 | HOLD    | Special key or single character | Press and hold key untill RELEASE command |
 | RELEASE | Special key or single character | Release key                               |
 
+## Wait for button press
+
+Will wait indefinitely for a button to be pressed
+| Command               | Parameters   | Notes                                                                 |
+| --------------------- | ------------ | --------------------------------------------------------------------- |
+| WAIT_FOR_BUTTON_PRESS | None         | Will wait for the user to press a button to continue script execution |
+
 
 ## String
 


### PR DESCRIPTION
# What's new

- Added WAIT_FOR_BUTTON_PRESS to badusb

# Verification 

- to verify this addition you can use the following script:
```
DELAY 700
STRINGLN vim /tmp/abc.txt
DELAY 1000
STRING i
DELAY 3000
STRINGLN HELLO WORLD!
HOLD a
DELAY 2000
RELEASE a
ENTER
STRINGLN "Please press button"
WAIT_FOR_BUTTON_PRESS
STRINGLN "button was pressed"
```

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
