### PR TITLE
Fix roll-over in file browser and archive

### DIFF
--- a/applications/main/archive/views/archive_browser_view.c
+++ b/applications/main/archive/views/archive_browser_view.c
@@ -345,11 +345,13 @@ static bool archive_view_input(InputEvent* event, void* context) {
 
                     if(event->key == InputKeyUp) {
                         if(model->item_idx < scroll_speed) {
-                            scroll_speed = model->item_idx;
+                            model->button_held_for_ticks = 0;
+                            model->item_idx = model->item_cnt - 1;
+                        } else {
+                            model->item_idx =
+                                ((model->item_idx - scroll_speed) + model->item_cnt) %
+                                model->item_cnt;
                         }
-
-                        model->item_idx =
-                            ((model->item_idx - scroll_speed) + model->item_cnt) % model->item_cnt;
                         if(is_file_list_load_required(model)) {
                             model->list_loading = true;
                             browser->callback(ArchiveBrowserEventLoadPrevItems, browser->context);
@@ -361,11 +363,12 @@ static bool archive_view_input(InputEvent* event, void* context) {
                         model->button_held_for_ticks += 1;
                     } else if(event->key == InputKeyDown) {
                         int32_t count = model->item_cnt;
-                        if(model->item_idx >= (count - scroll_speed)) {
-                            scroll_speed = model->item_cnt - model->item_idx - 1;
+                        if(model->item_idx + scroll_speed >= count) {
+                            model->button_held_for_ticks = 0;
+                            model->item_idx = 0;
+                        } else {
+                            model->item_idx = (model->item_idx + scroll_speed) % model->item_cnt;
                         }
-
-                        model->item_idx = (model->item_idx + scroll_speed) % model->item_cnt;
                         if(is_file_list_load_required(model)) {
                             model->list_loading = true;
                             browser->callback(ArchiveBrowserEventLoadNextItems, browser->context);

--- a/applications/services/gui/modules/file_browser.c
+++ b/applications/services/gui/modules/file_browser.c
@@ -602,11 +602,13 @@ static bool file_browser_view_input_callback(InputEvent* event, void* context) {
 
                     if(event->key == InputKeyUp) {
                         if(model->item_idx < scroll_speed) {
-                            scroll_speed = model->item_idx;
+                            model->button_held_for_ticks = 0;
+                            model->item_idx = model->item_cnt - 1;
+                        } else {
+                            model->item_idx =
+                                ((model->item_idx - scroll_speed) + model->item_cnt) %
+                                model->item_cnt;
                         }
-
-                        model->item_idx =
-                            ((model->item_idx - scroll_speed) + model->item_cnt) % model->item_cnt;
                         if(browser_is_list_load_required(model)) {
                             model->list_loading = true;
                             int32_t load_offset = CLAMP(
@@ -622,10 +624,11 @@ static bool file_browser_view_input_callback(InputEvent* event, void* context) {
                     } else if(event->key == InputKeyDown) {
                         int32_t count = model->item_cnt;
                         if(model->item_idx + scroll_speed >= count) {
-                            scroll_speed = count - model->item_idx - 1;
+                            model->button_held_for_ticks = 0;
+                            model->item_idx = 0;
+                        } else {
+                            model->item_idx = (model->item_idx + scroll_speed) % model->item_cnt;
                         }
-
-                        model->item_idx = (model->item_idx + scroll_speed) % model->item_cnt;
                         if(browser_is_list_load_required(model)) {
                             model->list_loading = true;
                             int32_t load_offset = CLAMP(


### PR DESCRIPTION
# What's new

- The file browser and archive now roll-over (as they should)

# Verification 

- Check that acceleration still works as intended
- Check that reaching the end/beginning of the list resets the acceleration and moves selection to the opposite end of the list

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
