### PR TITLE
[FL-3286] Don't reboot on crash in debug builds

### DIFF
--- a/furi/core/check.c
+++ b/furi/core/check.c
@@ -121,9 +121,9 @@ FURI_NORETURN void __furi_crash() {
 
     if(__furi_check_message == NULL) {
         __furi_check_message = "Fatal Error";
-    } else if(__furi_check_message == (void*)__furi_assert_message_flag) {
+    } else if(__furi_check_message == (void*)__FURI_ASSERT_MESSAGE_FLAG) {
         __furi_check_message = "furi_assert failed";
-    } else if(__furi_check_message == (void*)__furi_check_message_flag) {
+    } else if(__furi_check_message == (void*)__FURI_CHECK_MESSAGE_FLAG) {
         __furi_check_message = "furi_check failed";
     }
 

--- a/furi/core/check.c
+++ b/furi/core/check.c
@@ -69,7 +69,7 @@ static void __furi_put_uint32_as_hex(uint32_t data) {
     furi_hal_console_puts(tmp_str);
 }
 
-static void __furi_print_stack_and_register_info() {
+static void __furi_print_register_info() {
     // Print registers
     for(uint8_t i = 0; i < 12; i++) {
         furi_hal_console_puts("\r\n\tr");
@@ -80,6 +80,9 @@ static void __furi_print_stack_and_register_info() {
 
     furi_hal_console_puts("\r\n\tlr : ");
     __furi_put_uint32_as_hex(__furi_check_registers[12]);
+}
+
+static void __furi_print_stack_info() {
     furi_hal_console_puts("\r\n\tstack watermark: ");
     __furi_put_uint32_as_text(uxTaskGetStackHighWaterMark(NULL) * 4);
 }
@@ -118,14 +121,19 @@ FURI_NORETURN void __furi_crash() {
 
     if(__furi_check_message == NULL) {
         __furi_check_message = "Fatal Error";
+    } else if(__furi_check_message == (void*)__furi_assert_message_flag) {
+        __furi_check_message = "furi_assert failed";
+    } else if(__furi_check_message == (void*)__furi_check_message_flag) {
+        __furi_check_message = "furi_check failed";
     }
 
     furi_hal_console_puts("\r\n\033[0;31m[CRASH]");
     __furi_print_name(isr);
     furi_hal_console_puts(__furi_check_message);
 
+    __furi_print_register_info();
     if(!isr) {
-        __furi_print_stack_and_register_info();
+        __furi_print_stack_info();
     }
     __furi_print_heap_info();
 

--- a/furi/core/check.c
+++ b/furi/core/check.c
@@ -112,21 +112,25 @@ FURI_NORETURN void __furi_crash() {
     }
     __furi_print_heap_info();
 
+#ifndef FURI_DEBUG
     // Check if debug enabled by DAP
     // https://developer.arm.com/documentation/ddi0403/d/Debug-Architecture/ARMv7-M-Debug/Debug-register-support-in-the-SCS/Debug-Halting-Control-and-Status-Register--DHCSR?lang=en
     bool debug = CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk;
     if(debug) {
+#endif
         furi_hal_console_puts("\r\nSystem halted. Connect debugger for more info\r\n");
         furi_hal_console_puts("\033[0m\r\n");
         furi_hal_debug_enable();
 
         RESTORE_REGISTERS_AND_HALT_MCU(true);
+#ifndef FURI_DEBUG
     } else {
         furi_hal_rtc_set_fault_data((uint32_t)__furi_check_message);
         furi_hal_console_puts("\r\nRebooting system.\r\n");
         furi_hal_console_puts("\033[0m\r\n");
         furi_hal_power_reset();
     }
+#endif
     __builtin_unreachable();
 }
 

--- a/furi/core/check.h
+++ b/furi/core/check.h
@@ -21,8 +21,9 @@ extern "C" {
 #define FURI_NORETURN noreturn
 #endif
 
-#define __furi_assert_message_flag 1
-#define __furi_check_message_flag 2
+// Flags instead of pointers will save ~4 bytes on furi_assert and furi_check calls.
+#define __FURI_ASSERT_MESSAGE_FLAG (0x01)
+#define __FURI_CHECK_MESSAGE_FLAG (0x02)
 
 /** Crash system */
 FURI_NORETURN void __furi_crash();
@@ -50,7 +51,7 @@ FURI_NORETURN void __furi_halt();
 #define furi_check(__e)                             \
     do {                                            \
         if(!(__e)) {                                \
-            furi_crash(__furi_assert_message_flag); \
+            furi_crash(__FURI_ASSERT_MESSAGE_FLAG); \
         }                                           \
     } while(0)
 
@@ -59,7 +60,7 @@ FURI_NORETURN void __furi_halt();
 #define furi_assert(__e)                           \
     do {                                           \
         if(!(__e)) {                               \
-            furi_crash(__furi_check_message_flag); \
+            furi_crash(__FURI_CHECK_MESSAGE_FLAG); \
         }                                          \
     } while(0)
 #else

--- a/furi/core/check.h
+++ b/furi/core/check.h
@@ -21,6 +21,9 @@ extern "C" {
 #define FURI_NORETURN noreturn
 #endif
 
+#define __furi_assert_message_flag 1
+#define __furi_check_message_flag 2
+
 /** Crash system */
 FURI_NORETURN void __furi_crash();
 
@@ -44,20 +47,20 @@ FURI_NORETURN void __furi_halt();
     } while(0)
 
 /** Check condition and crash if check failed */
-#define furi_check(__e)                          \
-    do {                                         \
-        if(!(__e)) {                             \
-            furi_crash("furi_check failed\r\n"); \
-        }                                        \
+#define furi_check(__e)                             \
+    do {                                            \
+        if(!(__e)) {                                \
+            furi_crash(__furi_assert_message_flag); \
+        }                                           \
     } while(0)
 
 /** Only in debug build: Assert condition and crash if assert failed  */
 #ifdef FURI_DEBUG
-#define furi_assert(__e)                          \
-    do {                                          \
-        if(!(__e)) {                              \
-            furi_crash("furi_assert failed\r\n"); \
-        }                                         \
+#define furi_assert(__e)                           \
+    do {                                           \
+        if(!(__e)) {                               \
+            furi_crash(__furi_check_message_flag); \
+        }                                          \
     } while(0)
 #else
 #define furi_assert(__e) \


### PR DESCRIPTION
# What's new

- [FL-3286] furi: never reboot on furi_crash in debug builds

# Verification 

- Trigger assert/check in debug build with debug off

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-3286]: https://flipperzero.atlassian.net/browse/FL-3286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ