### PR TITLE
FatFS: use rtc for timestamping

### DIFF
--- a/firmware/targets/f7/fatfs/fatfs.c
+++ b/firmware/targets/f7/fatfs/fatfs.c
@@ -1,4 +1,5 @@
 #include "fatfs.h"
+#include "furi_hal_rtc.h"
 
 /** logical drive path */
 char fatfs_path[4];
@@ -14,6 +15,11 @@ void fatfs_init(void) {
   * @param  None
   * @retval Time in DWORD
   */
-DWORD get_fattime(void) {
-    return 0;
+
+DWORD get_fattime() {
+    FuriHalRtcDateTime furi_time;
+    furi_hal_rtc_get_datetime(&furi_time);
+
+    return (furi_time.year - 1980) << 25 | furi_time.month << 21 | furi_time.day << 16 |
+           furi_time.hour << 11 | furi_time.minute << 5 | furi_time.second >> 1;
 }

--- a/firmware/targets/f7/fatfs/fatfs.c
+++ b/firmware/targets/f7/fatfs/fatfs.c
@@ -20,6 +20,7 @@ DWORD get_fattime() {
     FuriHalRtcDateTime furi_time;
     furi_hal_rtc_get_datetime(&furi_time);
 
-    return (furi_time.year - 1980) << 25 | furi_time.month << 21 | furi_time.day << 16 |
-           furi_time.hour << 11 | furi_time.minute << 5 | furi_time.second >> 1;
+    return ((uint32_t)(furi_time.year - 1980) << 25) | furi_time.month << 21 |
+           furi_time.day << 16 | furi_time.hour << 11 | furi_time.minute << 5 |
+           furi_time.second >> 1;
 }

--- a/firmware/targets/f7/fatfs/fatfs.c
+++ b/firmware/targets/f7/fatfs/fatfs.c
@@ -10,12 +10,10 @@ void fatfs_init(void) {
     FATFS_LinkDriver(&sd_fatfs_driver, fatfs_path);
 }
 
-/**
-  * @brief  Gets Time from RTC 
-  * @param  None
-  * @retval Time in DWORD
+/** Gets Time from RTC
+  *
+  * @return     Time in DWORD (toasters per square washing machine)
   */
-
 DWORD get_fattime() {
     FuriHalRtcDateTime furi_time;
     furi_hal_rtc_get_datetime(&furi_time);

--- a/firmware/targets/f7/fatfs/fatfs.c
+++ b/firmware/targets/f7/fatfs/fatfs.c
@@ -21,6 +21,5 @@ DWORD get_fattime() {
     furi_hal_rtc_get_datetime(&furi_time);
 
     return ((uint32_t)(furi_time.year - 1980) << 25) | furi_time.month << 21 |
-           furi_time.day << 16 | furi_time.hour << 11 | furi_time.minute << 5 |
-           furi_time.second >> 1;
+           furi_time.day << 16 | furi_time.hour << 11 | furi_time.minute << 5 | furi_time.second;
 }

--- a/firmware/targets/f7/fatfs/ffconf.h
+++ b/firmware/targets/f7/fatfs/ffconf.h
@@ -219,7 +219,7 @@
 /  When enable exFAT, also LFN needs to be enabled. (_USE_LFN >= 1)
 /  Note that enabling exFAT discards C89 compatibility. */
 
-#define _FS_NORTC 1
+#define _FS_NORTC 0
 #define _NORTC_MON 7
 #define _NORTC_MDAY 20
 #define _NORTC_YEAR 2021

--- a/firmware/targets/f7/fatfs/ffconf.h
+++ b/firmware/targets/f7/fatfs/ffconf.h
@@ -220,9 +220,6 @@
 /  Note that enabling exFAT discards C89 compatibility. */
 
 #define _FS_NORTC 0
-#define _NORTC_MON 7
-#define _NORTC_MDAY 20
-#define _NORTC_YEAR 2021
 /* The option _FS_NORTC switches timestamp functiton. If the system does not have
 /  any RTC function or valid timestamp is not needed, set _FS_NORTC = 1 to disable
 /  the timestamp function. All objects modified by FatFs will have a fixed timestamp

--- a/firmware/targets/f7/furi_hal/furi_hal_rtc.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_rtc.c
@@ -281,8 +281,10 @@ FuriHalRtcLocaleDateFormat furi_hal_rtc_get_locale_dateformat() {
 }
 
 void furi_hal_rtc_set_datetime(FuriHalRtcDateTime* datetime) {
+    furi_assert(!FURI_IS_IRQ_MODE());
     furi_assert(datetime);
 
+    FURI_CRITICAL_ENTER();
     /* Disable write protection */
     LL_RTC_DisableWriteProtection(RTC);
 
@@ -319,13 +321,17 @@ void furi_hal_rtc_set_datetime(FuriHalRtcDateTime* datetime) {
 
     /* Enable write protection */
     LL_RTC_EnableWriteProtection(RTC);
+    FURI_CRITICAL_EXIT();
 }
 
 void furi_hal_rtc_get_datetime(FuriHalRtcDateTime* datetime) {
+    furi_assert(!FURI_IS_IRQ_MODE());
     furi_assert(datetime);
 
+    FURI_CRITICAL_ENTER();
     uint32_t time = LL_RTC_TIME_Get(RTC); // 0x00HHMMSS
     uint32_t date = LL_RTC_DATE_Get(RTC); // 0xWWDDMMYY
+    FURI_CRITICAL_EXIT();
 
     datetime->second = __LL_RTC_CONVERT_BCD2BIN((time >> 0) & 0xFF);
     datetime->minute = __LL_RTC_CONVERT_BCD2BIN((time >> 8) & 0xFF);

--- a/firmware/targets/f7/furi_hal/furi_hal_rtc.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_rtc.c
@@ -281,7 +281,7 @@ FuriHalRtcLocaleDateFormat furi_hal_rtc_get_locale_dateformat() {
 }
 
 void furi_hal_rtc_set_datetime(FuriHalRtcDateTime* datetime) {
-    furi_assert(!FURI_IS_IRQ_MODE());
+    furi_check(!FURI_IS_IRQ_MODE());
     furi_assert(datetime);
 
     FURI_CRITICAL_ENTER();
@@ -325,7 +325,7 @@ void furi_hal_rtc_set_datetime(FuriHalRtcDateTime* datetime) {
 }
 
 void furi_hal_rtc_get_datetime(FuriHalRtcDateTime* datetime) {
-    furi_assert(!FURI_IS_IRQ_MODE());
+    furi_check(!FURI_IS_IRQ_MODE());
     furi_assert(datetime);
 
     FURI_CRITICAL_ENTER();

--- a/lib/fatfs/diskio.h
+++ b/lib/fatfs/diskio.h
@@ -37,7 +37,6 @@ DSTATUS disk_status (BYTE pdrv);
 DRESULT disk_read (BYTE pdrv, BYTE* buff, DWORD sector, UINT count);
 DRESULT disk_write (BYTE pdrv, const BYTE* buff, DWORD sector, UINT count);
 DRESULT disk_ioctl (BYTE pdrv, BYTE cmd, void* buff);
-DWORD get_fattime (void);
 
 /* Disk Status Bits (DSTATUS) */
 


### PR DESCRIPTION
# What's new

- fatfs: use rtc for timestamping

# Verification 

- Write files to SD-Card and check timestamps

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
