### PR TITLE
[DOC] Remove defunct link in ReadMe.md

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -95,7 +95,6 @@ Make sure your Flipper is on, and your firmware is functioning. Connect your Fli
 - [Hardware combos and Un-bricking](/documentation/KeyCombo.md) - recovering your Flipper from the most nasty situations
 - [Flipper File Formats](/documentation/file_formats) - everything about how Flipper stores your data and how you can work with it
 - [Universal Remotes](/documentation/UniversalRemotes.md) - contributing your infrared remote to the universal remote database
-- [Firmware Roadmap](/documentation/RoadMap.md)
 - And much more in the [documentation](/documentation) folder
 
 # Project structure


### PR DESCRIPTION
# What's new

- Documentation changes

In a recent change, the RoadMap.md file was removed from the documentation directory, and a roadmap section was added to the ReadMe.md, but the existing link to RoadMap.md was not removed, leaving this extraneous and defunct link in the main readme file.

# Verification 

- Click the erroneous link in the current dev branch ReadMe.md, see 404.
- Notice lack of erroneous link in my branch.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
