### PR TITLE
[FL-3583]Account for the "-" in line carry-over

### DIFF
--- a/applications/services/gui/elements.c
+++ b/applications/services/gui/elements.c
@@ -290,7 +290,8 @@ void elements_multiline_text_aligned(
         } else if((y + font_height) > canvas_height(canvas)) {
             line = furi_string_alloc_printf("%.*s...\n", chars_fit, start);
         } else {
-            line = furi_string_alloc_printf("%.*s-\n", chars_fit, start);
+            // Account for the added "-" in length
+            line = furi_string_alloc_printf("%.*s-\n", chars_fit - 1, start);
         }
         canvas_draw_str_aligned(canvas, x, y, horizontal, vertical, furi_string_get_cstr(line));
         furi_string_free(line);


### PR DESCRIPTION
# What's new

- Center-aligned text no longer goes out of bounds in some edge cases

# Verification 

- Set the sudoku game as your favorite
- Delete the file for the game
- Try triggering the favorite app
- The error message should not have the "A" in "Application" cut off

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
