### PR TITLE
Game deeds update

### DIFF
--- a/applications/external/snake_game/snake_game.c
+++ b/applications/external/snake_game/snake_game.c
@@ -346,7 +346,7 @@ int32_t snake_game_app(void* p) {
 
     notification_message_block(notification, &sequence_display_backlight_enforce_on);
 
-    dolphin_deed(DolphinDeedPluginGameStart);
+    dolphin_deed(DolphinDeedPluginStart);
 
     SnakeEvent event;
     for(bool processing = true; processing;) {

--- a/applications/services/dolphin/helpers/dolphin_deed.c
+++ b/applications/services/dolphin/helpers/dolphin_deed.c
@@ -40,8 +40,9 @@ static const DolphinDeedWeight dolphin_deed_weights[] = {
     {1, DolphinAppPlugin}, // DolphinDeedGpioUartBridge
 
     {1, DolphinAppPlugin}, // DolphinDeedPluginStart
-    {1, DolphinAppPlugin}, // DolphinDeedPluginGameStart
-    {10, DolphinAppPlugin}, // DolphinDeedPluginGameWin
+
+    {5, DolphinAppGame}, // DolphinDeedGameWin
+    {3, DolphinAppGame}, // DolphinDeedGameLost
 };
 
 static uint8_t dolphin_deed_limits[] = {
@@ -52,6 +53,7 @@ static uint8_t dolphin_deed_limits[] = {
     20, // DolphinAppIbutton
     20, // DolphinAppBadusb
     20, // DolphinAppPlugin
+    20, // DolphinAppGame
 };
 
 _Static_assert(COUNT_OF(dolphin_deed_weights) == DolphinDeedMAX, "dolphin_deed_weights size error");

--- a/applications/services/dolphin/helpers/dolphin_deed.h
+++ b/applications/services/dolphin/helpers/dolphin_deed.h
@@ -1,4 +1,4 @@
-#pragma once
+\#pragma once
 
 #include <stdint.h>
 
@@ -14,6 +14,7 @@ typedef enum {
     DolphinAppIbutton,
     DolphinAppBadusb,
     DolphinAppPlugin,
+    DolphinAppGame,
     DolphinAppMAX,
 } DolphinApp;
 
@@ -56,8 +57,9 @@ typedef enum {
     DolphinDeedGpioUartBridge,
 
     DolphinDeedPluginStart,
-    DolphinDeedPluginGameStart,
-    DolphinDeedPluginGameWin,
+
+    DolphinDeedGameWin,
+    DolphinDeedGameLost,
 
     DolphinDeedMAX,
 

--- a/applications/services/dolphin/helpers/dolphin_deed.h
+++ b/applications/services/dolphin/helpers/dolphin_deed.h
@@ -1,4 +1,4 @@
-\#pragma once
+#pragma once
 
 #include <stdint.h>
 


### PR DESCRIPTION
- I changed the DolphinDeedPluginGameStart to DolphinDeedPluginStart because having multiple start "rewards" with the same value is unnecessary.
- Also added win and loss conditions. with reduced XP awarded to them.
- Updated the snake game to reflect the changes, I think we should add DolphinDeedGameWin and DolphinDeedGameLost to it as well in snake_game_process_game_step?