### PR TITLE
[FL-3397] FuriHal, Infrared, Protobuf: various fixes and improvements

### DIFF
--- a/applications/settings/desktop_settings/scenes/desktop_settings_scene_favorite.c
+++ b/applications/settings/desktop_settings/scenes/desktop_settings_scene_favorite.c
@@ -78,7 +78,7 @@ void desktop_settings_scene_favorite_on_enter(void* context) {
         app);
 
     if(curr_favorite_app->is_external) {
-        if (curr_favorite_app->name_or_path[0] == '\0') {
+        if(curr_favorite_app->name_or_path[0] == '\0') {
             pre_select_item = EXTERNAL_BROWSER_INDEX;
         } else {
             pre_select_item = EXTERNAL_APPLICATION_INDEX;

--- a/applications/settings/desktop_settings/scenes/desktop_settings_scene_favorite.c
+++ b/applications/settings/desktop_settings/scenes/desktop_settings_scene_favorite.c
@@ -5,8 +5,11 @@
 #include <storage/storage.h>
 #include <dialogs/dialogs.h>
 
+#define EXTERNAL_BROWSER_NAME ("Applications")
+#define EXTERNAL_BROWSER_INDEX (FLIPPER_APPS_COUNT + 1)
+
 #define EXTERNAL_APPLICATION_NAME ("[External Application]")
-#define EXTERNAL_APPLICATION_INDEX (FLIPPER_APPS_COUNT + 1)
+#define EXTERNAL_APPLICATION_INDEX (FLIPPER_APPS_COUNT + 2)
 
 static bool favorite_fap_selector_item_callback(
     FuriString* file_path,
@@ -58,14 +61,28 @@ void desktop_settings_scene_favorite_on_enter(void* context) {
         }
     }
 
+    // Special case: Application browser
+    submenu_add_item(
+        submenu,
+        EXTERNAL_BROWSER_NAME,
+        EXTERNAL_BROWSER_INDEX,
+        desktop_settings_scene_favorite_submenu_callback,
+        app);
+
+    // Special case: Specific application
     submenu_add_item(
         submenu,
         EXTERNAL_APPLICATION_NAME,
         EXTERNAL_APPLICATION_INDEX,
         desktop_settings_scene_favorite_submenu_callback,
         app);
+
     if(curr_favorite_app->is_external) {
-        pre_select_item = EXTERNAL_APPLICATION_INDEX;
+        if (curr_favorite_app->name_or_path[0] == '\0') {
+            pre_select_item = EXTERNAL_BROWSER_INDEX;
+        } else {
+            pre_select_item = EXTERNAL_APPLICATION_INDEX;
+        }
     }
 
     submenu_set_header(
@@ -86,7 +103,11 @@ bool desktop_settings_scene_favorite_on_event(void* context, SceneManagerEvent e
                                                         &app->settings.favorite_secondary;
 
     if(event.type == SceneManagerEventTypeCustom) {
-        if(event.event == EXTERNAL_APPLICATION_INDEX) {
+        if(event.event == EXTERNAL_BROWSER_INDEX) {
+            curr_favorite_app->is_external = true;
+            curr_favorite_app->name_or_path[0] = '\0';
+            consumed = true;
+        } else if(event.event == EXTERNAL_APPLICATION_INDEX) {
             const DialogsFileBrowserOptions browser_options = {
                 .extension = ".fap",
                 .icon = &I_unknown_10px,

--- a/firmware/targets/f7/furi_hal/furi_hal_infrared.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_infrared.c
@@ -373,9 +373,6 @@ static void furi_hal_infrared_configure_tim_pwm_tx(uint32_t freq, float duty_cyc
     LL_TIM_EnableAllOutputs(INFRARED_DMA_TIMER);
     LL_TIM_DisableIT_UPDATE(INFRARED_DMA_TIMER);
     LL_TIM_EnableDMAReq_UPDATE(INFRARED_DMA_TIMER);
-
-    NVIC_SetPriority(TIM1_UP_TIM16_IRQn, NVIC_EncodePriority(NVIC_GetPriorityGrouping(), 5, 0));
-    NVIC_EnableIRQ(TIM1_UP_TIM16_IRQn);
 }
 
 static void furi_hal_infrared_configure_tim_cmgr2_dma_tx(void) {

--- a/firmware/targets/f7/furi_hal/furi_hal_interrupt.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_interrupt.c
@@ -129,7 +129,6 @@ void furi_hal_interrupt_set_isr_ex(
     void* context) {
     furi_check(index < FuriHalInterruptIdMax);
     furi_check(priority < 15);
-    furi_check(furi_hal_interrupt_irqn[index]);
 
     if(isr) {
         // Pre ISR set

--- a/firmware/targets/f7/furi_hal/furi_hal_interrupt.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_interrupt.c
@@ -62,7 +62,7 @@ const IRQn_Type furi_hal_interrupt_irqn[FuriHalInterruptIdMax] = {
 
 __attribute__((always_inline)) static inline void
     furi_hal_interrupt_call(FuriHalInterruptId index) {
-    furi_assert(furi_hal_interrupt_isr[index].isr);
+    furi_check(furi_hal_interrupt_isr[index].isr);
     furi_hal_interrupt_isr[index].isr(furi_hal_interrupt_isr[index].context);
 }
 

--- a/firmware/targets/f7/furi_hal/furi_hal_interrupt.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_interrupt.c
@@ -127,16 +127,16 @@ void furi_hal_interrupt_set_isr_ex(
     uint16_t priority,
     FuriHalInterruptISR isr,
     void* context) {
-    furi_assert(index < FuriHalInterruptIdMax);
-    furi_assert(priority < 15);
-    furi_assert(furi_hal_interrupt_irqn[index]);
+    furi_check(index < FuriHalInterruptIdMax);
+    furi_check(priority < 15);
+    furi_check(furi_hal_interrupt_irqn[index]);
 
     if(isr) {
         // Pre ISR set
-        furi_assert(furi_hal_interrupt_isr[index].isr == NULL);
+        furi_check(furi_hal_interrupt_isr[index].isr == NULL);
     } else {
         // Pre ISR clear
-        furi_assert(furi_hal_interrupt_isr[index].isr != NULL);
+        furi_check(furi_hal_interrupt_isr[index].isr != NULL);
         furi_hal_interrupt_disable(index);
         furi_hal_interrupt_clear_pending(index);
     }


### PR DESCRIPTION
# What's new

- Infrared: fix crash caused by null-ptr dereference in interrupt call
- FuriHal: callback checks in interrupt handlers
- Protobuf: bump to latest

# Verification 

- Check `RFID/NFC Detector` + `Infrared`
- Check everything
- Check protobuf version

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
