### PR TITLE
[FL-3300] API version in UI

### DIFF
--- a/.vscode/example/launch.json
+++ b/.vscode/example/launch.json
@@ -11,11 +11,10 @@
             "args": {
                 "useSingleResult": true,
                 "env": {
-                    "PATH": "${workspaceFolder};${env:PATH}",
-                    "FBT_QUIET": 1
+                    "PATH": "${workspaceFolder}${command:extension.commandvariable.envListSep}${env:PATH}"
                 },
-                "command": "fbt get_blackmagic",
-                "description": "Get Blackmagic device",
+                "command": "fbt -s get_blackmagic",
+                "description": "Get Blackmagic device"
             }
         }
     ],

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,7 +8,8 @@
 		"amiralizadeh9480.cpp-helper",
 		"marus25.cortex-debug",
 		"zxh404.vscode-proto3",
-		"augustocdias.tasks-shell-input"
+		"augustocdias.tasks-shell-input",
+		"rioj7.command-variable"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [

--- a/applications/services/desktop/views/desktop_view_debug.c
+++ b/applications/services/desktop/views/desktop_view_debug.c
@@ -65,13 +65,16 @@ void desktop_debug_render(Canvas* canvas, void* model) {
             version_get_builddate(ver));
         canvas_draw_str(canvas, 0, 30 + STATUS_BAR_Y_SHIFT, buffer);
 
+        uint16_t api_major, api_minor;
+        furi_hal_info_get_api_version(&api_major, &api_minor);
         snprintf(
             buffer,
             sizeof(buffer),
-            "%s%s [%s] %s",
+            "%s%s [%d.%d] %s",
             version_get_dirty_flag(ver) ? "[!] " : "",
             version_get_githash(ver),
-            version_get_gitbranchnum(ver),
+            api_major,
+            api_minor,
             c2_ver ? c2_ver->StackTypeString : "<none>");
         canvas_draw_str(canvas, 0, 40 + STATUS_BAR_Y_SHIFT, buffer);
 

--- a/applications/settings/about/about.c
+++ b/applications/settings/about/about.c
@@ -7,6 +7,7 @@
 #include <furi_hal_version.h>
 #include <furi_hal_region.h>
 #include <furi_hal_bt.h>
+#include <furi_hal_info.h>
 
 typedef DialogMessageButton (*AboutDialogScreen)(DialogsApp* dialogs, DialogMessage* message);
 
@@ -134,14 +135,17 @@ static DialogMessageButton fw_version_screen(DialogsApp* dialogs, DialogMessage*
     if(!ver) { //-V1051
         furi_string_cat_printf(buffer, "No info\n");
     } else {
+        uint16_t api_major, api_minor;
+        furi_hal_info_get_api_version(&api_major, &api_minor);
         furi_string_cat_printf(
             buffer,
-            "%s [%s]\n%s%s [%s] %s\n[%d] %s",
+            "%s [%s]\n%s%s [%d.%d] %s\n[%d] %s",
             version_get_version(ver),
             version_get_builddate(ver),
             version_get_dirty_flag(ver) ? "[!] " : "",
             version_get_githash(ver),
-            version_get_gitbranchnum(ver),
+            api_major,
+            api_minor,
             c2_ver ? c2_ver->StackTypeString : "<none>",
             version_get_target(ver),
             version_get_gitbranch(ver));

--- a/scripts/flipper/storage.py
+++ b/scripts/flipper/storage.py
@@ -1,12 +1,13 @@
-import os
-import sys
-import serial
-import time
-import hashlib
-import math
-import logging
-import posixpath
 import enum
+import hashlib
+import logging
+import math
+import os
+import posixpath
+import sys
+import time
+
+import serial
 
 
 def timing(func):
@@ -236,6 +237,7 @@ class FlipperStorage:
             filesize = os.fstat(file.fileno()).st_size
 
             buffer_size = self.chunk_size
+            start_time = time.time()
             while True:
                 filedata = file.read(buffer_size)
                 size = len(filedata)
@@ -254,11 +256,13 @@ class FlipperStorage:
                 self.port.write(filedata)
                 self.read.until(self.CLI_PROMPT)
 
-                percent = str(math.ceil(file.tell() / filesize * 100))
+                ftell = file.tell()
+                percent = str(math.ceil(ftell / filesize * 100))
                 total_chunks = str(math.ceil(filesize / buffer_size))
-                current_chunk = str(math.ceil(file.tell() / buffer_size))
+                current_chunk = str(math.ceil(ftell / buffer_size))
+                approx_speed = ftell / (time.time() - start_time + 0.0001)
                 sys.stdout.write(
-                    f"\r{percent}%, chunk {current_chunk} of {total_chunks}"
+                    f"\r{percent}%, chunk {current_chunk} of {total_chunks} @ {approx_speed/1024:.2f} kb/s"
                 )
                 sys.stdout.flush()
         print()

--- a/scripts/selfupdate.py
+++ b/scripts/selfupdate.py
@@ -15,7 +15,7 @@ class Main(App):
 
         self.parser.add_argument("manifest_path", help="Manifest path")
         self.parser.add_argument(
-            "--pkg_dir_name", help="Update dir name", default="pcbundle", required=False
+            "--pkg_dir_name", help="Update dir name", default=None, required=False
         )
         self.parser.set_defaults(func=self.install)
 

--- a/scripts/ufbt/project_template/.vscode/extensions.json
+++ b/scripts/ufbt/project_template/.vscode/extensions.json
@@ -8,7 +8,8 @@
 		"amiralizadeh9480.cpp-helper",
 		"marus25.cortex-debug",
 		"zxh404.vscode-proto3",
-		"augustocdias.tasks-shell-input"
+		"augustocdias.tasks-shell-input",
+		"rioj7.command-variable"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [


### PR DESCRIPTION
# What's new

- [FL-3300] desktop, about: replaced commit# with API version
- scripts: storage: added speed meter
- scripts: selfupdate: use actual folder name, not generic "pcbundle"
- vscode: fixed broken get_blackmagic shell integration on *nix

# Verification 

- Check out UI changes
- Update firmware with flash_usb and verify speed meter is working
- Re-deploy vscode config and check debugging with blackmagic

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-3300]: https://flipperzero.atlassian.net/browse/FL-3300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ