### PR TITLE
[FL-3584] Emulation exit fix

### DIFF
--- a/applications/main/nfc/helpers/protocol_support/mf_desfire/mf_desfire.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_desfire/mf_desfire.c
@@ -66,8 +66,8 @@ static void nfc_scene_read_success_on_enter_mf_desfire(NfcApp* instance) {
 }
 
 static void nfc_scene_emulate_on_enter_mf_desfire(NfcApp* instance) {
-    const MfDesfireData* data = nfc_device_get_data(instance->nfc_device, NfcProtocolMfDesfire);
-    const Iso14443_4aData* iso14443_4a_data = data->iso14443_4a_data;
+    const Iso14443_4aData* iso14443_4a_data =
+        nfc_device_get_data(instance->nfc_device, NfcProtocolIso14443_4a);
 
     instance->listener =
         nfc_listener_alloc(instance->nfc, NfcProtocolIso14443_4a, iso14443_4a_data);

--- a/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
+++ b/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
@@ -507,17 +507,13 @@ static bool
 static void nfc_protocol_support_scene_emulate_on_exit(NfcApp* instance) {
     nfc_listener_stop(instance->listener);
 
-    NfcDevice* nfc_stub = nfc_device_alloc();
-    NfcProtocol protocol = nfc_device_get_protocol(instance->nfc_device);
+    const NfcProtocol protocol = nfc_device_get_protocol(instance->nfc_device);
     const NfcDeviceData* data = nfc_listener_get_data(instance->listener, protocol);
-    nfc_device_set_data(nfc_stub, protocol, data);
 
-    //TODO: think about nfc_device_is_equal(NfcDevice*,NfcDeviceData*);
-    if(!nfc_device_is_equal(nfc_stub, instance->nfc_device)) {
+    if(!nfc_device_contains_data(instance->nfc_device, protocol, data)) {
         nfc_device_set_data(instance->nfc_device, protocol, data);
         nfc_save_shadow_file(instance);
     }
-    nfc_device_free(nfc_stub);
 
     nfc_listener_free(instance->listener);
 

--- a/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
+++ b/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
@@ -107,7 +107,8 @@ static void nfc_protocol_support_scene_read_on_enter(NfcApp* instance) {
 
     view_dispatcher_switch_to_view(instance->view_dispatcher, NfcViewPopup);
 
-    const NfcProtocol protocol = instance->protocols_detected[instance->protocols_detected_selected_idx];
+    const NfcProtocol protocol =
+        instance->protocols_detected[instance->protocols_detected_selected_idx];
     instance->poller = nfc_poller_alloc(instance->nfc, protocol);
 
     // Start poller with the appropriate callback

--- a/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
+++ b/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
@@ -508,11 +508,15 @@ static void nfc_protocol_support_scene_emulate_on_exit(NfcApp* instance) {
     nfc_listener_stop(instance->listener);
 
     const NfcProtocol protocol = nfc_device_get_protocol(instance->nfc_device);
-    const NfcDeviceData* data = nfc_listener_get_data(instance->listener, protocol);
 
-    if(!nfc_device_contains_data(instance->nfc_device, protocol, data)) {
-        nfc_device_set_data(instance->nfc_device, protocol, data);
-        nfc_save_shadow_file(instance);
+    // TODO: What are shadow files for partial emulation?
+    if(protocol == nfc_listener_get_protocol(instance->listener)) {
+        const NfcDeviceData* data = nfc_listener_get_data(instance->listener, protocol);
+
+        if(!nfc_device_contains_data(instance->nfc_device, protocol, data)) {
+            nfc_device_set_data(instance->nfc_device, protocol, data);
+            nfc_save_shadow_file(instance);
+        }
     }
 
     nfc_listener_free(instance->listener);

--- a/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
+++ b/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
@@ -512,7 +512,6 @@ static void nfc_protocol_support_scene_emulate_on_exit(NfcApp* instance) {
 
     const NfcProtocol protocol = nfc_device_get_protocol(instance->nfc_device);
 
-    // TODO: What are shadow files for partial emulation?
     if(protocol == nfc_listener_get_protocol(instance->listener)) {
         const NfcDeviceData* data = nfc_listener_get_data(instance->listener, protocol);
 

--- a/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
+++ b/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
@@ -515,7 +515,7 @@ static void nfc_protocol_support_scene_emulate_on_exit(NfcApp* instance) {
     if(protocol == nfc_listener_get_protocol(instance->listener)) {
         const NfcDeviceData* data = nfc_listener_get_data(instance->listener, protocol);
 
-        if(!nfc_device_contains_data(instance->nfc_device, protocol, data)) {
+        if(!nfc_device_is_equal_data(instance->nfc_device, protocol, data)) {
             nfc_device_set_data(instance->nfc_device, protocol, data);
             nfc_save_shadow_file(instance);
         }

--- a/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
+++ b/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
@@ -107,7 +107,7 @@ static void nfc_protocol_support_scene_read_on_enter(NfcApp* instance) {
 
     view_dispatcher_switch_to_view(instance->view_dispatcher, NfcViewPopup);
 
-    const NfcProtocol protocol = instance->protocols_detected[instance->protocols_detected_idx];
+    const NfcProtocol protocol = instance->protocols_detected[instance->protocols_detected_selected_idx];
     instance->poller = nfc_poller_alloc(instance->nfc, protocol);
 
     // Start poller with the appropriate callback
@@ -135,7 +135,7 @@ static bool nfc_protocol_support_scene_read_on_event(NfcApp* instance, SceneMana
                 consumed = true;
             } else {
                 const NfcProtocol protocol =
-                    instance->protocols_detected[instance->protocols_detected_idx];
+                    instance->protocols_detected[instance->protocols_detected_selected_idx];
                 if(nfc_protocol_support[protocol]->scene_read.on_event) {
                     consumed =
                         nfc_protocol_support[protocol]->scene_read.on_event(instance, event.event);

--- a/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
+++ b/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
@@ -135,8 +135,7 @@ static bool nfc_protocol_support_scene_read_on_event(NfcApp* instance, SceneMana
                 dolphin_deed(DolphinDeedNfcReadSuccess);
                 consumed = true;
             } else {
-                const NfcProtocol protocol =
-                    instance->protocols_detected[instance->protocols_detected_selected_idx];
+                const NfcProtocol protocol = nfc_poller_get_protocol(instance->poller);
                 if(nfc_protocol_support[protocol]->scene_read.on_event) {
                     consumed =
                         nfc_protocol_support[protocol]->scene_read.on_event(instance, event.event);

--- a/applications/main/nfc/nfc_app.c
+++ b/applications/main/nfc/nfc_app.c
@@ -444,13 +444,13 @@ void nfc_app_set_detected_protocols(NfcApp* instance, const NfcProtocol* types, 
 
     memcpy(instance->protocols_detected, types, count);
     instance->protocols_detected_num = count;
-    instance->protocols_detected_idx = 0;
+    instance->protocols_detected_selected_idx = 0;
 }
 
 void nfc_app_reset_detected_protocols(NfcApp* instance) {
     furi_assert(instance);
 
-    instance->protocols_detected_idx = 0;
+    instance->protocols_detected_selected_idx = 0;
     instance->protocols_detected_num = 0;
 }
 

--- a/applications/main/nfc/nfc_app_i.h
+++ b/applications/main/nfc/nfc_app_i.h
@@ -100,9 +100,9 @@ struct NfcApp {
     FuriString* text_box_store;
     uint8_t byte_input_store[6];
 
-    size_t protocols_detected_num;
-    size_t protocols_detected_idx;
+    uint32_t protocols_detected_num;
     NfcProtocol protocols_detected[NfcProtocolNum];
+    uint32_t protocols_detected_selected_idx;
 
     void* rpc_ctx;
     NfcRpcState rpc_state;

--- a/applications/main/nfc/scenes/nfc_scene_detect.c
+++ b/applications/main/nfc/scenes/nfc_scene_detect.c
@@ -39,7 +39,6 @@ bool nfc_scene_detect_on_event(void* context, SceneManagerEvent event) {
             if(instance->protocols_detected_num > 1) {
                 scene_manager_next_scene(instance->scene_manager, NfcSceneSelectProtocol);
             } else {
-                instance->protocols_detected_idx = 0;
                 scene_manager_next_scene(instance->scene_manager, NfcSceneRead);
             }
             consumed = true;

--- a/applications/main/nfc/scenes/nfc_scene_detect.c
+++ b/applications/main/nfc/scenes/nfc_scene_detect.c
@@ -7,8 +7,7 @@ void nfc_scene_detect_scan_callback(NfcScannerEvent event, void* context) {
     NfcApp* instance = context;
 
     if(event.type == NfcScannerEventTypeDetected) {
-        instance->protocols_detected_num = event.data.protocol_num;
-        memcpy(instance->protocols_detected, event.data.protocols, event.data.protocol_num);
+        nfc_app_set_detected_protocols(instance, event.data.protocols, event.data.protocol_num);
         view_dispatcher_send_custom_event(instance->view_dispatcher, NfcCustomEventWorkerExit);
     }
 }

--- a/applications/main/nfc/scenes/nfc_scene_select_protocol.c
+++ b/applications/main/nfc/scenes/nfc_scene_select_protocol.c
@@ -15,7 +15,7 @@ void nfc_scene_select_protocol_on_enter(void* context) {
     if(scene_manager_has_previous_scene(instance->scene_manager, NfcSceneExtraActions)) {
         prefix = "Read";
         instance->protocols_detected_num = NfcProtocolNum;
-        for(size_t i = 0; i < NfcProtocolNum; i++) {
+        for(uint32_t i = 0; i < NfcProtocolNum; i++) {
             instance->protocols_detected[i] = i;
         }
     } else {
@@ -24,7 +24,7 @@ void nfc_scene_select_protocol_on_enter(void* context) {
         notification_message(instance->notifications, &sequence_single_vibro);
     }
 
-    for(size_t i = 0; i < instance->protocols_detected_num; i++) {
+    for(uint32_t i = 0; i < instance->protocols_detected_num; i++) {
         furi_string_printf(
             temp_str,
             "%s %s",
@@ -39,7 +39,7 @@ void nfc_scene_select_protocol_on_enter(void* context) {
     }
     furi_string_free(temp_str);
 
-    uint32_t state =
+    const uint32_t state =
         scene_manager_get_scene_state(instance->scene_manager, NfcSceneSelectProtocol);
     submenu_set_selected_item(submenu, state);
 
@@ -51,7 +51,7 @@ bool nfc_scene_select_protocol_on_event(void* context, SceneManagerEvent event) 
     bool consumed = false;
 
     if(event.type == SceneManagerEventTypeCustom) {
-        instance->protocols_detected_idx = event.event;
+        instance->protocols_detected_selected_idx = event.event;
         scene_manager_next_scene(instance->scene_manager, NfcSceneRead);
         scene_manager_set_scene_state(
             instance->scene_manager, NfcSceneSelectProtocol, event.event);

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -2254,14 +2254,16 @@ Function,+,nfc_iso14443a_poller_trx_sdd_frame,NfcError,"Nfc*, const BitBuffer*, 
 Function,+,nfc_iso14443a_poller_trx_short_frame,NfcError,"Nfc*, NfcIso14443aShortFrame, BitBuffer*, uint32_t"
 Function,+,nfc_listener_alloc,NfcListener*,"Nfc*, NfcProtocol, const NfcDeviceData*"
 Function,+,nfc_listener_free,void,NfcListener*
-Function,+,nfc_listener_get_data,const NfcDeviceData*,"NfcListener*, NfcProtocol"
+Function,+,nfc_listener_get_data,const NfcDeviceData*,"const NfcListener*, NfcProtocol"
+Function,+,nfc_listener_get_protocol,NfcProtocol,const NfcListener*
 Function,+,nfc_listener_start,void,"NfcListener*, NfcGenericCallback, void*"
 Function,+,nfc_listener_stop,void,NfcListener*
 Function,+,nfc_listener_tx,NfcError,"Nfc*, const BitBuffer*"
 Function,+,nfc_poller_alloc,NfcPoller*,"Nfc*, NfcProtocol"
 Function,+,nfc_poller_detect,_Bool,NfcPoller*
 Function,+,nfc_poller_free,void,NfcPoller*
-Function,+,nfc_poller_get_data,const NfcDeviceData*,NfcPoller*
+Function,+,nfc_poller_get_data,const NfcDeviceData*,const NfcPoller*
+Function,+,nfc_poller_get_protocol,NfcProtocol,const NfcPoller*
 Function,+,nfc_poller_start,void,"NfcPoller*, NfcGenericCallback, void*"
 Function,+,nfc_poller_stop,void,NfcPoller*
 Function,+,nfc_poller_trx,NfcError,"Nfc*, const BitBuffer*, BitBuffer*, uint32_t"

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -2226,7 +2226,7 @@ Function,+,nfc_data_generator_fill_data,void,"NfcDataGeneratorType, NfcDevice*"
 Function,+,nfc_data_generator_get_name,const char*,NfcDataGeneratorType
 Function,+,nfc_device_alloc,NfcDevice*,
 Function,+,nfc_device_clear,void,NfcDevice*
-Function,+,nfc_device_contains_data,_Bool,"const NfcDevice*, NfcProtocol, const NfcDeviceData*"
+Function,+,nfc_device_is_equal_data,_Bool,"const NfcDevice*, NfcProtocol, const NfcDeviceData*"
 Function,+,nfc_device_copy_data,void,"const NfcDevice*, NfcProtocol, NfcDeviceData*"
 Function,+,nfc_device_free,void,NfcDevice*
 Function,+,nfc_device_get_data,const NfcDeviceData*,"const NfcDevice*, NfcProtocol"

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -2222,6 +2222,7 @@ Function,+,nfc_data_generator_fill_data,void,"NfcDataGeneratorType, NfcDevice*"
 Function,+,nfc_data_generator_get_name,const char*,NfcDataGeneratorType
 Function,+,nfc_device_alloc,NfcDevice*,
 Function,+,nfc_device_clear,void,NfcDevice*
+Function,+,nfc_device_contains_data,_Bool,"const NfcDevice*, NfcProtocol, const NfcDeviceData*"
 Function,+,nfc_device_copy_data,void,"const NfcDevice*, NfcProtocol, NfcDeviceData*"
 Function,+,nfc_device_free,void,NfcDevice*
 Function,+,nfc_device_get_data,const NfcDeviceData*,"const NfcDevice*, NfcProtocol"

--- a/lib/nfc/nfc_device.c
+++ b/lib/nfc/nfc_device.c
@@ -117,17 +117,23 @@ void nfc_device_copy_data(
     nfc_devices[protocol]->copy(protocol_data, instance->protocol_data);
 }
 
+bool nfc_device_contains_data(
+    const NfcDevice* instance,
+    NfcProtocol protocol,
+    const NfcDeviceData* protocol_data) {
+    furi_assert(instance);
+    furi_assert(protocol < NfcProtocolNum);
+    furi_assert(protocol_data);
+
+    return instance->protocol == protocol &&
+           nfc_devices[protocol]->is_equal(instance->protocol_data, protocol_data);
+}
+
 bool nfc_device_is_equal(const NfcDevice* instance, const NfcDevice* other) {
     furi_assert(instance);
     furi_assert(other);
 
-    bool is_equal = false;
-    if(instance->protocol == other->protocol) {
-        is_equal = nfc_devices[instance->protocol]->is_equal(
-            instance->protocol_data, other->protocol_data);
-    }
-
-    return is_equal;
+    return nfc_device_contains_data(instance, other->protocol, other->protocol_data);
 }
 
 void nfc_device_set_loading_callback(

--- a/lib/nfc/nfc_device.c
+++ b/lib/nfc/nfc_device.c
@@ -117,7 +117,7 @@ void nfc_device_copy_data(
     nfc_devices[protocol]->copy(protocol_data, instance->protocol_data);
 }
 
-bool nfc_device_contains_data(
+bool nfc_device_is_equal_data(
     const NfcDevice* instance,
     NfcProtocol protocol,
     const NfcDeviceData* protocol_data) {
@@ -133,7 +133,7 @@ bool nfc_device_is_equal(const NfcDevice* instance, const NfcDevice* other) {
     furi_assert(instance);
     furi_assert(other);
 
-    return nfc_device_contains_data(instance, other->protocol, other->protocol_data);
+    return nfc_device_is_equal_data(instance, other->protocol, other->protocol_data);
 }
 
 void nfc_device_set_loading_callback(

--- a/lib/nfc/nfc_device.h
+++ b/lib/nfc/nfc_device.h
@@ -45,6 +45,11 @@ void nfc_device_copy_data(
     NfcProtocol protocol,
     NfcDeviceData* protocol_data);
 
+bool nfc_device_contains_data(
+    const NfcDevice* instance,
+    NfcProtocol protocol,
+    const NfcDeviceData* protocol_data);
+
 bool nfc_device_is_equal(const NfcDevice* instance, const NfcDevice* other);
 
 void nfc_device_set_loading_callback(

--- a/lib/nfc/nfc_device.h
+++ b/lib/nfc/nfc_device.h
@@ -45,7 +45,7 @@ void nfc_device_copy_data(
     NfcProtocol protocol,
     NfcDeviceData* protocol_data);
 
-bool nfc_device_contains_data(
+bool nfc_device_is_equal_data(
     const NfcDevice* instance,
     NfcProtocol protocol,
     const NfcDeviceData* protocol_data);

--- a/lib/nfc/nfc_listener.c
+++ b/lib/nfc/nfc_listener.c
@@ -129,7 +129,13 @@ void nfc_listener_stop(NfcListener* instance) {
     nfc_stop(instance->nfc);
 }
 
-const NfcDeviceData* nfc_listener_get_data(NfcListener* instance, NfcProtocol protocol) {
+NfcProtocol nfc_listener_get_protocol(const NfcListener* instance) {
+    furi_assert(instance);
+
+    return instance->protocol;
+}
+
+const NfcDeviceData* nfc_listener_get_data(const NfcListener* instance, NfcProtocol protocol) {
     furi_assert(instance);
     furi_assert(instance->protocol == protocol);
 

--- a/lib/nfc/nfc_listener.h
+++ b/lib/nfc/nfc_listener.h
@@ -17,7 +17,9 @@ void nfc_listener_start(NfcListener* instance, NfcGenericCallback callback, void
 
 void nfc_listener_stop(NfcListener* instance);
 
-const NfcDeviceData* nfc_listener_get_data(NfcListener* instance, NfcProtocol protocol);
+NfcProtocol nfc_listener_get_protocol(const NfcListener* instance);
+
+const NfcDeviceData* nfc_listener_get_data(const NfcListener* instance, NfcProtocol protocol);
 
 #ifdef __cplusplus
 }

--- a/lib/nfc/nfc_poller.c
+++ b/lib/nfc/nfc_poller.c
@@ -201,7 +201,13 @@ bool nfc_poller_detect(NfcPoller* instance) {
     return instance->protocol_detected;
 }
 
-const NfcDeviceData* nfc_poller_get_data(NfcPoller* instance) {
+NfcProtocol nfc_poller_get_protocol(const NfcPoller* instance) {
+    furi_assert(instance);
+
+    return instance->protocol;
+}
+
+const NfcDeviceData* nfc_poller_get_data(const NfcPoller* instance) {
     furi_assert(instance);
 
     NfcPollerListElement* tail_poller = instance->list.tail;

--- a/lib/nfc/nfc_poller.h
+++ b/lib/nfc/nfc_poller.h
@@ -19,7 +19,9 @@ void nfc_poller_stop(NfcPoller* instance);
 
 bool nfc_poller_detect(NfcPoller* instance);
 
-const NfcDeviceData* nfc_poller_get_data(NfcPoller* instance);
+NfcProtocol nfc_poller_get_protocol(const NfcPoller* instance);
+
+const NfcDeviceData* nfc_poller_get_data(const NfcPoller* instance);
 
 #ifdef __cplusplus
 }

--- a/lib/nfc/protocols/iso14443_4a/iso14443_4a_listener_i.c
+++ b/lib/nfc/protocols/iso14443_4a/iso14443_4a_listener_i.c
@@ -4,6 +4,7 @@
 
 Iso14443_4aError
     iso14443_4a_listener_send_ats(Iso14443_4aListener* instance, const Iso14443_4aAtsData* data) {
+    bit_buffer_reset(instance->tx_buffer);
     bit_buffer_append_byte(instance->tx_buffer, data->tl);
 
     if(data->tl > 1) {


### PR DESCRIPTION
# What's new

- Fix crash when exiting partial emulation

# Verification 

- Partially emulate an Mf DESFire tag (Emulate UID)
- Exit the emulaton screen. The app should not crash.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
