### PR TITLE
[#2589] Correctly aborts when correct key is found

### DIFF
--- a/applications/external/picopass/picopass_worker.c
+++ b/applications/external/picopass/picopass_worker.c
@@ -570,7 +570,7 @@ void picopass_worker_elite_dict_attack(PicopassWorker* picopass_worker) {
                 picopass_worker->callback(PicopassWorkerEventFail, picopass_worker->context);
                 break;
             }
-            picopass_worker->callback(PicopassWorkerEventSuccess, picopass_worker->context);
+            picopass_worker->callback(PicopassWorkerEventAborted, picopass_worker->context);
             break;
         }
 
@@ -596,6 +596,9 @@ int32_t picopass_worker_task(void* context) {
         picopass_worker_write_key(picopass_worker);
     } else if(picopass_worker->state == PicopassWorkerStateEliteDictAttack) {
         picopass_worker_elite_dict_attack(picopass_worker);
+    } else if(picopass_worker->state == PicopassWorkerStateStop) {
+        FURI_LOG_D(TAG, "Worker state stop");
+        // no-op
     } else {
         FURI_LOG_W(TAG, "Unknown state %d", picopass_worker->state);
     }

--- a/applications/external/picopass/scenes/picopass_scene_elite_dict_attack.c
+++ b/applications/external/picopass/scenes/picopass_scene_elite_dict_attack.c
@@ -116,8 +116,7 @@ bool picopass_scene_elite_dict_attack_on_event(void* context, SceneManagerEvent 
     uint32_t state =
         scene_manager_get_scene_state(picopass->scene_manager, PicopassSceneEliteDictAttack);
     if(event.type == SceneManagerEventTypeCustom) {
-        if(event.event == PicopassWorkerEventSuccess ||
-           event.event == PicopassWorkerEventAborted) {
+        if(event.event == PicopassWorkerEventSuccess) {
             if(state == DictAttackStateUserDictInProgress ||
                state == DictAttackStateStandardDictInProgress) {
                 picopass_worker_stop(picopass->worker);
@@ -127,6 +126,9 @@ bool picopass_scene_elite_dict_attack_on_event(void* context, SceneManagerEvent 
                 scene_manager_next_scene(picopass->scene_manager, PicopassSceneReadCardSuccess);
                 consumed = true;
             }
+        } else if(event.event == PicopassWorkerEventAborted) {
+            scene_manager_next_scene(picopass->scene_manager, PicopassSceneReadCardSuccess);
+            consumed = true;
         } else if(event.event == PicopassWorkerEventCardDetected) {
             dict_attack_set_card_detected(picopass->dict_attack);
             consumed = true;


### PR DESCRIPTION
# What's new

- Correctly aborts when correct key is found.
- Fixes https://github.com/flipperdevices/flipperzero-firmware/issues/2589

# Verification 

(all with the Elite Dict. Attack option)
- Try to read standard keyed card: success
- Try to read factory keyed card: success
- Try to read card with Standard iClass key, but using KDF (standard key added to user elite dictionary): success 

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
