### PR TITLE
[FL-3213] f7: add PB9 to debug pins

### DIFF
--- a/firmware/targets/f7/furi_hal/furi_hal_resources.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_resources.c
@@ -81,6 +81,7 @@ const GpioPinRecord gpio_pins[] = {
     /* Dangerous pins, may damage hardware */
     {.pin = &gpio_usart_rx, .name = "PB7", .debug = true},
     {.pin = &gpio_speaker, .name = "PB8", .debug = true},
+    {.pin = &gpio_infrared_tx, .name = "PB9", .debug = true},
 };
 
 const size_t gpio_pins_count = sizeof(gpio_pins) / sizeof(GpioPinRecord);


### PR DESCRIPTION
# What's new

- f7: add PB9 to debug pins

# Verification 

- PB9 should be available in gpio cli in debug mode

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
