### PR TITLE
Fix storage.py exist_dir logic

### DIFF
--- a/scripts/flipper/storage.py
+++ b/scripts/flipper/storage.py
@@ -323,7 +323,7 @@ class FlipperStorage:
                 return False
             raise FlipperStorageException.from_error_code(path, error_code)
 
-        return True
+        return response == b"Directory"
 
     def exist_file(self, path: str):
         """Does file exist on Flipper"""

--- a/scripts/flipper/storage.py
+++ b/scripts/flipper/storage.py
@@ -323,7 +323,7 @@ class FlipperStorage:
                 return False
             raise FlipperStorageException.from_error_code(path, error_code)
 
-        return response == b"Directory"
+        return response == b"Directory" or response.startswith(b"Storage")
 
     def exist_file(self, path: str):
         """Does file exist on Flipper"""


### PR DESCRIPTION
# What's new

- The method `exist_dir` would return true if the given path existed as either a directory or a file, which is what the plain `exist` method is for. This led to issues when trying to receive files via storage.py.

# Verification 

- Confirm that receiving a single file via `storage.py receive` does not work on dev (receiving a full directory should work fine)
- Confirm that receiving a single file via `storage.py receive` does work on this PR (receiving a full directory should also still work)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
