### PR TITLE
FuriHal: allow nulling null isr

### DIFF
--- a/firmware/targets/f7/furi_hal/furi_hal_interrupt.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_interrupt.c
@@ -128,7 +128,7 @@ void furi_hal_interrupt_set_isr_ex(
     FuriHalInterruptISR isr,
     void* context) {
     furi_check(index < FuriHalInterruptIdMax);
-    furi_check(priority < 15);
+    furi_check(priority <= 15);
 
     if(isr) {
         // Pre ISR set

--- a/firmware/targets/f7/furi_hal/furi_hal_interrupt.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_interrupt.c
@@ -135,7 +135,6 @@ void furi_hal_interrupt_set_isr_ex(
         furi_check(furi_hal_interrupt_isr[index].isr == NULL);
     } else {
         // Pre ISR clear
-        furi_check(furi_hal_interrupt_isr[index].isr != NULL);
         furi_hal_interrupt_disable(index);
         furi_hal_interrupt_clear_pending(index);
     }

--- a/furi/core/check.c
+++ b/furi/core/check.c
@@ -36,7 +36,7 @@ PLACE_IN_SECTION("MB_MEM2") uint32_t __furi_check_registers[13] = {0};
  * 
  */
 #define RESTORE_REGISTERS_AND_HALT_MCU(debug)           \
-    register const bool r0 asm("r0") = debug;           \
+    register bool r0 asm("r0") = debug;                 \
     asm volatile("cbnz  r0, with_debugger%=         \n" \
                  "ldr   r12, =__furi_check_registers\n" \
                  "ldm   r12, {r0-r11}               \n" \


### PR DESCRIPTION
# What's new

- FuriHal: allow nulling null isr and prio 15
- Furi: prevent gcc from optimizing debug in RESTORE_REGISTERS_AND_HALT_MCU 

# Verification 

- `flizzer tracker` will remain broken but in a better way: null isr is ok to null again and priority 15 is ok to use
- Check everything

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
