### PR TITLE
github: don't cancel jobs if parallel ones failed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
   main:
     runs-on: [self-hosted, FlipperZeroShell]
     strategy:
+      fail-fast: false
       matrix:
         target: [f7, f18]    
     steps:

--- a/.github/workflows/build_compact.yml
+++ b/.github/workflows/build_compact.yml
@@ -10,6 +10,7 @@ jobs:
   compact:
     runs-on: [self-hosted, FlipperZeroShell]
     strategy:
+      fail-fast: false
       matrix:
         target: [f7, f18]
     steps:


### PR DESCRIPTION
# What's new

- github: don't cancel jobs if parallel ones failed

# Verification 

- see cancelled jobs in https://github.com/flipperdevices/flipperzero-firmware/pull/3037 - should no longer happen 

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
