### PR TITLE
[FL-3340] SubGhz: fix flipper crashes after exiting broadcast blocking message and crash cli

### DIFF
--- a/applications/main/subghz/helpers/subghz_error_type.h
+++ b/applications/main/subghz/helpers/subghz_error_type.h
@@ -10,4 +10,5 @@ typedef enum {
         1, /** File parsing error, or wrong file structure, or missing required parameters. more accurate data can be obtained through the debug port */
     SubGhzErrorTypeOnlyRX =
         2, /** Transmission on this frequency is blocked by regional settings */
+    SubGhzErrorTypeParserOthers = 3, /** Error in protocol parameters description */
 } SubGhzErrorType;

--- a/applications/main/subghz/scenes/subghz_scene_rpc.c
+++ b/applications/main/subghz/scenes/subghz_scene_rpc.c
@@ -40,15 +40,26 @@ bool subghz_scene_rpc_on_event(void* context, SceneManagerEvent event) {
         } else if(event.event == SubGhzCustomEventSceneRpcButtonPress) {
             bool result = false;
             if((state == SubGhzRpcStateLoaded)) {
-                result = subghz_tx_start(subghz, subghz_txrx_get_fff_data(subghz->txrx));
-                state = SubGhzRpcStateTx;
-                if(result) subghz_blink_start(subghz);
-            }
-            if(!result) {
-                rpc_system_app_set_error_code(subghz->rpc_ctx, SubGhzErrorTypeOnlyRX);
-                rpc_system_app_set_error_text(
-                    subghz->rpc_ctx,
-                    "Transmission on this frequency is restricted in your region");
+                switch(
+                    subghz_txrx_tx_start(subghz->txrx, subghz_txrx_get_fff_data(subghz->txrx))) {
+                case SubGhzTxRxStartTxStateErrorOnlyRx:
+                    rpc_system_app_set_error_code(subghz->rpc_ctx, SubGhzErrorTypeOnlyRX);
+                    rpc_system_app_set_error_text(
+                        subghz->rpc_ctx,
+                        "Transmission on this frequency is restricted in your region");
+                    break;
+                case SubGhzTxRxStartTxStateErrorParserOthers:
+                    rpc_system_app_set_error_code(subghz->rpc_ctx, SubGhzErrorTypeParserOthers);
+                    rpc_system_app_set_error_text(
+                        subghz->rpc_ctx, "Error in protocol parameters description");
+                    break;
+
+                default: //if(SubGhzTxRxStartTxStateOk)
+                    result = true;
+                    subghz_blink_start(subghz);
+                    state = SubGhzRpcStateTx;
+                    break;
+                }
             }
             rpc_system_app_confirm(subghz->rpc_ctx, RpcAppEventButtonPress, result);
         } else if(event.event == SubGhzCustomEventSceneRpcButtonRelease) {
@@ -56,9 +67,9 @@ bool subghz_scene_rpc_on_event(void* context, SceneManagerEvent event) {
             if(state == SubGhzRpcStateTx) {
                 subghz_txrx_stop(subghz->txrx);
                 subghz_blink_stop(subghz);
-                state = SubGhzRpcStateIdle;
                 result = true;
             }
+            state = SubGhzRpcStateIdle;
             rpc_system_app_confirm(subghz->rpc_ctx, RpcAppEventButtonRelease, result);
         } else if(event.event == SubGhzCustomEventSceneRpcLoad) {
             bool result = false;
@@ -95,7 +106,7 @@ bool subghz_scene_rpc_on_event(void* context, SceneManagerEvent event) {
 void subghz_scene_rpc_on_exit(void* context) {
     SubGhz* subghz = context;
     SubGhzRpcState state = scene_manager_get_scene_state(subghz->scene_manager, SubGhzSceneRpc);
-    if(state != SubGhzRpcStateIdle) {
+    if(state == SubGhzRpcStateTx) {
         subghz_txrx_stop(subghz->txrx);
         subghz_blink_stop(subghz);
     }

--- a/applications/main/subghz/subghz_cli.c
+++ b/applications/main/subghz/subghz_cli.c
@@ -176,16 +176,19 @@ void subghz_cli_command_tx(Cli* cli, FuriString* args, void* context) {
 
     furi_hal_power_suppress_charge_enter();
 
-    furi_hal_subghz_start_async_tx(subghz_transmitter_yield, transmitter);
+    if(furi_hal_subghz_start_async_tx(subghz_transmitter_yield, transmitter)) {
+        while(!(furi_hal_subghz_is_async_tx_complete() || cli_cmd_interrupt_received(cli))) {
+            printf(".");
+            fflush(stdout);
+            furi_delay_ms(333);
+        }
+        furi_hal_subghz_stop_async_tx();
 
-    while(!(furi_hal_subghz_is_async_tx_complete() || cli_cmd_interrupt_received(cli))) {
-        printf(".");
-        fflush(stdout);
-        furi_delay_ms(333);
+    } else {
+        printf("Transmission on this frequency is restricted in your region\r\n");
     }
-    furi_hal_subghz_stop_async_tx();
-    furi_hal_subghz_sleep();
 
+    furi_hal_subghz_sleep();
     furi_hal_power_suppress_charge_exit();
 
     flipper_format_free(flipper_format);


### PR DESCRIPTION
# What's new

- [FL-3340] SubGhz: fix flipper crashes after exiting broadcast blocking message and crash cli

# Verification 

- Transmit the saved SubGhz file at a frequency not intended for use in this region via RPC and via CLI

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-3340]: https://flipperzero.atlassian.net/browse/FL-3340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ