### PR TITLE
[FL-3543] Check the filetype of the update manifest

### DIFF
--- a/lib/update_util/update_manifest.c
+++ b/lib/update_util/update_manifest.c
@@ -54,10 +54,10 @@ static bool
 
     FuriString* filetype;
 
-    // TODO FL-3543: compare filetype?
     filetype = furi_string_alloc();
     update_manifest->valid =
         flipper_format_read_header(flipper_file, filetype, &update_manifest->manifest_version) &&
+        furi_string_cmp_str(filetype, "Flipper firmware upgrade configuration") == 0 &&
         flipper_format_read_string(flipper_file, MANIFEST_KEY_INFO, update_manifest->version) &&
         flipper_format_read_uint32(
             flipper_file, MANIFEST_KEY_TARGET, &update_manifest->target, 1) &&


### PR DESCRIPTION
# What's new

- When updating, the manifest filetype is now checked

# Verification 

- Do a normal self-update, check that it still works
- Edit the manifest filetype to any other string, check that the update will fail

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
