### PR TITLE
[FL-3566] iButton: Return to the file selection if file is corrupted

### DIFF
--- a/applications/main/ibutton/ibutton.c
+++ b/applications/main/ibutton/ibutton.c
@@ -195,6 +195,7 @@ bool ibutton_load_key(iButton* ibutton) {
 
 bool ibutton_select_and_load_key(iButton* ibutton) {
     DialogsFileBrowserOptions browser_options;
+    bool success = false;
     dialog_file_browser_set_basic_options(
         &browser_options, IBUTTON_APP_FILENAME_EXTENSION, &I_ibutt_10px);
     browser_options.base_path = IBUTTON_APP_FOLDER;
@@ -203,9 +204,14 @@ bool ibutton_select_and_load_key(iButton* ibutton) {
         furi_string_set(ibutton->file_path, browser_options.base_path);
     }
 
-    return dialog_file_browser_show(
-               ibutton->dialogs, ibutton->file_path, ibutton->file_path, &browser_options) &&
-           ibutton_load_key(ibutton);
+    do {
+        if(!dialog_file_browser_show(
+               ibutton->dialogs, ibutton->file_path, ibutton->file_path, &browser_options))
+            break;
+        success = ibutton_load_key(ibutton);
+    } while(!success);
+
+    return success;
 }
 
 bool ibutton_save_key(iButton* ibutton) {


### PR DESCRIPTION
# What's new

- The "Cannot load key file" error message leads back to the file picker instead of the main menu

# Verification 

- Open a broken file and press left or back in iButton. You should be returned to the file selection menu with the cursor on that file.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
