### PR TITLE
[FL-3280] cubewb: downgraded to v1.15.0

### DIFF
--- a/fbt_options.py
+++ b/fbt_options.py
@@ -20,7 +20,7 @@ DIST_SUFFIX = "local"
 COPRO_OB_DATA = "scripts/ob.data"
 
 # Must match lib/STM32CubeWB version
-COPRO_CUBE_VERSION = "1.16.0"
+COPRO_CUBE_VERSION = "1.15.0"
 
 COPRO_CUBE_DIR = "lib/STM32CubeWB"
 

--- a/firmware/targets/f18/api_symbols.csv
+++ b/firmware/targets/f18/api_symbols.csv
@@ -199,8 +199,8 @@ Function,-,LL_EXTI_StructInit,void,LL_EXTI_InitTypeDef*
 Function,-,LL_GPIO_DeInit,ErrorStatus,GPIO_TypeDef*
 Function,+,LL_GPIO_Init,ErrorStatus,"GPIO_TypeDef*, LL_GPIO_InitTypeDef*"
 Function,-,LL_GPIO_StructInit,void,LL_GPIO_InitTypeDef*
-Function,-,LL_I2C_DeInit,ErrorStatus,const I2C_TypeDef*
-Function,+,LL_I2C_Init,ErrorStatus,"I2C_TypeDef*, const LL_I2C_InitTypeDef*"
+Function,-,LL_I2C_DeInit,ErrorStatus,I2C_TypeDef*
+Function,+,LL_I2C_Init,ErrorStatus,"I2C_TypeDef*, LL_I2C_InitTypeDef*"
 Function,-,LL_I2C_StructInit,void,LL_I2C_InitTypeDef*
 Function,-,LL_Init1msTick,void,uint32_t
 Function,+,LL_LPTIM_DeInit,ErrorStatus,LPTIM_TypeDef*

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -231,8 +231,8 @@ Function,-,LL_EXTI_StructInit,void,LL_EXTI_InitTypeDef*
 Function,-,LL_GPIO_DeInit,ErrorStatus,GPIO_TypeDef*
 Function,+,LL_GPIO_Init,ErrorStatus,"GPIO_TypeDef*, LL_GPIO_InitTypeDef*"
 Function,-,LL_GPIO_StructInit,void,LL_GPIO_InitTypeDef*
-Function,-,LL_I2C_DeInit,ErrorStatus,const I2C_TypeDef*
-Function,+,LL_I2C_Init,ErrorStatus,"I2C_TypeDef*, const LL_I2C_InitTypeDef*"
+Function,-,LL_I2C_DeInit,ErrorStatus,I2C_TypeDef*
+Function,+,LL_I2C_Init,ErrorStatus,"I2C_TypeDef*, LL_I2C_InitTypeDef*"
 Function,-,LL_I2C_StructInit,void,LL_I2C_InitTypeDef*
 Function,-,LL_Init1msTick,void,uint32_t
 Function,+,LL_LPTIM_DeInit,ErrorStatus,LPTIM_TypeDef*

--- a/firmware/targets/f7/ble_glue/ble_app.c
+++ b/firmware/targets/f7/ble_glue/ble_app.c
@@ -18,8 +18,8 @@ PLACE_IN_SECTION("MB_MEM1") ALIGN(4) static TL_CmdPacket_t ble_app_cmd_buffer;
 PLACE_IN_SECTION("MB_MEM2") ALIGN(4) static uint32_t ble_app_nvm[BLE_NVM_SRAM_SIZE];
 
 _Static_assert(
-    sizeof(SHCI_C2_Ble_Init_Cmd_Packet_t) == 58,
-    "Ble stack config structure size mismatch (check new config options - last updated for v.1.16.0)");
+    sizeof(SHCI_C2_Ble_Init_Cmd_Packet_t) == 57,
+    "Ble stack config structure size mismatch (check new config options - last updated for v.1.15.0)");
 
 typedef struct {
     FuriMutex* hci_mtx;

--- a/firmware/targets/f7/furi_hal/furi_hal_flash.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_flash.c
@@ -27,6 +27,16 @@
 #define FURI_HAL_FLASH_OPT_KEY2 0x4C5D6E7F
 #define FURI_HAL_FLASH_OB_TOTAL_WORDS (0x80 / (sizeof(uint32_t) * 2))
 
+/* lib/STM32CubeWB/Projects/P-NUCLEO-WB55.Nucleo/Applications/BLE/BLE_RfWithFlash/Core/Src/flash_driver.c
+ * ProcessSingleFlashOperation, quote:
+  > In most BLE application, the flash should not be blocked by the CPU2 longer than FLASH_TIMEOUT_VALUE (1000ms)
+  > However, it could be that for some marginal application, this time is longer.
+  > ... there is no other way than waiting the operation to be completed.
+  > If for any reason this test is never passed, this means there is a failure in the system and there is no other
+  > way to recover than applying a device reset. 
+ */
+#define FURI_HAL_FLASH_C2_LOCK_TIMEOUT_MS 3000u /* 3 seconds */
+
 #define IS_ADDR_ALIGNED_64BITS(__VALUE__) (((__VALUE__)&0x7U) == (0x00UL))
 #define IS_FLASH_PROGRAM_ADDRESS(__VALUE__)                                             \
     (((__VALUE__) >= FLASH_BASE) && ((__VALUE__) <= (FLASH_BASE + FLASH_SIZE - 8UL)) && \
@@ -132,9 +142,11 @@ static void furi_hal_flash_begin_with_core2(bool erase_flag) {
     for(volatile uint32_t i = 0; i < 35; i++)
         ;
 
+    FuriHalCortexTimer timer = furi_hal_cortex_timer_get(FURI_HAL_FLASH_C2_LOCK_TIMEOUT_MS * 1000);
     while(true) {
         /* Wait till flash controller become usable */
         while(LL_FLASH_IsActiveFlag_OperationSuspended()) {
+            furi_check(!furi_hal_cortex_timer_is_expired(timer));
             furi_thread_yield();
         };
 
@@ -144,6 +156,7 @@ static void furi_hal_flash_begin_with_core2(bool erase_flag) {
         /* Actually we already have mutex for it, but specification is specification  */
         if(LL_HSEM_IsSemaphoreLocked(HSEM, CFG_HW_BLOCK_FLASH_REQ_BY_CPU1_SEMID)) {
             taskEXIT_CRITICAL();
+            furi_check(!furi_hal_cortex_timer_is_expired(timer));
             furi_thread_yield();
             continue;
         }
@@ -151,6 +164,7 @@ static void furi_hal_flash_begin_with_core2(bool erase_flag) {
         /* Take sempahopre and prevent core2 from anything funky */
         if(LL_HSEM_1StepLock(HSEM, CFG_HW_BLOCK_FLASH_REQ_BY_CPU2_SEMID) != 0) {
             taskEXIT_CRITICAL();
+            furi_check(!furi_hal_cortex_timer_is_expired(timer));
             furi_thread_yield();
             continue;
         }
@@ -237,7 +251,6 @@ bool furi_hal_flash_wait_last_operation(uint32_t timeout) {
        Even if the FLASH operation fails, the BUSY flag will be reset and an error
        flag will be set */
     FuriHalCortexTimer timer = furi_hal_cortex_timer_get(timeout * 1000);
-
     while(READ_BIT(FLASH->SR, FLASH_SR_BSY)) {
         if(furi_hal_cortex_timer_is_expired(timer)) {
             return false;
@@ -263,7 +276,6 @@ bool furi_hal_flash_wait_last_operation(uint32_t timeout) {
 
     /* Wait for control register to be written */
     timer = furi_hal_cortex_timer_get(timeout * 1000);
-
     while(READ_BIT(FLASH->SR, FLASH_SR_CFGBSY)) {
         if(furi_hal_cortex_timer_is_expired(timer)) {
             return false;

--- a/firmware/targets/f7/furi_hal/furi_hal_gpio.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_gpio.c
@@ -178,10 +178,13 @@ void furi_hal_gpio_add_int_callback(const GpioPin* gpio, GpioExtiCallback cb, vo
 
     FURI_CRITICAL_ENTER();
     uint8_t pin_num = furi_hal_gpio_get_pin_num(gpio);
-    furi_check(gpio_interrupt[pin_num].callback == NULL);
-    gpio_interrupt[pin_num].callback = cb;
-    gpio_interrupt[pin_num].context = ctx;
-    gpio_interrupt[pin_num].ready = true;
+    volatile GpioInterrupt* interrupt = &gpio_interrupt[pin_num];
+    furi_check(
+        (interrupt->callback == NULL) ||
+        ((interrupt->callback == cb) && (interrupt->context == ctx)));
+    interrupt->callback = cb;
+    interrupt->context = ctx;
+    interrupt->ready = true;
     FURI_CRITICAL_EXIT();
 }
 

--- a/firmware/targets/f7/furi_hal/furi_hal_gpio.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_gpio.c
@@ -178,13 +178,10 @@ void furi_hal_gpio_add_int_callback(const GpioPin* gpio, GpioExtiCallback cb, vo
 
     FURI_CRITICAL_ENTER();
     uint8_t pin_num = furi_hal_gpio_get_pin_num(gpio);
-    volatile GpioInterrupt* interrupt = &gpio_interrupt[pin_num];
-    furi_check(
-        (interrupt->callback == NULL) ||
-        ((interrupt->callback == cb) && (interrupt->context == ctx)));
-    interrupt->callback = cb;
-    interrupt->context = ctx;
-    interrupt->ready = true;
+    furi_check(gpio_interrupt[pin_num].callback == NULL);
+    gpio_interrupt[pin_num].callback = cb;
+    gpio_interrupt[pin_num].context = ctx;
+    gpio_interrupt[pin_num].ready = true;
     FURI_CRITICAL_EXIT();
 }
 

--- a/lib/ST25RFAL002/platform.c
+++ b/lib/ST25RFAL002/platform.c
@@ -52,12 +52,12 @@ void platformSetIrqCallback(PlatformIrqCallback callback) {
         furi_thread_mark_as_service(rfal_platform.thread);
         furi_thread_set_priority(rfal_platform.thread, FuriThreadPriorityIsr);
         furi_thread_start(rfal_platform.thread);
-
-        furi_hal_gpio_add_int_callback(&gpio_nfc_irq_rfid_pull, nfc_isr, NULL);
-        // Disable interrupt callback as the pin is shared between 2 apps
-        // It is enabled in rfalLowPowerModeStop()
-        furi_hal_gpio_disable_int_callback(&gpio_nfc_irq_rfid_pull);
     }
+
+    furi_hal_gpio_add_int_callback(&gpio_nfc_irq_rfid_pull, nfc_isr, NULL);
+    // Disable interrupt callback as the pin is shared between 2 apps
+    // It is enabled in rfalLowPowerModeStop()
+    furi_hal_gpio_disable_int_callback(&gpio_nfc_irq_rfid_pull);
 }
 
 bool platformSpiTxRx(const uint8_t* txBuf, uint8_t* rxBuf, uint16_t len) {

--- a/lib/ST25RFAL002/platform.c
+++ b/lib/ST25RFAL002/platform.c
@@ -52,12 +52,12 @@ void platformSetIrqCallback(PlatformIrqCallback callback) {
         furi_thread_mark_as_service(rfal_platform.thread);
         furi_thread_set_priority(rfal_platform.thread, FuriThreadPriorityIsr);
         furi_thread_start(rfal_platform.thread);
-    }
 
-    furi_hal_gpio_add_int_callback(&gpio_nfc_irq_rfid_pull, nfc_isr, NULL);
-    // Disable interrupt callback as the pin is shared between 2 apps
-    // It is enabled in rfalLowPowerModeStop()
-    furi_hal_gpio_disable_int_callback(&gpio_nfc_irq_rfid_pull);
+        furi_hal_gpio_add_int_callback(&gpio_nfc_irq_rfid_pull, nfc_isr, NULL);
+        // Disable interrupt callback as the pin is shared between 2 apps
+        // It is enabled in rfalLowPowerModeStop()
+        furi_hal_gpio_disable_int_callback(&gpio_nfc_irq_rfid_pull);
+    }
 }
 
 bool platformSpiTxRx(const uint8_t* txBuf, uint8_t* rxBuf, uint16_t len) {

--- a/scripts/fbt_tools/fbt_dist.py
+++ b/scripts/fbt_tools/fbt_dist.py
@@ -112,6 +112,8 @@ def DistCommand(env, name, source, **kw):
 
 
 def generate(env):
+    if not env["VERBOSE"]:
+        env.SetDefault(COPROCOMSTR="\tCOPRO\t${TARGET}")
     env.AddMethod(AddFwProject)
     env.AddMethod(DistCommand)
     env.AddMethod(AddOpenOCDFlashTarget)
@@ -147,7 +149,7 @@ def generate(env):
                         '--stack_file="${COPRO_STACK_BIN}" '
                         "--stack_addr=${COPRO_STACK_ADDR} ",
                     ],
-                    "\tCOPRO\t${TARGET}",
+                    "$COPROCOMSTR",
                 )
             ),
         }

--- a/scripts/flipper/assets/copro.py
+++ b/scripts/flipper/assets/copro.py
@@ -34,7 +34,7 @@ class Copro:
         self.mcu_copro = None
         self.logger = logging.getLogger(self.__class__.__name__)
 
-    def loadCubeInfo(self, cube_dir, cube_version):
+    def loadCubeInfo(self, cube_dir, reference_cube_version):
         if not os.path.isdir(cube_dir):
             raise Exception(f'"{cube_dir}" doesn\'t exists')
         self.cube_dir = cube_dir
@@ -50,7 +50,7 @@ class Copro:
         if not cube_version or not cube_version.startswith("FW.WB"):
             raise Exception(f"Incorrect Cube package or version info")
         cube_version = cube_version.replace("FW.WB.", "", 1)
-        if cube_version != cube_version:
+        if cube_version != reference_cube_version:
             raise Exception(f"Unsupported cube version")
         self.version = cube_version
 

--- a/scripts/flipper/storage.py
+++ b/scripts/flipper/storage.py
@@ -335,7 +335,9 @@ class FlipperStorage:
 
     def _check_no_error(self, response, path=None):
         if self.has_error(response):
-            raise FlipperStorageException.from_error_code(self.get_error(response))
+            raise FlipperStorageException.from_error_code(
+                path, self.get_error(response)
+            )
 
     def size(self, path: str):
         """file size on Flipper"""


### PR DESCRIPTION
# What's new

- [FL-3280] cubewb: downgraded to v1.15.0 
- now triggering system reset if timing out of 3s while waiting for C2 to release flash controller
- changed flash ops timeout calculation to furi_hal_cortex_timer
- fixed cube submodule version validation code
- ~~nfc: fixed missing interrupt setup on multiple platformSetIrqCallback() invocations (caused broken NFC when other app re-initialized an interrupt on any other port's pin 2)~~

# Verification 

- Tricky RFAL testcase
- General stability should be much better than on v1.16.0

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-3280]: https://flipperzero.atlassian.net/browse/FL-3280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ