### PR TITLE
Disable ci/cd on release* branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev
-      - "release*"
     tags:
       - '*'
   pull_request:
@@ -19,7 +18,7 @@ jobs:
     runs-on: [self-hosted,FlipperZeroShell]
     steps:
       - name: 'Wipe workspace'
-        run: find ./ -mount -maxdepth 1 -exec rm -rf {} \; 
+        run: find ./ -mount -maxdepth 1 -exec rm -rf {} \;
 
       - name: 'Checkout code'
         uses: actions/checkout@v3
@@ -167,7 +166,7 @@ jobs:
         target: [f7, f18]
     steps:
       - name: 'Wipe workspace'
-        run: find ./ -mount -maxdepth 1 -exec rm -rf {} \; 
+        run: find ./ -mount -maxdepth 1 -exec rm -rf {} \;
 
       - name: 'Checkout code'
         uses: actions/checkout@v3
@@ -207,7 +206,7 @@ jobs:
           cd testapp
           ufbt create APPID=testapp
           ufbt
-      
+
       - name: Build example & external apps with uFBT
         run: |
           for appdir in 'applications/external' 'applications/examples'; do

--- a/.github/workflows/lint_and_submodule_check.yml
+++ b/.github/workflows/lint_and_submodule_check.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev
-      - "release*"
     tags:
       - '*'
   pull_request:
@@ -19,7 +18,7 @@ jobs:
     runs-on: [self-hosted,FlipperZeroShell]
     steps:
       - name: 'Wipe workspace'
-        run: find ./ -mount -maxdepth 1 -exec rm -rf {} \; 
+        run: find ./ -mount -maxdepth 1 -exec rm -rf {} \;
 
       - name: 'Checkout code'
         uses: actions/checkout@v3
@@ -64,7 +63,7 @@ jobs:
           else
             echo "Python Lint: all good ✨" >> $GITHUB_STEP_SUMMARY;
           fi
-  
+
       - name: 'Check C++ code formatting'
         id: syntax_check_cpp
         if: always()

--- a/.github/workflows/merge_report.yml
+++ b/.github/workflows/merge_report.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [self-hosted,FlipperZeroShell]
     steps:
       - name: 'Wipe workspace'
-        run: find ./ -mount -maxdepth 1 -exec rm -rf {} \; 
+        run: find ./ -mount -maxdepth 1 -exec rm -rf {} \;
 
       - name: 'Checkout code'
         uses: actions/checkout@v3

--- a/.github/workflows/pvs_studio.yml
+++ b/.github/workflows/pvs_studio.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev
-      - "release*"
     tags:
       - '*'
   pull_request:
@@ -20,7 +19,7 @@ jobs:
     runs-on: [self-hosted, FlipperZeroShell]
     steps:
       - name: 'Wipe workspace'
-        run: find ./ -mount -maxdepth 1 -exec rm -rf {} \; 
+        run: find ./ -mount -maxdepth 1 -exec rm -rf {} \;
 
       - name: 'Checkout code'
         uses: actions/checkout@v3

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [self-hosted, FlipperZeroUnitTest]
     steps:
       - name: 'Wipe workspace'
-        run: find ./ -mount -maxdepth 1 -exec rm -rf {} \; 
+        run: find ./ -mount -maxdepth 1 -exec rm -rf {} \;
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/updater_test.yml
+++ b/.github/workflows/updater_test.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: [self-hosted, FlipperZeroUpdaterTest]
     steps:
       - name: 'Wipe workspace'
-        run: find ./ -mount -maxdepth 1 -exec rm -rf {} \; 
+        run: find ./ -mount -maxdepth 1 -exec rm -rf {} \;
 
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-          submodules: false          
+          submodules: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: 'Get flipper from device manager (mock)'
@@ -50,7 +50,7 @@ jobs:
           echo "tag=$(git tag -l --sort=-version:refname | grep -v "rc\|RC" | head -1)" >> $GITHUB_OUTPUT
 
       - name: 'Wipe workspace'
-        run: find ./ -mount -maxdepth 1 -exec rm -rf {} \; 
+        run: find ./ -mount -maxdepth 1 -exec rm -rf {} \;
 
       - name: 'Checkout latest release'
         uses: actions/checkout@v3


### PR DESCRIPTION
# What's new

- Disable ci/cd on release* branches

# Verification 

- Workflows should not be triggered on push to release* branches

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
