### PR TITLE
[FL-3302] Part 2 of hooking C2 IPC

### DIFF
--- a/firmware/targets/f7/ble_glue/ble_glue.c
+++ b/firmware/targets/f7/ble_glue/ble_glue.c
@@ -2,6 +2,7 @@
 #include "app_common.h"
 #include "ble_app.h"
 #include <ble/ble.h>
+#include <hci_tl.h>
 
 #include <interface/patterns/ble_thread/tl/tl.h>
 #include <interface/patterns/ble_thread/shci/shci.h>
@@ -70,6 +71,20 @@ void shci_register_io_bus(tSHciIO* fops) {
     /* Register IO bus services */
     fops->Init = TL_SYS_Init;
     fops->Send = ble_glue_TL_SYS_SendCmd;
+}
+
+static int32_t ble_glue_TL_BLE_SendCmd(uint8_t* buffer, uint16_t size) {
+    if(furi_hal_bt_get_hardfault_info()) {
+        furi_crash("ST(R) Copro(R) HardFault");
+    }
+
+    return TL_BLE_SendCmd(buffer, size);
+}
+
+void hci_register_io_bus(tHciIO* fops) {
+    /* Register IO bus services */
+    fops->Init = TL_BLE_Init;
+    fops->Send = ble_glue_TL_BLE_SendCmd;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/lib/stm32wb.scons
+++ b/lib/stm32wb.scons
@@ -48,7 +48,10 @@ sources += Glob(
 )
 sources += Glob(
     "stm32wb_copro/wpan/interface/patterns/ble_thread/tl/*_tl*.c",
-    exclude="stm32wb_copro/wpan/interface/patterns/ble_thread/tl/shci_tl_if.c",
+    exclude=[
+        "stm32wb_copro/wpan/interface/patterns/ble_thread/tl/hci_tl_if.c",
+        "stm32wb_copro/wpan/interface/patterns/ble_thread/tl/shci_tl_if.c",
+    ],
     source=True,
 )
 sources += [


### PR DESCRIPTION
# What's new

- [FL-3302] hal: ble_glue: part 2 of hooking C2 IPC

# Verification 

- Handling other possible crash path

![image](https://github.com/flipperdevices/flipperzero-firmware/assets/277532/68393729-0bd2-4ae9-a20c-0695267a1783)


# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-3302]: https://flipperzero.atlassian.net/browse/FL-3302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ