### PR TITLE
Removed explicit dependency on scons for external scripting

### DIFF
--- a/scripts/fbt/appmanifest.py
+++ b/scripts/fbt/appmanifest.py
@@ -2,8 +2,14 @@ import os
 import re
 from dataclasses import dataclass, field
 from enum import Enum
-from fbt.util import resolve_real_dir_node
 from typing import Callable, ClassVar, List, Optional, Tuple, Union
+
+try:
+    from fbt.util import resolve_real_dir_node
+except ImportError:
+    # When running outside of SCons, we don't have access to SCons.Node
+    def resolve_real_dir_node(node):
+        return node
 
 
 class FlipperManifestException(Exception):


### PR DESCRIPTION
# What's new

- scripts: appmanifest: removed explicit dependency on scons for external scripting

# Verification 

- try importing `appmanifest` from clean Python environment

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
