### PR TITLE
[FL-3317] fbt: allow strings for fap_version field in app manifests

### DIFF
--- a/documentation/AppManifests.md
+++ b/documentation/AppManifests.md
@@ -47,7 +47,7 @@ Only two parameters are mandatory: **_appid_** and **_apptype_**. Others are opt
 The following parameters are used only for [FAPs](./AppsOnSDCard.md):
 
 - **sources**: list of strings, file name masks used for gathering sources within the app folder. The default value of `["*.c*"]` includes C and C++ source files. Applications cannot use the `"lib"` folder for their own source code, as it is reserved for **fap_private_libs**.
-- **fap_version**: tuple, 2 numbers in the form of (x,y): application version to be embedded within .fap file. The default value is (0,1), meaning version "0.1".
+- **fap_version**: string, application version. The default value is "0.1". You can also use a tuple of 2 numbers in the form of (x,y) to specify the version. It is also possible to add more dot-separated parts to the version, like patch number, but only major and minor version numbers are stored in the built .fap.
 - **fap_icon**: name of a `.png` file, 1-bit color depth, 10x10px, to be embedded within `.fap` file.
 - **fap_libs**: list of extra libraries to link the application against. Provides access to extra functions that are not exported as a part of main firmware at the expense of increased `.fap` file size and RAM consumption.
 - **fap_category**: string, may be empty. App subcategory, also determines the path of the FAP within the apps folder in the file system.

--- a/scripts/debug/flipperapps.py
+++ b/scripts/debug/flipperapps.py
@@ -196,7 +196,10 @@ class FlipperAppStateHelper:
         self.set_debug_mode(False)
 
     def set_debug_mode(self, mode: bool) -> None:
-        gdb.execute(f"set variable furi_hal_debug_gdb_session_active = {int(mode)}")
+        try:
+            gdb.execute(f"set variable furi_hal_debug_gdb_session_active = {int(mode)}")
+        except gdb.error as e:
+            print(f"Failed to set debug mode: {e}")
 
 
 # Init additional 'fap-set-debug-elf-root' command and set up hooks

--- a/scripts/fbt/appmanifest.py
+++ b/scripts/fbt/appmanifest.py
@@ -56,7 +56,7 @@ class FlipperApplication:
 
     # .fap-specific
     sources: List[str] = field(default_factory=lambda: ["*.c*"])
-    fap_version: Tuple[int] = field(default_factory=lambda: (0, 1))
+    fap_version: str | Tuple[int] = "0.1"
     fap_icon: Optional[str] = None
     fap_libs: List[str] = field(default_factory=list)
     fap_category: str = ""
@@ -84,6 +84,13 @@ class FlipperApplication:
     def __post_init__(self):
         if self.apptype == FlipperAppType.PLUGIN:
             self.stack_size = 0
+        if isinstance(self.fap_version, str):
+            try:
+                self.fap_version = tuple(int(v) for v in self.fap_version.split("."))
+            except ValueError:
+                raise FlipperManifestException(
+                    f"Invalid version string '{self.fap_version}'. Must be in the form 'major.minor'"
+                )
 
 
 class AppManager:

--- a/scripts/ufbt/project_template/app_template/application.fam
+++ b/scripts/ufbt/project_template/app_template/application.fam
@@ -8,7 +8,7 @@ App(
     stack_size=2 * 1024,
     fap_category="Examples",
     # Optional values
-    # fap_version=(0, 1),  # (major, minor)
+    # fap_version="0.1",
     fap_icon="@FBT_APPID@.png",  # 10x10 1-bit PNG
     # fap_description="A simple app",
     # fap_author="J. Doe",


### PR DESCRIPTION
# What's new

- [FL-3317] fbt: allow strings for fap_version field in app manifests

# Verification 

- Try building apps with `fap_version` field containing either tuples or strings with more than 2 parts in it.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-3317]: https://flipperzero.atlassian.net/browse/FL-3317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ