### PR TITLE
Keep HSI16 working in stop mode

### DIFF
--- a/firmware/targets/f7/furi_hal/furi_hal_clock.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_clock.c
@@ -144,6 +144,7 @@ void furi_hal_clock_init() {
     LL_RCC_SetRNGClockSource(LL_RCC_RNG_CLKSOURCE_CLK48);
     LL_RCC_SetUSBClockSource(LL_RCC_USB_CLKSOURCE_PLLSAI1);
     LL_RCC_SetCLK48ClockSource(LL_RCC_CLK48_CLKSOURCE_PLLSAI1);
+    LL_RCC_HSI_EnableInStopMode(); // Ensure that MR is capable of work in STOP0
     LL_RCC_SetSMPSClockSource(LL_RCC_SMPS_CLKSOURCE_HSE);
     LL_RCC_SetSMPSPrescaler(LL_RCC_SMPS_DIV_1);
     LL_RCC_SetRFWKPClockSource(LL_RCC_RFWKP_CLKSOURCE_LSE);
@@ -207,8 +208,8 @@ void furi_hal_clock_switch_to_hsi() {
     while(!LL_RCC_HSI_IsReady())
         ;
 
-    LL_RCC_SetSysClkSource(LL_RCC_SYS_CLKSOURCE_HSI);
     LL_RCC_SetSMPSClockSource(LL_RCC_SMPS_CLKSOURCE_HSI);
+    LL_RCC_SetSysClkSource(LL_RCC_SYS_CLKSOURCE_HSI);
 
     while(LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_HSI)
         ;

--- a/firmware/targets/f7/furi_hal/furi_hal_power.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_power.c
@@ -94,6 +94,7 @@ void furi_hal_power_init() {
 
     LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
     LL_PWR_SMPS_SetMode(LL_PWR_SMPS_STEP_DOWN);
+
     LL_PWR_SetPowerMode(FURI_HAL_POWER_STOP_MODE);
     LL_C2_PWR_SetPowerMode(FURI_HAL_POWER_STOP_MODE);
 


### PR DESCRIPTION
# What's new

- Keep HSI16 working in stop mode.

# Verification 

- Check that firmware with debug off and `--extra-define=FURI_HAL_POWER_STOP_MODE=LL_PWR_MODE_STOP0` is working correctly

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
