### PR TITLE
Fix core2 crash in stop mode when clocked too slow

### DIFF
--- a/firmware/targets/f7/ble_glue/ble_app.c
+++ b/firmware/targets/f7/ble_glue/ble_app.c
@@ -88,7 +88,7 @@ bool ble_app_init() {
             .min_tx_power = 0,
             .max_tx_power = 0,
             .rx_model_config = 1,
-            /* New stack (13.3->16.0)*/
+            /* New stack (13.3->15.0) */
             .max_adv_set_nbr = 1, // Only used if SHCI_C2_BLE_INIT_OPTIONS_EXT_ADV is set
             .max_adv_data_len = 31, // Only used if SHCI_C2_BLE_INIT_OPTIONS_EXT_ADV is set
             .tx_path_compens = 0, // RF TX Path Compensation, * 0.1 dB

--- a/firmware/targets/f7/furi_hal/furi_hal_bt.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_bt.c
@@ -84,9 +84,7 @@ void furi_hal_bt_init() {
     }
 
     // Explicitly tell that we are in charge of CLK48 domain
-    if(!LL_HSEM_IsSemaphoreLocked(HSEM, CFG_HW_CLK48_CONFIG_SEMID)) {
-        furi_check(LL_HSEM_1StepLock(HSEM, CFG_HW_CLK48_CONFIG_SEMID) == 0);
-    }
+    furi_check(LL_HSEM_1StepLock(HSEM, CFG_HW_CLK48_CONFIG_SEMID) == 0);
 
     // Start Core2
     ble_glue_init();
@@ -129,9 +127,7 @@ bool furi_hal_bt_start_radio_stack() {
     furi_mutex_acquire(furi_hal_bt_core2_mtx, FuriWaitForever);
 
     // Explicitly tell that we are in charge of CLK48 domain
-    if(!LL_HSEM_IsSemaphoreLocked(HSEM, CFG_HW_CLK48_CONFIG_SEMID)) {
-        furi_check(LL_HSEM_1StepLock(HSEM, CFG_HW_CLK48_CONFIG_SEMID) == 0);
-    }
+    furi_check(LL_HSEM_1StepLock(HSEM, CFG_HW_CLK48_CONFIG_SEMID) == 0);
 
     do {
         // Wait until C2 is started or timeout

--- a/firmware/targets/f7/furi_hal/furi_hal_clock.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_clock.c
@@ -213,7 +213,11 @@ void furi_hal_clock_switch_to_hsi() {
     while(LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_HSI)
         ;
 
-    LL_FLASH_SetLatency(LL_FLASH_LATENCY_1);
+    LL_C2_RCC_SetAHBPrescaler(LL_RCC_SYSCLK_DIV_1);
+
+    LL_FLASH_SetLatency(LL_FLASH_LATENCY_0);
+    while(LL_FLASH_GetLatency() != LL_FLASH_LATENCY_0)
+        ;
 }
 
 void furi_hal_clock_switch_to_pll() {
@@ -228,7 +232,11 @@ void furi_hal_clock_switch_to_pll() {
     while(!LL_RCC_PLLSAI1_IsReady())
         ;
 
+    LL_C2_RCC_SetAHBPrescaler(LL_RCC_SYSCLK_DIV_2);
+
     LL_FLASH_SetLatency(LL_FLASH_LATENCY_3);
+    while(LL_FLASH_GetLatency() != LL_FLASH_LATENCY_3)
+        ;
 
     LL_RCC_SetSysClkSource(LL_RCC_SYS_CLKSOURCE_PLL);
     LL_RCC_SetSMPSClockSource(LL_RCC_SMPS_CLKSOURCE_HSE);

--- a/firmware/targets/f7/furi_hal/furi_hal_power.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_power.c
@@ -29,10 +29,6 @@
 #define FURI_HAL_POWER_DEBUG_STOP_GPIO (&gpio_ext_pc3)
 #endif
 
-#ifndef FURI_HAL_POWER_DEBUG_ABNORMAL_GPIO
-#define FURI_HAL_POWER_DEBUG_ABNORMAL_GPIO (&gpio_ext_pb3)
-#endif
-
 #ifndef FURI_HAL_POWER_STOP_MODE
 #define FURI_HAL_POWER_STOP_MODE (LL_PWR_MODE_STOP2)
 #endif
@@ -92,10 +88,8 @@ void furi_hal_power_init() {
 #ifdef FURI_HAL_POWER_DEBUG
     furi_hal_gpio_init_simple(FURI_HAL_POWER_DEBUG_WFI_GPIO, GpioModeOutputPushPull);
     furi_hal_gpio_init_simple(FURI_HAL_POWER_DEBUG_STOP_GPIO, GpioModeOutputPushPull);
-    furi_hal_gpio_init_simple(FURI_HAL_POWER_DEBUG_ABNORMAL_GPIO, GpioModeOutputPushPull);
     furi_hal_gpio_write(FURI_HAL_POWER_DEBUG_WFI_GPIO, 0);
     furi_hal_gpio_write(FURI_HAL_POWER_DEBUG_STOP_GPIO, 0);
-    furi_hal_gpio_write(FURI_HAL_POWER_DEBUG_ABNORMAL_GPIO, 0);
 #endif
 
     LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
@@ -158,9 +152,7 @@ bool furi_hal_power_sleep_available() {
 
 static inline bool furi_hal_power_deep_sleep_available() {
     return furi_hal_bt_is_alive() && !furi_hal_rtc_is_flag_set(FuriHalRtcFlagLegacySleep) &&
-           !furi_hal_debug_is_gdb_session_active() && !LL_PWR_IsActiveFlag_CRPE() &&
-           !LL_PWR_IsActiveFlag_CRP() && !LL_PWR_IsActiveFlag_BLEA() &&
-           !LL_PWR_IsActiveFlag_BLEWU();
+           !furi_hal_debug_is_gdb_session_active();
 }
 
 static inline void furi_hal_power_light_sleep() {
@@ -211,16 +203,7 @@ static inline void furi_hal_power_deep_sleep() {
     __force_stores();
 #endif
 
-    bool should_abort_sleep = LL_PWR_IsActiveFlag_CRPE() || LL_PWR_IsActiveFlag_CRP() ||
-                              LL_PWR_IsActiveFlag_BLEA() || LL_PWR_IsActiveFlag_BLEWU();
-
-    if(should_abort_sleep) {
-#ifdef FURI_HAL_POWER_DEBUG
-        furi_hal_gpio_write(FURI_HAL_POWER_DEBUG_ABNORMAL_GPIO, 1);
-#endif
-    } else {
-        __WFI();
-    }
+    __WFI();
 
     LL_LPM_EnableSleep();
 

--- a/furi/core/check.h
+++ b/furi/core/check.h
@@ -48,20 +48,20 @@ FURI_NORETURN void __furi_halt();
     } while(0)
 
 /** Check condition and crash if check failed */
-#define furi_check(__e)                             \
-    do {                                            \
-        if(!(__e)) {                                \
-            furi_crash(__FURI_ASSERT_MESSAGE_FLAG); \
-        }                                           \
-    } while(0)
-
-/** Only in debug build: Assert condition and crash if assert failed  */
-#ifdef FURI_DEBUG
-#define furi_assert(__e)                           \
+#define furi_check(__e)                            \
     do {                                           \
         if(!(__e)) {                               \
             furi_crash(__FURI_CHECK_MESSAGE_FLAG); \
         }                                          \
+    } while(0)
+
+/** Only in debug build: Assert condition and crash if assert failed  */
+#ifdef FURI_DEBUG
+#define furi_assert(__e)                            \
+    do {                                            \
+        if(!(__e)) {                                \
+            furi_crash(__FURI_ASSERT_MESSAGE_FLAG); \
+        }                                           \
     } while(0)
 #else
 #define furi_assert(__e) \


### PR DESCRIPTION
# What's new

- FuriHal: use proper divider for core2 when transition to sleep, remove extra stop mode transition checks, cleanup code
- Furi: proper assert and check messages

# Verification 

- Using attached patch ensure that core2 is not crashing anymore
- Check everything else, couple times

```
diff --git a/firmware/targets/f7/ble_glue/gap.c b/firmware/targets/f7/ble_glue/gap.c
index f0a9ced3c..49e57f5cd 100644
--- a/firmware/targets/f7/ble_glue/gap.c
+++ b/firmware/targets/f7/ble_glue/gap.c
@@ -410,7 +410,7 @@ static void gap_advertise_start(GapState new_state) {
     gap->state = new_state;
     GapEvent event = {.type = GapEventTypeStartAdvertising};
     gap->on_event_cb(event, gap->context);
-    furi_timer_start(gap->advertise_timer, INITIAL_ADV_TIMEOUT);
+    furi_timer_start(gap->advertise_timer, 15);
 }
 ```

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
