### PR TITLE
NFC: fix ISO14443-4A cards emulation

### DIFF
--- a/firmware/targets/f7/furi_hal/furi_hal_nfc.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_nfc.c
@@ -701,7 +701,9 @@ bool furi_hal_nfc_tx_rx(FuriHalNfcTxRxContext* tx_rx, uint16_t timeout_ms) {
         rfalNfcWorker();
         state = rfalNfcGetState();
         ret = rfalNfcDataExchangeGetStatus();
-        if(ret == ERR_BUSY) {
+        if(ret == ERR_WRONG_STATE) {
+            return false;
+        } else if(ret == ERR_BUSY) {
             if(DWT->CYCCNT - start > timeout_ms * clocks_in_ms) {
                 FURI_LOG_D(TAG, "Timeout during data exchange");
                 return false;


### PR DESCRIPTION
# What's new

- Add RFAL "Wrong state" error handling

# Verification 

- All ISO14443-4A uid emulation work

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
