### PR TITLE
[FL-3407] NFC: Mf Ultralight emulation optimization

### DIFF
--- a/lib/nfc/nfc_worker.c
+++ b/lib/nfc/nfc_worker.c
@@ -724,6 +724,8 @@ void nfc_worker_emulate_mf_ultralight(NfcWorker* nfc_worker) {
     emulator.auth_received_callback = nfc_worker_mf_ultralight_auth_received_callback;
     emulator.context = nfc_worker;
 
+    rfal_platform_spi_acquire();
+
     while(nfc_worker->state == NfcWorkerStateMfUltralightEmulate) {
         mf_ul_reset_emulation(&emulator, true);
         furi_hal_nfc_emulate_nfca(
@@ -743,6 +745,8 @@ void nfc_worker_emulate_mf_ultralight(NfcWorker* nfc_worker) {
             emulator.data_changed = false;
         }
     }
+
+    rfal_platform_spi_release();
 }
 
 static bool nfc_worker_mf_get_b_key_from_sector_trailer(


### PR DESCRIPTION
# What's new

- Lock SPI line during MFU emulation

# Verification 

- During Mf Ultralight emulation Flipper responds much faster

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
