### PR TITLE
unit bench timeout increase

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,6 +35,7 @@ jobs:
       - name: 'Wait for flipper and format ext'
         id: format_ext
         if: steps.flashing.outcome == 'success'
+        timeout-minutes: 5
         run: |
           source scripts/toolchain/fbtenv.sh
           python3 scripts/testing/await_flipper.py ${{steps.device.outputs.flipper}}
@@ -43,6 +44,7 @@ jobs:
       - name: 'Copy assets and unit data, reboot and wait for flipper'
         id: copy
         if: steps.format_ext.outcome == 'success'
+        timeout-minutes: 5
         run: |
           source scripts/toolchain/fbtenv.sh
           python3 scripts/storage.py -p ${{steps.device.outputs.flipper}} -f send assets/resources /ext
@@ -53,7 +55,7 @@ jobs:
       - name: 'Run units and validate results'
         id: run_units
         if: steps.copy.outcome == 'success'
-        timeout-minutes: 2.5
+        timeout-minutes: 5
         run: |
           source scripts/toolchain/fbtenv.sh
           python3 scripts/testing/units.py ${{steps.device.outputs.flipper}}


### PR DESCRIPTION
# What's new

Increased timeout on steps and added timeout for copy and format as a temporary measure, device manager will be permanent fix

# Verification 

Unit tests like https://github.com/flipperdevices/flipperzero-firmware/actions/runs/4867732839 pass without freezing

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
