### PR TITLE
[FL-3398] Desktop settings: show icon and name for external applications

### DIFF
--- a/applications/settings/desktop_settings/scenes/desktop_settings_scene_favorite.c
+++ b/applications/settings/desktop_settings/scenes/desktop_settings_scene_favorite.c
@@ -1,6 +1,7 @@
 #include "../desktop_settings_app.h"
 #include "applications.h"
 #include "desktop_settings_scene.h"
+#include <flipper_application/flipper_application.h>
 #include <storage/storage.h>
 #include <dialogs/dialogs.h>
 
@@ -13,16 +14,9 @@ static bool favorite_fap_selector_item_callback(
     uint8_t** icon_ptr,
     FuriString* item_name) {
     UNUSED(context);
-#ifdef APP_FAP_LOADER
     Storage* storage = furi_record_open(RECORD_STORAGE);
-    bool success = fap_loader_load_name_and_icon(file_path, storage, icon_ptr, item_name);
+    bool success = flipper_application_load_name_and_icon(file_path, storage, icon_ptr, item_name);
     furi_record_close(RECORD_STORAGE);
-#else
-    UNUSED(file_path);
-    UNUSED(icon_ptr);
-    UNUSED(item_name);
-    bool success = false;
-#endif
     return success;
 }
 


### PR DESCRIPTION
# What's new

- Desktop settings now can show icon and name for external applications

# Verification 

- Open desktop settings, select Favorite App and check that it can show icon and name for external applications.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
