### PR TITLE
loader: restored support for debug apps

### DIFF
--- a/applications/services/applications.h
+++ b/applications/services/applications.h
@@ -51,6 +51,12 @@ extern const size_t FLIPPER_ON_SYSTEM_START_COUNT;
 extern const FlipperInternalApplication FLIPPER_SYSTEM_APPS[];
 extern const size_t FLIPPER_SYSTEM_APPS_COUNT;
 
+/* Debug apps 
+ * Can only be spawned by loader by name
+ */
+extern const FlipperInternalApplication FLIPPER_DEBUG_APPS[];
+extern const size_t FLIPPER_DEBUG_APPS_COUNT;
+
 extern const FlipperInternalApplication FLIPPER_ARCHIVE;
 
 /* Settings list

--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -381,12 +381,7 @@ Desktop* desktop_alloc() {
     }
     gui_add_view_port(desktop->gui, desktop->stealth_mode_icon_viewport, GuiLayerStatusBarLeft);
 
-    // Special case: autostart application is already running
     desktop->loader = furi_record_open(RECORD_LOADER);
-    if(loader_is_locked(desktop->loader) &&
-       animation_manager_is_animation_loaded(desktop->animation_manager)) {
-        animation_manager_unload_and_stall_animation(desktop->animation_manager);
-    }
 
     desktop->notification = furi_record_open(RECORD_NOTIFICATION);
     desktop->app_start_stop_subscription = furi_pubsub_subscribe(
@@ -475,6 +470,12 @@ int32_t desktop_srv(void* p) {
 
     if(furi_hal_rtc_get_fault_data()) {
         scene_manager_next_scene(desktop->scene_manager, DesktopSceneFault);
+    }
+
+    // Special case: autostart application is already running
+    if(loader_is_locked(desktop->loader) &&
+       animation_manager_is_animation_loaded(desktop->animation_manager)) {
+        animation_manager_unload_and_stall_animation(desktop->animation_manager);
     }
 
     view_dispatcher_run(desktop->view_dispatcher);

--- a/applications/services/loader/loader.c
+++ b/applications/services/loader/loader.c
@@ -1,4 +1,5 @@
 #include "loader.h"
+#include "core/core_defines.h"
 #include "loader_i.h"
 #include <applications.h>
 #include <storage/storage.h>
@@ -186,18 +187,24 @@ static FlipperInternalApplication const* loader_find_application_by_name_in_list
 }
 
 static const FlipperInternalApplication* loader_find_application_by_name(const char* name) {
-    const FlipperInternalApplication* application = NULL;
-    application = loader_find_application_by_name_in_list(name, FLIPPER_APPS, FLIPPER_APPS_COUNT);
-    if(!application) {
-        application = loader_find_application_by_name_in_list(
-            name, FLIPPER_SETTINGS_APPS, FLIPPER_SETTINGS_APPS_COUNT);
-    }
-    if(!application) {
-        application = loader_find_application_by_name_in_list(
-            name, FLIPPER_SYSTEM_APPS, FLIPPER_SYSTEM_APPS_COUNT);
+    const struct {
+        const FlipperInternalApplication* list;
+        const uint32_t count;
+    } lists[] = {
+        {FLIPPER_SETTINGS_APPS, FLIPPER_SETTINGS_APPS_COUNT},
+        {FLIPPER_SYSTEM_APPS, FLIPPER_SYSTEM_APPS_COUNT},
+        {FLIPPER_DEBUG_APPS, FLIPPER_DEBUG_APPS_COUNT},
+    };
+
+    for(size_t i = 0; i < COUNT_OF(lists); i++) {
+        const FlipperInternalApplication* application =
+            loader_find_application_by_name_in_list(name, lists[i].list, lists[i].count);
+        if(application) {
+            return application;
+        }
     }
 
-    return application;
+    return NULL;
 }
 
 static void loader_start_app_thread(Loader* loader, FlipperInternalApplicationFlag flags) {

--- a/applications/services/loader/loader.c
+++ b/applications/services/loader/loader.c
@@ -498,6 +498,7 @@ int32_t loader_srv(void* p) {
     }
 
     if(FLIPPER_AUTORUN_APP_NAME && strlen(FLIPPER_AUTORUN_APP_NAME)) {
+        FURI_LOG_I(TAG, "Starting autorun app: %s", FLIPPER_AUTORUN_APP_NAME);
         loader_do_start_by_name(loader, FLIPPER_AUTORUN_APP_NAME, NULL, NULL);
     }
 

--- a/applications/services/loader/loader.c
+++ b/applications/services/loader/loader.c
@@ -260,9 +260,7 @@ static void loader_log_status_error(
         furi_string_vprintf(error_message, format, args);
         FURI_LOG_E(TAG, "Status [%d]: %s", status, furi_string_get_cstr(error_message));
     } else {
-        FuriString* tmp = furi_string_alloc();
-        FURI_LOG_E(TAG, "Status [%d]: %s", status, furi_string_get_cstr(tmp));
-        furi_string_free(tmp);
+        FURI_LOG_E(TAG, "Status [%d]", status);
     }
 }
 

--- a/applications/services/loader/loader.c
+++ b/applications/services/loader/loader.c
@@ -497,7 +497,8 @@ int32_t loader_srv(void* p) {
         FLIPPER_ON_SYSTEM_START[i]();
     }
 
-    if(FLIPPER_AUTORUN_APP_NAME && strlen(FLIPPER_AUTORUN_APP_NAME)) {
+    if((furi_hal_rtc_get_boot_mode() == FuriHalRtcBootModeNormal) && FLIPPER_AUTORUN_APP_NAME &&
+       strlen(FLIPPER_AUTORUN_APP_NAME)) {
         FURI_LOG_I(TAG, "Starting autorun app: %s", FLIPPER_AUTORUN_APP_NAME);
         loader_do_start_by_name(loader, FLIPPER_AUTORUN_APP_NAME, NULL, NULL);
     }


### PR DESCRIPTION
# What's new

- restored loader support for debug apps (no GUI tho)

# Verification 

- `./fbt LOADER_AUTOSTART="Display Test" --extra-int-apps=display_test flash_usb`

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
