### PR TITLE
uFBT: devboard_flash to update WiFi devboard

### DIFF
--- a/scripts/ufbt/SConstruct
+++ b/scripts/ufbt/SConstruct
@@ -348,6 +348,9 @@ appenv.PhonyTarget(
     '${PYTHON3} "${FBT_SCRIPT_DIR}/serial_cli.py" -p ${FLIP_PORT}',
 )
 
+# Update WiFi devboard firmware
+dist_env.PhonyTarget("devboard_flash", "${PYTHON3} ${FBT_SCRIPT_DIR}/wifi_board.py")
+
 # Linter
 
 dist_env.PhonyTarget(

--- a/scripts/ufbt/site_tools/ufbt_help.py
+++ b/scripts/ufbt/site_tools/ufbt_help.py
@@ -26,6 +26,8 @@ Flashing & debugging:
         Install firmware using self-update package
     debug, debug_other, blackmagic:
         Start GDB
+    devboard_flash:
+        Update WiFi dev board with the latest firmware
 
 Other:
     cli:


### PR DESCRIPTION
# What's new

- Added new target `devboard_flash` to update WiFi devboard firmware.

# Verification 

- `pip install ufbt`
- `./fbt updater_package`
- `ufbt update -t f7 -l dist/f7-D/flipper-z-f7-sdk-local.zip`
- Prepare the devboard by entering bootloader mode and run `ufbt devboard_flash`

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
