### PR TITLE
[FL-3360] Core2, SRAM2: provide safety gap

### DIFF
--- a/furi/core/thread.c
+++ b/furi/core/thread.c
@@ -56,6 +56,8 @@ static int32_t __furi_thread_stdout_flush(FuriThread* thread);
 
 /** Catch threads that are trying to exit wrong way */
 __attribute__((__noreturn__)) void furi_thread_catch() { //-V1082
+    // If you're here it means you're probably doing something wrong
+    // with critical sections or with scheduler state
     asm volatile("nop"); // extra magic
     furi_crash("You are doing it wrong"); //-V779
     __builtin_unreachable();


### PR DESCRIPTION
# What's new

- Safety gap in SRAM2B

# Verification 

- Restart core2 on f18 fw, check that sd-card is still usable.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
