### PR TITLE
Storage, common_rename: check that old path is exists

### DIFF
--- a/applications/services/storage/storage_external_api.c
+++ b/applications/services/storage/storage_external_api.c
@@ -424,19 +424,25 @@ FS_Error storage_common_remove(Storage* storage, const char* path) {
 FS_Error storage_common_rename(Storage* storage, const char* old_path, const char* new_path) {
     FS_Error error;
 
-    if(storage_file_exists(storage, new_path)) {
-        error = storage_common_remove(storage, new_path);
-        if(error != FSE_OK) {
-            return error;
+    do {
+        if(!storage_common_exists(storage, old_path)) {
+            error = FSE_NOT_EXIST;
+            break;
         }
-    }
 
-    error = storage_common_copy(storage, old_path, new_path);
-    if(error == FSE_OK) {
+        if(storage_file_exists(storage, new_path)) {
+            storage_common_remove(storage, new_path);
+        }
+
+        error = storage_common_copy(storage, old_path, new_path);
+        if(error != FSE_OK) {
+            break;
+        }
+
         if(!storage_simply_remove_recursive(storage, old_path)) {
             error = FSE_INTERNAL;
         }
-    }
+    } while(false);
 
     return error;
 }

--- a/applications/services/storage/storage_external_api.c
+++ b/applications/services/storage/storage_external_api.c
@@ -426,7 +426,7 @@ FS_Error storage_common_rename(Storage* storage, const char* old_path, const cha
 
     do {
         if(!storage_common_exists(storage, old_path)) {
-            error = FSE_NOT_EXIST;
+            error = FSE_INVALID_NAME;
             break;
         }
 


### PR DESCRIPTION
# What's new

- storage_common_rename: check that old path is exists

# Verification 

- Rename file with qFlipper.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
