### PR TITLE
FBT: update WiFi devboard firmware

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -327,6 +327,9 @@ distenv.PhonyTarget(
     "cli", "${PYTHON3} ${FBT_SCRIPT_DIR}/serial_cli.py  -p ${FLIP_PORT}"
 )
 
+# Update WiFi devboard firmware
+distenv.PhonyTarget("devboard_flash", "${PYTHON3} ${FBT_SCRIPT_DIR}/wifi_board.py")
+
 
 # Find blackmagic probe
 distenv.PhonyTarget(

--- a/documentation/fbt.md
+++ b/documentation/fbt.md
@@ -69,6 +69,7 @@ To run cleanup (think of `make clean`) for specified targets, add the `-c` optio
 - `debug` - build and flash firmware, then attach with gdb with firmware's .elf loaded.
 - `debug_other`, `debug_other_blackmagic` - attach GDB without loading any `.elf`. It will allow you to manually add external `.elf` files with `add-symbol-file` in GDB.
 - `updater_debug` - attach GDB with the updater's `.elf` loaded.
+- `devboard_flash` - update WiFi dev board with the latest firmware.
 - `blackmagic` - debug firmware with Blackmagic probe (WiFi dev board).
 - `openocd` - just start OpenOCD.
 - `get_blackmagic` - output the blackmagic address in the GDB remote format. Useful for IDE integration.


### PR DESCRIPTION
# What's new

- Added new target `devboard_flash` to update WiFi devboard firmware.

# Verification 

- Prepare the devboard by entering bootloader mode and run `./fbt devboard_flash` 

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
