### PR TITLE
Actions: unit_test and updater timeouts

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -29,12 +29,14 @@ jobs:
       - name: 'Flash unit tests firmware'
         id: flashing
         if: success()
+        timeout-minutes: 5
         run: |
           ./fbt flash OPENOCD_ADAPTER_SERIAL=2A0906016415303030303032 FIRMWARE_APP_SET=unit_tests FORCE=1
 
       - name: 'Wait for flipper and format ext'
         id: format_ext
         if: steps.flashing.outcome == 'success'
+        timeout-minutes: 5
         run: |
           source scripts/toolchain/fbtenv.sh
           python3 scripts/testing/await_flipper.py ${{steps.device.outputs.flipper}}
@@ -43,6 +45,7 @@ jobs:
       - name: 'Copy assets and unit data, reboot and wait for flipper'
         id: copy
         if: steps.format_ext.outcome == 'success'
+        timeout-minutes: 3
         run: |
           source scripts/toolchain/fbtenv.sh
           python3 scripts/storage.py -p ${{steps.device.outputs.flipper}} -f send assets/resources /ext
@@ -53,7 +56,7 @@ jobs:
       - name: 'Run units and validate results'
         id: run_units
         if: steps.copy.outcome == 'success'
-        timeout-minutes: 2.5
+        timeout-minutes: 5
         run: |
           source scripts/toolchain/fbtenv.sh
           python3 scripts/testing/units.py ${{steps.device.outputs.flipper}}

--- a/.github/workflows/updater_test.yml
+++ b/.github/workflows/updater_test.yml
@@ -30,6 +30,7 @@ jobs:
 
       - name: 'Flashing target firmware'
         id: first_full_flash
+        timeout-minutes: 3
         run: |
           source scripts/toolchain/fbtenv.sh
           ./fbt flash_usb_full PORT=${{steps.device.outputs.flipper}} FORCE=1
@@ -37,6 +38,7 @@ jobs:
 
       - name: 'Validating updater'
         id: second_full_flash
+        timeout-minutes: 3
         if: success()
         run: |
           source scripts/toolchain/fbtenv.sh

--- a/.github/workflows/updater_test.yml
+++ b/.github/workflows/updater_test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: 'Flashing target firmware'
         id: first_full_flash
-        timeout-minutes: 3
+        timeout-minutes: 5
         run: |
           source scripts/toolchain/fbtenv.sh
           ./fbt flash_usb_full PORT=${{steps.device.outputs.flipper}} FORCE=1
@@ -38,7 +38,7 @@ jobs:
 
       - name: 'Validating updater'
         id: second_full_flash
-        timeout-minutes: 3
+        timeout-minutes: 5
         if: success()
         run: |
           source scripts/toolchain/fbtenv.sh

--- a/applications/main/subghz/helpers/subghz_frequency_analyzer_log_item_array.h
+++ b/applications/main/subghz/helpers/subghz_frequency_analyzer_log_item_array.h
@@ -35,7 +35,7 @@ TUPLE_DEF2(
         M_DEFAULT_OPLIST)
 
 /* Define the array, register the oplist and define further algorithms on it */
-ARRAY_DEF(SubGhzFrequencyAnalyzerLogItemArray, SubGhzFrequencyAnalyzerLogItem_t)
+ARRAY_DEF(SubGhzFrequencyAnalyzerLogItemArray, SubGhzFrequencyAnalyzerLogItem_t) //-V779
 #define M_OPL_SubGhzFrequencyAnalyzerLogItemArray_t() \
     ARRAY_OPLIST(SubGhzFrequencyAnalyzerLogItemArray, M_OPL_SubGhzFrequencyAnalyzerLogItem_t())
 ALGO_DEF(SubGhzFrequencyAnalyzerLogItemArray, SubGhzFrequencyAnalyzerLogItemArray_t)

--- a/scripts/testing/await_flipper.py
+++ b/scripts/testing/await_flipper.py
@@ -8,6 +8,7 @@ import time
 def flp_serial_by_name(flp_name):
     if sys.platform == "darwin":  # MacOS
         flp_serial = "/dev/cu.usbmodemflip_" + flp_name + "1"
+        logging.info(f"Darwin, looking for {flp_serial}")
     elif sys.platform == "linux":  # Linux
         flp_serial = (
             "/dev/serial/by-id/usb-Flipper_Devices_Inc._Flipper_"
@@ -16,10 +17,12 @@ def flp_serial_by_name(flp_name):
             + flp_name
             + "-if00"
         )
+        logging.info(f"linux, looking for {flp_serial}")
 
     if os.path.exists(flp_serial):
         return flp_serial
     else:
+        logging.info(f"Couldn't find {logging.info} on this attempt.")
         if os.path.exists(flp_name):
             return flp_name
         else:
@@ -38,7 +41,7 @@ def main():
         level=logging.INFO,
         datefmt="%Y-%m-%d %H:%M:%S",
     )
-    logging.info("Waiting for Flipper to be ready...")
+    logging.info(f"Waiting for Flipper {flipper_name} to be ready...")
 
     while flipper == "" and elapsed < UPDATE_TIMEOUT:
         elapsed += 1

--- a/scripts/testing/units.py
+++ b/scripts/testing/units.py
@@ -20,13 +20,13 @@ def main():
         logging.error("Flipper not found!")
         sys.exit(1)
 
-    with serial.Serial(flp_serial, timeout=1) as flipper:
+    with serial.Serial(flp_serial, timeout=10) as flipper:
         logging.info(f"Found Flipper at {flp_serial}")
         flipper.baudrate = 230400
         flipper.flushOutput()
         flipper.flushInput()
 
-        flipper.timeout = 180
+        flipper.timeout = 300
 
         flipper.read_until(b">: ").decode("utf-8")
         flipper.write(b"unit_tests\r")


### PR DESCRIPTION
Timeout fix for crashing unit tests and minor extra logging. So far list_ports seems to work same way, so testing this out

# What's new

Just fixing units, this issue https://github.com/flipperdevices/flipperzero-firmware/actions/runs/5347807863/jobs/9696833276

# Verification 

Action no longer times out on run units step. Still investigating flipper not being found, hence extra logging

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
