### PR TITLE
[FL-3361] fbt: stable build dates

### DIFF
--- a/scripts/version.py
+++ b/scripts/version.py
@@ -40,12 +40,23 @@ class GitVersion:
         except subprocess.CalledProcessError:
             version = "unknown"
 
+        if "SOURCE_DATE_EPOCH" in os.environ:
+            commit_date = datetime.utcfromtimestamp(
+                int(os.environ["SOURCE_DATE_EPOCH"])
+            )
+        else:
+            commit_date = datetime.strptime(
+                self._exec_git("log -1 --format=%cd").strip(),
+                "%a %b %d %H:%M:%S %Y %z",
+            )
+
         return {
             "GIT_COMMIT": commit,
             "GIT_BRANCH": branch,
             "VERSION": version,
             "BUILD_DIRTY": dirty and 1 or 0,
             "GIT_ORIGIN": ",".join(self._get_git_origins()),
+            "GIT_COMMIT_DATE": commit_date,
         }
 
     def _get_git_origins(self):
@@ -102,10 +113,11 @@ class Main(App):
     def generate(self):
         current_info = GitVersion(self.args.sourcedir).get_version_info()
 
-        if "SOURCE_DATE_EPOCH" in os.environ:
-            build_date = datetime.utcfromtimestamp(int(os.environ["SOURCE_DATE_EPOCH"]))
-        else:
-            build_date = date.today()
+        build_date = (
+            date.today()
+            if current_info["BUILD_DIRTY"]
+            else current_info["GIT_COMMIT_DATE"]
+        )
 
         current_info.update(
             {

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -127,6 +127,8 @@ class Main(App):
             }
         )
 
+        del current_info["GIT_COMMIT_DATE"]
+
         version_values = []
         for key in current_info:
             val = current_info[key]


### PR DESCRIPTION
# What's new

- [FL-3361] scripts: using commit date for clean build timestamp; current day otherwise


# Verification 

- с+p this script into a checkout of older fw version & patch dirty check
- build firmware

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-3361]: https://flipperzero.atlassian.net/browse/FL-3361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ