### PR TITLE
[FL-3376] Fixed GATT attribute order 

### DIFF
--- a/firmware/targets/f7/ble_glue/gap.c
+++ b/firmware/targets/f7/ble_glue/gap.c
@@ -331,12 +331,6 @@ static void gap_init_svc(Gap* gap) {
         FURI_LOG_E(TAG, "Failed updating name characteristic: %d", status);
     }
 
-    status = aci_gatt_set_access_permission(
-        gap->service.gap_svc_handle, gap->service.dev_name_char_handle, 0x01);
-    if(status) {
-        FURI_LOG_E(TAG, "Failed to set name characteristic permissions: %d", status);
-    }
-
     uint8_t gap_appearence_char_uuid[2] = {
         gap->config->appearance_char & 0xff, gap->config->appearance_char >> 8};
     status = aci_gatt_update_char_value(

--- a/firmware/targets/f7/ble_glue/gap.c
+++ b/firmware/targets/f7/ble_glue/gap.c
@@ -330,6 +330,13 @@ static void gap_init_svc(Gap* gap) {
     if(status) {
         FURI_LOG_E(TAG, "Failed updating name characteristic: %d", status);
     }
+
+    status = aci_gatt_set_access_permission(
+        gap->service.gap_svc_handle, gap->service.dev_name_char_handle, 0x01);
+    if(status) {
+        FURI_LOG_E(TAG, "Failed to set name characteristic permissions: %d", status);
+    }
+
     uint8_t gap_appearence_char_uuid[2] = {
         gap->config->appearance_char & 0xff, gap->config->appearance_char >> 8};
     status = aci_gatt_update_char_value(

--- a/firmware/targets/f7/ble_glue/services/serial_service.c
+++ b/firmware/targets/f7/ble_glue/services/serial_service.c
@@ -10,24 +10,14 @@
 #define TAG "BtSerialSvc"
 
 typedef enum {
-    SerialSvcGattCharacteristicTx = 0,
-    SerialSvcGattCharacteristicRx,
+    SerialSvcGattCharacteristicRx = 0,
+    SerialSvcGattCharacteristicTx,
     SerialSvcGattCharacteristicFlowCtrl,
     SerialSvcGattCharacteristicStatus,
     SerialSvcGattCharacteristicCount,
 } SerialSvcGattCharacteristicId;
 
 static const FlipperGattCharacteristicParams serial_svc_chars[SerialSvcGattCharacteristicCount] = {
-    [SerialSvcGattCharacteristicTx] =
-        {.name = "TX",
-         .data_prop_type = FlipperGattCharacteristicDataFixed,
-         .data.fixed.length = SERIAL_SVC_DATA_LEN_MAX,
-         .uuid.Char_UUID_128 = SERIAL_SVC_TX_CHAR_UUID,
-         .uuid_type = UUID_TYPE_128,
-         .char_properties = CHAR_PROP_READ | CHAR_PROP_INDICATE,
-         .security_permissions = ATTR_PERMISSION_AUTHEN_READ,
-         .gatt_evt_mask = GATT_DONT_NOTIFY_EVENTS,
-         .is_variable = CHAR_VALUE_LEN_VARIABLE},
     [SerialSvcGattCharacteristicRx] =
         {.name = "RX",
          .data_prop_type = FlipperGattCharacteristicDataFixed,
@@ -37,6 +27,16 @@ static const FlipperGattCharacteristicParams serial_svc_chars[SerialSvcGattChara
          .char_properties = CHAR_PROP_WRITE_WITHOUT_RESP | CHAR_PROP_WRITE | CHAR_PROP_READ,
          .security_permissions = ATTR_PERMISSION_AUTHEN_READ | ATTR_PERMISSION_AUTHEN_WRITE,
          .gatt_evt_mask = GATT_NOTIFY_ATTRIBUTE_WRITE,
+         .is_variable = CHAR_VALUE_LEN_VARIABLE},
+    [SerialSvcGattCharacteristicTx] =
+        {.name = "TX",
+         .data_prop_type = FlipperGattCharacteristicDataFixed,
+         .data.fixed.length = SERIAL_SVC_DATA_LEN_MAX,
+         .uuid.Char_UUID_128 = SERIAL_SVC_TX_CHAR_UUID,
+         .uuid_type = UUID_TYPE_128,
+         .char_properties = CHAR_PROP_READ | CHAR_PROP_INDICATE,
+         .security_permissions = ATTR_PERMISSION_AUTHEN_READ,
+         .gatt_evt_mask = GATT_DONT_NOTIFY_EVENTS,
          .is_variable = CHAR_VALUE_LEN_VARIABLE},
     [SerialSvcGattCharacteristicFlowCtrl] =
         {.name = "Flow control",


### PR DESCRIPTION
# What's new

- [FL-3376] Fixed attribute order 
- hal: gatt: swapped rx/tx serial chars order

# Verification 

- Check Android connectivity Issue after update
- Check BLE Remote app with ios10/14

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-3376]: https://flipperzero.atlassian.net/browse/FL-3376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ