### PR TITLE
Add more detail to saved info screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,6 @@ openocd.log
 # PVS Studio temporary files
 .PVS-Studio/
 PVS-Studio.log
+*.PVS-Studio.*
 
 .gdbinit

--- a/applications/external/picopass/scenes/picopass_scene_device_info.c
+++ b/applications/external/picopass/scenes/picopass_scene_device_info.c
@@ -37,7 +37,7 @@ void picopass_scene_device_info_on_enter(void* context) {
         furi_string_cat_printf(wiegand_str, "Invalid PACS");
     } else {
         size_t bytesLength = pacs->record.bitLength / 8;
-        if (pacs->record.bitLength % 8 > 0) {
+        if(pacs->record.bitLength % 8 > 0) {
             // Add extra byte if there are bits remaining
             bytesLength++;
         }

--- a/applications/external/picopass/scenes/picopass_scene_device_info.c
+++ b/applications/external/picopass/scenes/picopass_scene_device_info.c
@@ -32,17 +32,15 @@ void picopass_scene_device_info_on_enter(void* context) {
         furi_string_cat_printf(csn_str, "%02X ", csn[i]);
     }
 
-    bool has_key = !picopass_is_memset(pacs->key, 0x00, PICOPASS_BLOCK_LEN);
-
     if(pacs->record.bitLength == 0 || pacs->record.bitLength == 255) {
         // Neither of these are valid.  Indicates the block was all 0x00 or all 0xff
         furi_string_cat_printf(wiegand_str, "Invalid PACS");
-
-        if(pacs->se_enabled) {
-            furi_string_cat_printf(credential_str, "SE enabled");
-        }
     } else {
-        size_t bytesLength = 1 + pacs->record.bitLength / 8;
+        size_t bytesLength = pacs->record.bitLength / 8;
+        if (pacs->record.bitLength % 8 > 0) {
+            // Add extra byte if there are bits remaining
+            bytesLength++;
+        }
         furi_string_set(credential_str, "");
         for(uint8_t i = PICOPASS_BLOCK_LEN - bytesLength; i < PICOPASS_BLOCK_LEN; i++) {
             furi_string_cat_printf(credential_str, " %02X", pacs->credential[i]);
@@ -57,19 +55,6 @@ void picopass_scene_device_info_on_enter(void* context) {
 
         if(pacs->sio) {
             furi_string_cat_printf(sio_str, "+SIO");
-        }
-
-        if(has_key) {
-            if(pacs->sio) {
-                furi_string_cat_printf(sio_str, " ");
-            }
-            furi_string_cat_printf(sio_str, "Key: ");
-
-            uint8_t key[PICOPASS_BLOCK_LEN];
-            memcpy(key, &pacs->key, PICOPASS_BLOCK_LEN);
-            for(uint8_t i = 0; i < PICOPASS_BLOCK_LEN; i++) {
-                furi_string_cat_printf(sio_str, "%02X", key[i]);
-            }
         }
     }
 

--- a/applications/external/picopass/scenes/picopass_scene_device_info.c
+++ b/applications/external/picopass/scenes/picopass_scene_device_info.c
@@ -14,43 +14,84 @@ void picopass_scene_device_info_widget_callback(
 void picopass_scene_device_info_on_enter(void* context) {
     Picopass* picopass = context;
 
-    FuriString* credential_str;
-    FuriString* wiegand_str;
-    credential_str = furi_string_alloc();
-    wiegand_str = furi_string_alloc();
+    FuriString* csn_str = furi_string_alloc_set("CSN:");
+    FuriString* credential_str = furi_string_alloc();
+    FuriString* wiegand_str = furi_string_alloc();
+    FuriString* sio_str = furi_string_alloc();
 
     DOLPHIN_DEED(DolphinDeedNfcReadSuccess);
 
     // Setup view
+    PicopassBlock* AA1 = picopass->dev->dev_data.AA1;
     PicopassPacs* pacs = &picopass->dev->dev_data.pacs;
     Widget* widget = picopass->widget;
 
-    size_t bytesLength = 1 + pacs->record.bitLength / 8;
-    furi_string_set(credential_str, "");
-    for(uint8_t i = PICOPASS_BLOCK_LEN - bytesLength; i < PICOPASS_BLOCK_LEN; i++) {
-        furi_string_cat_printf(credential_str, " %02X", pacs->credential[i]);
+    uint8_t csn[PICOPASS_BLOCK_LEN] = {0};
+    memcpy(csn, AA1[PICOPASS_CSN_BLOCK_INDEX].data, PICOPASS_BLOCK_LEN);
+    for(uint8_t i = 0; i < PICOPASS_BLOCK_LEN; i++) {
+        furi_string_cat_printf(csn_str, "%02X ", csn[i]);
     }
 
-    if(pacs->record.valid) {
-        furi_string_cat_printf(
-            wiegand_str, "FC: %u CN: %u", pacs->record.FacilityCode, pacs->record.CardNumber);
+    bool has_key = !picopass_is_memset(pacs->key, 0x00, PICOPASS_BLOCK_LEN);
+
+    if(pacs->record.bitLength == 0 || pacs->record.bitLength == 255) {
+        // Neither of these are valid.  Indicates the block was all 0x00 or all 0xff
+        furi_string_cat_printf(wiegand_str, "Invalid PACS");
+
+        if(pacs->se_enabled) {
+            furi_string_cat_printf(credential_str, "SE enabled");
+        }
     } else {
-        furi_string_cat_printf(wiegand_str, "%d bits", pacs->record.bitLength);
+        size_t bytesLength = 1 + pacs->record.bitLength / 8;
+        furi_string_set(credential_str, "");
+        for(uint8_t i = PICOPASS_BLOCK_LEN - bytesLength; i < PICOPASS_BLOCK_LEN; i++) {
+            furi_string_cat_printf(credential_str, " %02X", pacs->credential[i]);
+        }
+
+        if(pacs->record.valid) {
+            furi_string_cat_printf(
+                wiegand_str, "FC: %u CN: %u", pacs->record.FacilityCode, pacs->record.CardNumber);
+        } else {
+            furi_string_cat_printf(wiegand_str, "%d bits", pacs->record.bitLength);
+        }
+
+        if(pacs->sio) {
+            furi_string_cat_printf(sio_str, "+SIO");
+        }
+
+        if(has_key) {
+            if(pacs->sio) {
+                furi_string_cat_printf(sio_str, " ");
+            }
+            furi_string_cat_printf(sio_str, "Key: ");
+
+            uint8_t key[PICOPASS_BLOCK_LEN];
+            memcpy(key, &pacs->key, PICOPASS_BLOCK_LEN);
+            for(uint8_t i = 0; i < PICOPASS_BLOCK_LEN; i++) {
+                furi_string_cat_printf(sio_str, "%02X", key[i]);
+            }
+        }
     }
 
     widget_add_string_element(
-        widget, 64, 12, AlignCenter, AlignCenter, FontPrimary, furi_string_get_cstr(wiegand_str));
+        widget, 64, 5, AlignCenter, AlignCenter, FontSecondary, furi_string_get_cstr(csn_str));
+    widget_add_string_element(
+        widget, 64, 20, AlignCenter, AlignCenter, FontPrimary, furi_string_get_cstr(wiegand_str));
     widget_add_string_element(
         widget,
         64,
-        32,
+        36,
         AlignCenter,
         AlignCenter,
         FontSecondary,
         furi_string_get_cstr(credential_str));
+    widget_add_string_element(
+        widget, 64, 46, AlignCenter, AlignCenter, FontSecondary, furi_string_get_cstr(sio_str));
 
+    furi_string_free(csn_str);
     furi_string_free(credential_str);
     furi_string_free(wiegand_str);
+    furi_string_free(sio_str);
 
     widget_add_button_element(
         picopass->widget,


### PR DESCRIPTION
# What's new

- Bringing more of the details we added to "read success" into the "info" screen

# Verification 

- Select an existing saved picopass
- Select "Info"
- See credential as before
- See CSN

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
