### PR TITLE
[FL-3582] SubGhz: heap overflow text error

### DIFF
--- a/applications/main/subghz/scenes/subghz_scene_receiver.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver.c
@@ -123,7 +123,7 @@ void subghz_scene_receiver_on_enter(void* context) {
         subghz_rx_key_state_set(subghz, SubGhzRxKeyStateAddKey);
     }
     furi_string_free(str_buff);
-    subghz_scene_receiver_update_statusbar(subghz);
+
     subghz_view_receiver_set_callback(
         subghz->subghz_receiver, subghz_scene_receiver_callback, subghz);
     subghz_txrx_set_rx_calback(subghz->txrx, subghz_scene_add_to_history_callback, subghz);
@@ -135,6 +135,8 @@ void subghz_scene_receiver_on_enter(void* context) {
     //to use a universal decoder, we are looking for a link to it
     furi_check(
         subghz_txrx_load_decoder_by_name_protocol(subghz->txrx, SUBGHZ_PROTOCOL_BIN_RAW_NAME));
+
+    subghz_scene_receiver_update_statusbar(subghz);
 
     view_dispatcher_switch_to_view(subghz->view_dispatcher, SubGhzViewIdReceiver);
 }


### PR DESCRIPTION
# What's new

- [FL-3582] SubGhz: heap overflow text error

# Verification 

- Receive a signal until the inscription "Free heap LOW" appears, press "Back" then "Stay". The inscription must remain

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-3582]: https://flipperzero.atlassian.net/browse/FL-3582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ