### PR TITLE
[FL-3565] Rfid: fix crash on broken key launch from archive

### DIFF
--- a/applications/main/lfrfid/lfrfid.c
+++ b/applications/main/lfrfid/lfrfid.c
@@ -186,13 +186,15 @@ int32_t lfrfid_app(void* p) {
             dolphin_deed(DolphinDeedRfidEmulate);
         } else {
             furi_string_set(app->file_path, args);
-            lfrfid_load_key_data(app, app->file_path, true);
-            view_dispatcher_attach_to_gui(
-                app->view_dispatcher, app->gui, ViewDispatcherTypeFullscreen);
-            scene_manager_next_scene(app->scene_manager, LfRfidSceneEmulate);
-            dolphin_deed(DolphinDeedRfidEmulate);
+            if(lfrfid_load_key_data(app, app->file_path, true)) {
+                view_dispatcher_attach_to_gui(
+                    app->view_dispatcher, app->gui, ViewDispatcherTypeFullscreen);
+                scene_manager_next_scene(app->scene_manager, LfRfidSceneEmulate);
+                dolphin_deed(DolphinDeedRfidEmulate);
+            } else {
+                view_dispatcher_stop(app->view_dispatcher);
+            }
         }
-
     } else {
         view_dispatcher_attach_to_gui(
             app->view_dispatcher, app->gui, ViewDispatcherTypeFullscreen);


### PR DESCRIPTION
# What's new

- Rfid: fix crash on broken key launch from archive, fixes #2983

# Verification 

- Open broken rfid key from archive (#2983)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
