### PR TITLE
feat: add API for fallible `ViewDispatcher` View operations

### DIFF
--- a/applications/services/gui/view_dispatcher.h
+++ b/applications/services/gui/view_dispatcher.h
@@ -123,12 +123,29 @@ void view_dispatcher_stop(ViewDispatcher* view_dispatcher);
  */
 void view_dispatcher_add_view(ViewDispatcher* view_dispatcher, uint32_t view_id, View* view);
 
+/** Try to add view to ViewDispatcher
+ *
+ * @param      view_dispatcher  ViewDispatcher instance
+ * @param      view_id          View id to register
+ * @param      view             View instance
+ * @return     {@code true} if there is no view by this ID and {@code false} otherwise
+ */
+bool view_dispatcher_try_add_view(ViewDispatcher* view_dispatcher, uint32_t view_id, View* view);
+
 /** Remove view from ViewDispatcher
  *
  * @param      view_dispatcher  ViewDispatcher instance
  * @param      view_id          View id to remove
  */
 void view_dispatcher_remove_view(ViewDispatcher* view_dispatcher, uint32_t view_id);
+
+/** Try to remove view from ViewDispatcher
+ *
+ * @param      view_dispatcher  ViewDispatcher instance
+ * @param      view_id          View id to remove
+*  @return     {@code true} if there was a view by this ID and {@code false} otherwise
+ */
+bool view_dispatcher_try_remove_view(ViewDispatcher* view_dispatcher, uint32_t view_id);
 
 /** Switch to View
  *
@@ -138,6 +155,16 @@ void view_dispatcher_remove_view(ViewDispatcher* view_dispatcher, uint32_t view_
  *             reached
  */
 void view_dispatcher_switch_to_view(ViewDispatcher* view_dispatcher, uint32_t view_id);
+
+/** Switch to View
+ *
+ * @param      view_dispatcher  ViewDispatcher instance
+ * @param      view_id          View id to register
+*  @return     {@code true} if there is a view by this ID and {@code false} otherwise
+ * @warning    switching may be delayed till input events complementarity
+ *             reached
+ */
+bool view_dispatcher_try_switch_to_view(ViewDispatcher* view_dispatcher, uint32_t view_id);
 
 /** Send ViewPort of this ViewDispatcher instance to front
  *

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,34.1,,
+Version,+,34.2,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,
@@ -3055,6 +3055,9 @@ Function,+,view_dispatcher_set_navigation_event_callback,void,"ViewDispatcher*, 
 Function,+,view_dispatcher_set_tick_event_callback,void,"ViewDispatcher*, ViewDispatcherTickEventCallback, uint32_t"
 Function,+,view_dispatcher_stop,void,ViewDispatcher*
 Function,+,view_dispatcher_switch_to_view,void,"ViewDispatcher*, uint32_t"
+Function,+,view_dispatcher_try_add_view,_Bool,"ViewDispatcher*, uint32_t, View*"
+Function,+,view_dispatcher_try_remove_view,_Bool,"ViewDispatcher*, uint32_t"
+Function,+,view_dispatcher_try_switch_to_view,_Bool,"ViewDispatcher*, uint32_t"
 Function,+,view_free,void,View*
 Function,+,view_free_model,void,View*
 Function,+,view_get_model,void*,View*


### PR DESCRIPTION
# What's new

Fallible APIs (prefixed with `try_`) have been added to `ViewDispatcher` so that it can perform addition/usage/removal of `Views` permitting the operations to fail (depending on the contents of the `ViewSet`).

This API is important for FFI since it allows foreign callers (namely, ust bindings) to provide safe abstractions over `ViewDispatcher` without a need to duplicate IDs tracking on their side.

# Verification 

- `ViewDispatcher`-related tests and code should be re-run

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
