### PR TITLE
SubGHz: properly working with missing external driver

### DIFF
--- a/applications/main/subghz/helpers/subghz_txrx.c
+++ b/applications/main/subghz/helpers/subghz_txrx.c
@@ -552,7 +552,10 @@ bool subghz_txrx_radio_device_is_external_connected(SubGhzTxRx* instance, const 
         subghz_txrx_radio_device_power_on(instance);
     }
 
-    is_connect = subghz_devices_is_connect(subghz_devices_get_by_name(name));
+    const SubGhzDevice* device = subghz_devices_get_by_name(name);
+    if(device) {
+        is_connect = subghz_devices_is_connect(device);
+    }
 
     if(!is_otg_enabled) {
         subghz_txrx_radio_device_power_off(instance);


### PR DESCRIPTION
# What's new

- SubGHz: properly working with missing external driver

# Verification 

- Launch SubGHz without external driver on sd-card

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
