### PR TITLE
[FL-3327] Storage: common_rename is now POSIX compliant

### DIFF
--- a/applications/services/storage/storage.h
+++ b/applications/services/storage/storage.h
@@ -226,7 +226,7 @@ FS_Error storage_common_stat(Storage* storage, const char* path, FileInfo* filei
  */
 FS_Error storage_common_remove(Storage* storage, const char* path);
 
-/** Renames file/directory, file/directory must not be open
+/** Renames file/directory, file/directory must not be open. Will overwrite existing file.
  * @param app pointer to the api
  * @param old_path old path
  * @param new_path new path

--- a/applications/services/storage/storage_external_api.c
+++ b/applications/services/storage/storage_external_api.c
@@ -425,7 +425,10 @@ FS_Error storage_common_rename(Storage* storage, const char* old_path, const cha
     FS_Error error;
 
     if(storage_file_exists(storage, new_path)) {
-        storage_common_remove(storage, new_path);
+        error = storage_common_remove(storage, new_path);
+        if(error != FSE_OK) {
+            return error;
+        }
     }
 
     error = storage_common_copy(storage, old_path, new_path);

--- a/applications/services/storage/storage_external_api.c
+++ b/applications/services/storage/storage_external_api.c
@@ -422,7 +422,13 @@ FS_Error storage_common_remove(Storage* storage, const char* path) {
 }
 
 FS_Error storage_common_rename(Storage* storage, const char* old_path, const char* new_path) {
-    FS_Error error = storage_common_copy(storage, old_path, new_path);
+    FS_Error error;
+
+    if(storage_file_exists(storage, new_path)) {
+        storage_common_remove(storage, new_path);
+    }
+
+    error = storage_common_copy(storage, old_path, new_path);
     if(error == FSE_OK) {
         if(!storage_simply_remove_recursive(storage, old_path)) {
             error = FSE_INTERNAL;


### PR DESCRIPTION
# What's new

- storage_common_rename is now POSIX compliant

# Verification 

- try to use `storage rename` with existing new file

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
