### PR TITLE
Debug: sync apps on attach, makes it possible to debug already started app that has crashed

### DIFF
--- a/scripts/debug/flipperapps.py
+++ b/scripts/debug/flipperapps.py
@@ -188,6 +188,7 @@ class FlipperAppStateHelper:
         )
         self.app_type_ptr = gdb.lookup_type("FlipperApplication").pointer()
         self.app_list_entry_type = gdb.lookup_type("struct FlipperApplicationList_s")
+        self._sync_apps()
 
     def handle_stop(self, event) -> None:
         self._sync_apps()


### PR DESCRIPTION
# What's new

- Debug: sync apps on attach, makes it possible to debug already started app that has crashed

# Verification 

- Start app, connect debugger, ensure that app elf was loaded correctly and app is debuggable

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
