### PR TITLE
[FL-3359] github: added debugapps artifact; packaging resources per-target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,13 +64,13 @@ jobs:
         run: |
           set -e
           for TARGET in ${TARGETS}; do
-            TARGET="$(echo "${TARGET}" | sed 's/f//')"; \
-            ./fbt TARGET_HW=$TARGET copro_dist updater_package \
+            TARGET_HW="$(echo "${TARGET}" | sed 's/f//')"; \
+            ./fbt TARGET_HW=$TARGET_HW copro_dist updater_package \
               ${{ startsWith(github.ref, 'refs/tags') && 'DEBUG=0 COMPACT=1' || '' }}
             mv dist/${TARGET}-*/* artifacts/
             tar czpf "artifacts/flipper-z-${TARGET}-resources-${SUFFIX}.tgz" \
               -C assets resources
-            ./fbt TARGET_HW=$TARGET fap_dist
+            ./fbt TARGET_HW=$TARGET_HW fap_dist
             tar czpf "artifacts/flipper-z-${TARGET}-debugapps-${SUFFIX}.tgz" \
               -C dist/${TARGET}-*/apps/Debug dist/${TARGET}-*/apps/Debug 
           done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,10 +52,8 @@ jobs:
 
       - name: 'Make artifacts directory'
         run: |
-          rm -rf artifacts
-          rm -rf map_analyser_files
-          mkdir artifacts
-          mkdir map_analyser_files
+          rm -rf artifacts map_analyser_files
+          mkdir artifacts map_analyser_files
 
       - name: 'Bundle scripts'
         if: ${{ !github.event.pull_request.head.repo.fork }}
@@ -68,15 +66,13 @@ jobs:
           for TARGET in ${TARGETS}; do
             TARGET="$(echo "${TARGET}" | sed 's/f//')"; \
             ./fbt TARGET_HW=$TARGET copro_dist updater_package \
-            ${{ startsWith(github.ref, 'refs/tags') && 'DEBUG=0 COMPACT=1' || '' }}
-          done
-
-      - name: 'Move upload files'
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-          set -e
-          for TARGET in ${TARGETS}; do
+              ${{ startsWith(github.ref, 'refs/tags') && 'DEBUG=0 COMPACT=1' || '' }}
             mv dist/${TARGET}-*/* artifacts/
+            tar czpf "artifacts/flipper-z-${TARGET}-resources-${SUFFIX}.tgz" \
+              -C assets resources
+            ./fbt TARGET_HW=$TARGET fap_dist
+            tar czpf "artifacts/flipper-z-${TARGET}-debugapps-${SUFFIX}.tgz" \
+              -C dist/${TARGET}-*/apps/Debug dist/${TARGET}-*/apps/Debug 
           done
 
       - name: "Check for uncommitted changes"
@@ -86,7 +82,6 @@ jobs:
       - name: 'Bundle resources'
         if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
-          tar czpf "artifacts/flipper-z-any-resources-${SUFFIX}.tgz" -C assets resources
 
       - name: 'Bundle core2 firmware'
         if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
               -C assets resources
             ./fbt TARGET_HW=$TARGET_HW fap_dist
             tar czpf "artifacts/flipper-z-${TARGET}-debugapps-${SUFFIX}.tgz" \
-              -C dist/${TARGET}-*/apps/Debug dist/${TARGET}-*/apps/Debug 
+              -C dist/${TARGET}-*/apps/Debug .
           done
 
       - name: "Check for uncommitted changes"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,10 +79,6 @@ jobs:
         run: |
           git diff --exit-code
 
-      - name: 'Bundle resources'
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-
       - name: 'Bundle core2 firmware'
         if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |

--- a/scripts/sconsdist.py
+++ b/scripts/sconsdist.py
@@ -80,7 +80,7 @@ class Main(App):
                     src_file,
                     self.get_dist_path(self.get_project_file_name(project, filetype)),
                 )
-        for foldertype in ("sdk_headers",):
+        for foldertype in ("sdk_headers", "lib"):
             if exists(sdk_folder := join(obj_directory, foldertype)):
                 self.note_dist_component(foldertype, "dir", sdk_folder)
 
@@ -158,6 +158,7 @@ class Main(App):
             "firmware.elf",
             "update.dir",
             "sdk_headers.dir",
+            "lib.dir",
             "scripts.dir",
         )
 

--- a/scripts/sconsdist.py
+++ b/scripts/sconsdist.py
@@ -80,20 +80,9 @@ class Main(App):
                     src_file,
                     self.get_dist_path(self.get_project_file_name(project, filetype)),
                 )
-        for foldertype in ("sdk_headers", "lib"):
+        for foldertype in ("sdk_headers",):
             if exists(sdk_folder := join(obj_directory, foldertype)):
                 self.note_dist_component(foldertype, "dir", sdk_folder)
-
-        # TODO: remove this after everyone migrates to new uFBT
-        self.create_zip_stub("lib")
-
-    def create_zip_stub(self, foldertype):
-        with zipfile.ZipFile(
-            self.get_dist_path(self.get_dist_file_name(foldertype, "zip")),
-            "w",
-            zipfile.ZIP_DEFLATED,
-        ) as _:
-            pass
 
     def copy(self) -> int:
         self._dist_components: dict[str, str] = dict()
@@ -169,7 +158,6 @@ class Main(App):
             "firmware.elf",
             "update.dir",
             "sdk_headers.dir",
-            "lib.dir",
             "scripts.dir",
         )
 


### PR DESCRIPTION
# What's new

- [FL-3359] github: separate resource bundles for targets
- github: added artefact with debug apps

# Verification 

- https://update.flipperzero.one/builds/firmware/hedger/debugappsartifact/

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-3359]: https://flipperzero.atlassian.net/browse/FL-3359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ