### PR TITLE
ufbt: fixed FAP_SRC_DIR 

### DIFF
--- a/scripts/fbt/appmanifest.py
+++ b/scripts/fbt/appmanifest.py
@@ -2,6 +2,7 @@ import os
 import re
 from dataclasses import dataclass, field
 from enum import Enum
+from fbt.util import resolve_real_dir_node
 from typing import Callable, ClassVar, List, Optional, Tuple, Union
 
 
@@ -152,7 +153,7 @@ class AppManager:
                 FlipperApplication(
                     *args,
                     **kw,
-                    _appdir=app_dir_node,
+                    _appdir=resolve_real_dir_node(app_dir_node),
                     _apppath=os.path.dirname(app_manifest_path),
                     _appmanager=self,
                 ),

--- a/scripts/fbt/util.py
+++ b/scripts/fbt/util.py
@@ -45,23 +45,20 @@ def single_quote(arg_list):
     return " ".join(f"'{arg}'" if " " in arg else str(arg) for arg in arg_list)
 
 
-def extract_abs_dir(node):
+def resolve_real_dir_node(node):
     if isinstance(node, SCons.Node.FS.EntryProxy):
         node = node.get()
 
+    real_node = None
     for repo_dir in node.get_all_rdirs():
         if os.path.exists(repo_dir.abspath):
-            return repo_dir
+            real_node = repo_dir
+            break
 
+    if not real_node:
+        raise StopError(f"Can't find absolute path for {node.name} ({node})")
 
-def extract_abs_dir_path(node):
-    abs_dir_node = extract_abs_dir(node)
-    if abs_dir_node is None:
-        raise StopError(f"Can't find absolute path for {node.name}")
-
-    # Don't return abspath attribute (type is str), it will break in
-    # OverrideEnvironment.subst_list() by splitting path on spaces
-    return abs_dir_node
+    return real_node
 
 
 def path_as_posix(path):

--- a/scripts/fbt/util.py
+++ b/scripts/fbt/util.py
@@ -49,16 +49,11 @@ def resolve_real_dir_node(node):
     if isinstance(node, SCons.Node.FS.EntryProxy):
         node = node.get()
 
-    real_node = None
     for repo_dir in node.get_all_rdirs():
         if os.path.exists(repo_dir.abspath):
-            real_node = repo_dir
-            break
+            return repo_dir
 
-    if not real_node:
-        raise StopError(f"Can't find absolute path for {node.name} ({node})")
-
-    return real_node
+    raise StopError(f"Can't find absolute path for {node.name} ({node})")
 
 
 def path_as_posix(path):

--- a/scripts/fbt_tools/fbt_assets.py
+++ b/scripts/fbt_tools/fbt_assets.py
@@ -8,11 +8,14 @@ from SCons.Errors import StopError
 
 
 def icons_emitter(target, source, env):
+    icons_src = env.GlobRecursive("*.png", env["ICON_SRC_DIR"])
+    icons_src += env.GlobRecursive("frame_rate", env["ICON_SRC_DIR"])
+
     target = [
         target[0].File(env.subst("${ICON_FILE_NAME}.c")),
         target[0].File(env.subst("${ICON_FILE_NAME}.h")),
     ]
-    return target, source
+    return target, icons_src
 
 
 def proto_emitter(target, source, env):
@@ -104,17 +107,12 @@ def proto_ver_generator(target, source, env):
 
 
 def CompileIcons(env, target_dir, source_dir, *, icon_bundle_name="assets_icons"):
-    # Gathering icons sources
-    icons_src = env.GlobRecursive("*.png", source_dir)
-    icons_src += env.GlobRecursive("frame_rate", source_dir)
-
-    icons = env.IconBuilder(
+    return env.IconBuilder(
         target_dir,
-        source_dir,
+        None,
+        ICON_SRC_DIR=source_dir,
         ICON_FILE_NAME=icon_bundle_name,
     )
-    env.Depends(icons, icons_src)
-    return icons
 
 
 def generate(env):
@@ -137,7 +135,7 @@ def generate(env):
         BUILDERS={
             "IconBuilder": Builder(
                 action=Action(
-                    '${PYTHON3} ${ASSETS_COMPILER} icons ${ABSPATHGETTERFUNC(SOURCE)} ${TARGET.dir} --filename "${ICON_FILE_NAME}"',
+                    '${PYTHON3} ${ASSETS_COMPILER} icons ${ICON_SRC_DIR} ${TARGET.dir} --filename "${ICON_FILE_NAME}"',
                     "${ICONSCOMSTR}",
                 ),
                 emitter=icons_emitter,

--- a/scripts/fbt_tools/fbt_extapps.py
+++ b/scripts/fbt_tools/fbt_extapps.py
@@ -11,7 +11,7 @@ from fbt.appmanifest import FlipperApplication, FlipperAppType, FlipperManifestE
 from fbt.elfmanifest import assemble_manifest_data
 from fbt.fapassets import FileBundler
 from fbt.sdk.cache import SdkCache
-from fbt.util import extract_abs_dir_path
+from fbt.util import resolve_real_dir_node
 from SCons.Action import Action
 from SCons.Builder import Builder
 from SCons.Errors import UserError
@@ -119,7 +119,7 @@ class AppBuilder:
             CPPDEFINES=lib_def.cdefines,
             CPPPATH=list(
                 map(
-                    lambda cpath: extract_abs_dir_path(self.app._appdir.Dir(cpath)),
+                    lambda cpath: resolve_real_dir_node(self.app._appdir.Dir(cpath)),
                     lib_def.cincludes,
                 )
             ),

--- a/scripts/fbt_tools/fbt_extapps.py
+++ b/scripts/fbt_tools/fbt_extapps.py
@@ -50,7 +50,8 @@ class AppBuilder:
 
     def _setup_app_env(self):
         self.app_env = self.fw_env.Clone(
-            FAP_SRC_DIR=self.app._appdir, FAP_WORK_DIR=self.app_work_dir
+            FAP_SRC_DIR=self.app._appdir,
+            FAP_WORK_DIR=self.app_work_dir,
         )
         self.app_env.VariantDir(self.app_work_dir, self.app._appdir, duplicate=False)
 
@@ -133,7 +134,7 @@ class AppBuilder:
     def _build_app(self):
         self.app_env.Append(
             LIBS=[*self.app.fap_libs, *self.private_libs],
-            CPPPATH=self.app_env.Dir(self.app_work_dir),
+            CPPPATH=[self.app_env.Dir(self.app_work_dir), self.app._appdir],
         )
 
         app_sources = list(

--- a/scripts/ufbt/SConstruct
+++ b/scripts/ufbt/SConstruct
@@ -1,11 +1,10 @@
-from SCons.Platform import TempFileMunge
-from SCons.Node import FS
-from SCons.Errors import UserError
-
-
-import os
 import multiprocessing
+import os
 import pathlib
+
+from SCons.Errors import UserError
+from SCons.Node import FS
+from SCons.Platform import TempFileMunge
 
 SetOption("num_jobs", multiprocessing.cpu_count())
 SetOption("max_drift", 1)
@@ -67,16 +66,15 @@ core_env.Append(CPPDEFINES=GetOption("extra_defines"))
 
 # Now we can import stuff bundled with SDK - it was added to sys.path by ufbt_state
 
-from fbt.util import (
-    tempfile_arg_esc_func,
-    single_quote,
-    extract_abs_dir,
-    extract_abs_dir_path,
-    wrap_tempfile,
-    path_as_posix,
-)
-from fbt.appmanifest import FlipperAppType, FlipperApplication
+from fbt.appmanifest import FlipperApplication, FlipperAppType
 from fbt.sdk.cache import SdkCache
+from fbt.util import (
+    path_as_posix,
+    resolve_real_dir_node,
+    single_quote,
+    tempfile_arg_esc_func,
+    wrap_tempfile,
+)
 
 # Base environment with all tools loaded from SDK
 env = core_env.Clone(
@@ -107,7 +105,7 @@ env = core_env.Clone(
     PROGSUFFIX=".elf",
     TEMPFILEARGESCFUNC=tempfile_arg_esc_func,
     SINGLEQUOTEFUNC=single_quote,
-    ABSPATHGETTERFUNC=extract_abs_dir_path,
+    ABSPATHGETTERFUNC=resolve_real_dir_node,
     APPS=[],
     UFBT_API_VERSION=SdkCache(
         core_env.subst("$SDK_DEFINITION"), load_version_only=True
@@ -277,7 +275,7 @@ for app in known_extapps:
         continue
 
     app_artifacts = appenv.BuildAppElf(app)
-    app_src_dir = extract_abs_dir(app_artifacts.app._appdir)
+    app_src_dir = resolve_real_dir_node(app_artifacts.app._appdir)
     app_artifacts.installer = [
         appenv.Install(app_src_dir.Dir("dist"), app_artifacts.compact),
         appenv.Install(app_src_dir.Dir("dist").Dir("debug"), app_artifacts.debug),

--- a/site_scons/environ.scons
+++ b/site_scons/environ.scons
@@ -3,7 +3,7 @@ from fbt.util import (
     tempfile_arg_esc_func,
     single_quote,
     wrap_tempfile,
-    extract_abs_dir_path,
+    resolve_real_dir_node,
 )
 
 import os
@@ -58,7 +58,7 @@ coreenv = VAR_ENV.Clone(
     PROGSUFFIX=".elf",
     ENV=forward_os_env,
     SINGLEQUOTEFUNC=single_quote,
-    ABSPATHGETTERFUNC=extract_abs_dir_path,
+    ABSPATHGETTERFUNC=resolve_real_dir_node,
     # Setting up temp file parameters - to overcome command line length limits
     TEMPFILEARGESCFUNC=tempfile_arg_esc_func,
     ROOT_DIR=Dir("#"),


### PR DESCRIPTION
# What's new

- fbt, ufbt: fixed "_appdir" internal property and FAP_SRC_DIR not working in ufbt environment
- added app's own root dir to its `#include` paths

# Verification 

- check that firmware can be build
- try using FAP_SRC_DIR when building apps with ufbt

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
