### PR TITLE
Fixes #2957 - subghz decode_raw

### DIFF
--- a/applications/main/subghz/subghz_cli.c
+++ b/applications/main/subghz/subghz_cli.c
@@ -540,6 +540,7 @@ void subghz_cli_command_decode_raw(Cli* cli, FuriString* args, void* context) {
         SubGhzReceiver* receiver = subghz_receiver_alloc_init(environment);
         subghz_receiver_set_filter(receiver, SubGhzProtocolFlag_Decodable);
         subghz_receiver_set_rx_callback(receiver, subghz_cli_command_rx_callback, instance);
+        subghz_devices_init();
 
         SubGhzFileEncoderWorker* file_worker_encoder = subghz_file_encoder_worker_alloc();
         if(subghz_file_encoder_worker_start(
@@ -568,6 +569,7 @@ void subghz_cli_command_decode_raw(Cli* cli, FuriString* args, void* context) {
         printf("\r\nPackets received \033[0;32m%u\033[0m\r\n", instance->packet_count);
 
         // Cleanup
+        subghz_devices_deinit();
         subghz_receiver_free(receiver);
         subghz_environment_free(environment);
 

--- a/applications/main/subghz/subghz_cli.c
+++ b/applications/main/subghz/subghz_cli.c
@@ -540,7 +540,6 @@ void subghz_cli_command_decode_raw(Cli* cli, FuriString* args, void* context) {
         SubGhzReceiver* receiver = subghz_receiver_alloc_init(environment);
         subghz_receiver_set_filter(receiver, SubGhzProtocolFlag_Decodable);
         subghz_receiver_set_rx_callback(receiver, subghz_cli_command_rx_callback, instance);
-        subghz_devices_init();
 
         SubGhzFileEncoderWorker* file_worker_encoder = subghz_file_encoder_worker_alloc();
         if(subghz_file_encoder_worker_start(
@@ -569,7 +568,6 @@ void subghz_cli_command_decode_raw(Cli* cli, FuriString* args, void* context) {
         printf("\r\nPackets received \033[0;32m%u\033[0m\r\n", instance->packet_count);
 
         // Cleanup
-        subghz_devices_deinit();
         subghz_receiver_free(receiver);
         subghz_environment_free(environment);
 

--- a/lib/subghz/subghz_file_encoder_worker.c
+++ b/lib/subghz/subghz_file_encoder_worker.c
@@ -220,7 +220,9 @@ bool subghz_file_encoder_worker_start(
 
     furi_stream_buffer_reset(instance->stream);
     furi_string_set(instance->file_path, file_path);
-    instance->device = subghz_devices_get_by_name(radio_device_name);
+    if(radio_device_name) {
+        instance->device = subghz_devices_get_by_name(radio_device_name);
+    }
     instance->worker_running = true;
     furi_thread_start(instance->thread);
 


### PR DESCRIPTION
# What's new
Fixes CLI "subghz decode_raw" from hang/asserting, so it can successfully decode RAW files.

# Verification 
Record a raw signal (or copy /assets/unit_test/subghz/doorhan_raw.sub into your SD Card/subghz folder.)

Connect to the Flipper CLI (https://lab.flipper.net/cli on a supported browser)

Run the command to decode the saved RAW file...
>: subghz decode_raw /ext/subghz/doorhan_raw.sub
SubGhz decode_raw: Load_keystore keeloq_mfcodes OK
SubGhz decode_raw: Load_keystore keeloq_mfcodes_user ERROR
Listening at /ext/subghz/doorhan_raw.sub.

KeeLoq 64bit
Key:5AB6695A81636CB4
Fix:0x2D36C681    Cnt:04BD
Hop:0x5A966D5A    Btn:2
MF:DoorHan
Sn:0xD36C681 
KeeLoq 64bit
Key:1C81ADD481636CB4
Fix:0x2D36C681    Cnt:04BE
Hop:0x2BB58138    Btn:2
MF:DoorHan
Sn:0xD36C681 
KeeLoq 64bit
Key:3BBA515C81636CB4
Fix:0x2D36C681    Cnt:04BF
Hop:0x3A8A5DDC    Btn:2
MF:DoorHan
Sn:0xD36C681 

Packets received 3

>: 

Confirm Sub-GHz on the Flipper still works (Read/Saved/etc.)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
