### PR TITLE
Bugfix:  ISP Programmer and SubGhz

### DIFF
--- a/applications/external/avr_isp_programmer/helpers/avr_isp.c
+++ b/applications/external/avr_isp_programmer/helpers/avr_isp.c
@@ -152,8 +152,12 @@ bool avr_isp_auto_set_spi_speed_start_pmode(AvrIsp* instance) {
             }
         }
     }
-    if(instance->spi) avr_isp_spi_sw_free(instance->spi);
-    instance->spi = NULL;
+
+    if(instance->spi) {
+        avr_isp_spi_sw_free(instance->spi);
+        instance->spi = NULL;
+    }
+
     return false;
 }
 

--- a/applications/external/avr_isp_programmer/helpers/avr_isp.c
+++ b/applications/external/avr_isp_programmer/helpers/avr_isp.c
@@ -153,6 +153,7 @@ bool avr_isp_auto_set_spi_speed_start_pmode(AvrIsp* instance) {
         }
     }
     if(instance->spi) avr_isp_spi_sw_free(instance->spi);
+    instance->spi = NULL;
     return false;
 }
 

--- a/applications/external/avr_isp_programmer/lib/driver/avr_isp_prog.c
+++ b/applications/external/avr_isp_programmer/lib/driver/avr_isp_prog.c
@@ -317,8 +317,12 @@ static bool avr_isp_prog_auto_set_spi_speed_start_pmode(AvrIspProg* instance) {
             }
         }
     }
-    if(instance->spi) avr_isp_spi_sw_free(instance->spi);
-    instance->spi = NULL;
+
+    if(instance->spi) {
+        avr_isp_spi_sw_free(instance->spi);
+        instance->spi = NULL;
+    }
+
     return false;
 }
 

--- a/applications/external/avr_isp_programmer/lib/driver/avr_isp_prog.c
+++ b/applications/external/avr_isp_programmer/lib/driver/avr_isp_prog.c
@@ -318,6 +318,7 @@ static bool avr_isp_prog_auto_set_spi_speed_start_pmode(AvrIspProg* instance) {
         }
     }
     if(instance->spi) avr_isp_spi_sw_free(instance->spi);
+    instance->spi = NULL;
     return false;
 }
 

--- a/applications/main/subghz/scenes/subghz_scene_read_raw.c
+++ b/applications/main/subghz/scenes/subghz_scene_read_raw.c
@@ -230,7 +230,11 @@ bool subghz_scene_read_raw_on_event(void* context, SceneManagerEvent event) {
                    (subghz->txrx->txrx_state == SubGhzTxRxStateSleep)) {
                     if(!subghz_tx_start(subghz, subghz->txrx->fff_data)) {
                         subghz->txrx->rx_key_state = SubGhzRxKeyStateBack;
-                        scene_manager_next_scene(subghz->scene_manager, SubGhzSceneShowOnlyRx);
+                        subghz_read_raw_set_status(
+                            subghz->subghz_read_raw,
+                            SubGhzReadRAWStatusIDLE,
+                            "",
+                            subghz->txrx->raw_threshold_rssi);
                     } else {
                         if(scene_manager_has_previous_scene(
                                subghz->scene_manager, SubGhzSceneSaved) ||

--- a/applications/main/subghz/scenes/subghz_scene_transmitter.c
+++ b/applications/main/subghz/scenes/subghz_scene_transmitter.c
@@ -70,9 +70,7 @@ bool subghz_scene_transmitter_on_event(void* context, SceneManagerEvent event) {
             }
             if((subghz->txrx->txrx_state == SubGhzTxRxStateIDLE) ||
                (subghz->txrx->txrx_state == SubGhzTxRxStateSleep)) {
-                if(!subghz_tx_start(subghz, subghz->txrx->fff_data)) {
-                    scene_manager_next_scene(subghz->scene_manager, SubGhzSceneShowOnlyRx);
-                } else {
+                if(subghz_tx_start(subghz, subghz->txrx->fff_data)) {
                     subghz->state_notifications = SubGhzNotificationStateTx;
                     subghz_scene_transmitter_update_data_show(subghz);
                     DOLPHIN_DEED(DolphinDeedSubGhzSend);

--- a/applications/main/subghz/subghz_i.c
+++ b/applications/main/subghz/subghz_i.c
@@ -105,9 +105,11 @@ static bool subghz_tx(SubGhz* subghz, uint32_t frequency) {
     furi_hal_subghz_set_frequency_and_path(frequency);
     furi_hal_gpio_write(&gpio_cc1101_g0, false);
     furi_hal_gpio_init(&gpio_cc1101_g0, GpioModeOutputPushPull, GpioPullNo, GpioSpeedLow);
-    subghz_speaker_on(subghz);
     bool ret = furi_hal_subghz_tx();
-    subghz->txrx->txrx_state = SubGhzTxRxStateTx;
+    if(ret) {
+        subghz_speaker_on(subghz);
+        subghz->txrx->txrx_state = SubGhzTxRxStateTx;
+    }
     return ret;
 }
 

--- a/applications/main/subghz/subghz_i.c
+++ b/applications/main/subghz/subghz_i.c
@@ -117,6 +117,7 @@ void subghz_idle(SubGhz* subghz) {
     furi_assert(subghz);
     furi_assert(subghz->txrx->txrx_state != SubGhzTxRxStateSleep);
     furi_hal_subghz_idle();
+    subghz_speaker_off(subghz);
     subghz->txrx->txrx_state = SubGhzTxRxStateIDLE;
 }
 

--- a/firmware/targets/f7/furi_hal/furi_hal_region.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_region.c
@@ -73,8 +73,7 @@ const FuriHalRegion furi_hal_region_jp = {
 static const FuriHalRegion* furi_hal_region = NULL;
 
 void furi_hal_region_init() {
-    FuriHalVersionRegion region = FuriHalVersionRegionJp;
-    //= furi_hal_version_get_hw_region();
+    FuriHalVersionRegion region = furi_hal_version_get_hw_region();
 
     if(region == FuriHalVersionRegionUnknown) {
         furi_hal_region = &furi_hal_region_zero;

--- a/firmware/targets/f7/furi_hal/furi_hal_region.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_region.c
@@ -73,7 +73,8 @@ const FuriHalRegion furi_hal_region_jp = {
 static const FuriHalRegion* furi_hal_region = NULL;
 
 void furi_hal_region_init() {
-    FuriHalVersionRegion region = furi_hal_version_get_hw_region();
+    FuriHalVersionRegion region = FuriHalVersionRegionJp;
+    //= furi_hal_version_get_hw_region();
 
     if(region == FuriHalVersionRegionUnknown) {
         furi_hal_region = &furi_hal_region_zero;


### PR DESCRIPTION
# What's new

- AVR_ISP: fix NULL pointer dereference
- SubGhz: double back with a blocked transmission in this region
- SubGhz: fix speacker, when a transmission is blocked in this region

# Verification 

- Verification according to 0.81.0-rc bug reports

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
