### PR TITLE
fbt: reworked tool path handling

### DIFF
--- a/scripts/fbt_tools/compilation_db.py
+++ b/scripts/fbt_tools/compilation_db.py
@@ -135,7 +135,7 @@ def compilation_db_entry_action(target, source, env, **kw):
     if " " in tool_path:
         tool_path = quote(tool_path)
     # Replacing the executable with the full path
-    command = quote(tool_path) + command[len(executable) :]
+    command = tool_path + command[len(executable) :]
 
     entry = {
         "directory": env.Dir("#").abspath,

--- a/scripts/fbt_tools/compilation_db.py
+++ b/scripts/fbt_tools/compilation_db.py
@@ -131,6 +131,9 @@ def compilation_db_entry_action(target, source, env, **kw):
     if not (tool_path := _TOOL_PATH_CACHE.get(executable, None)):
         tool_path = env.WhereIs(executable) or executable
         _TOOL_PATH_CACHE[executable] = tool_path
+    # If there are spaces in the executable path, we need to quote it
+    if " " in tool_path:
+        tool_path = quote(tool_path)
     # Replacing the executable with the full path
     command = quote(tool_path) + command[len(executable) :]
 

--- a/scripts/fbt_tools/crosscc.py
+++ b/scripts/fbt_tools/crosscc.py
@@ -2,7 +2,6 @@ import subprocess
 
 import gdb
 import objdump
-import shutil
 
 import strip
 from SCons.Action import _subproc
@@ -13,7 +12,7 @@ from SCons.Tool import ar, asm, gcc, gnulink, gxx
 def prefix_commands(env, command_prefix, cmd_list):
     for command in cmd_list:
         if command in env:
-            env[command] = shutil.which(command_prefix + env[command])
+            env.Replace(**{command: command_prefix + env[command]})
 
 
 def _get_tool_version(env, tool):

--- a/scripts/fbt_tools/crosscc.py
+++ b/scripts/fbt_tools/crosscc.py
@@ -2,7 +2,6 @@ import subprocess
 
 import gdb
 import objdump
-
 import strip
 from SCons.Action import _subproc
 from SCons.Errors import StopError
@@ -12,20 +11,25 @@ from SCons.Tool import ar, asm, gcc, gnulink, gxx
 def prefix_commands(env, command_prefix, cmd_list):
     for command in cmd_list:
         if command in env:
-            env.Replace(**{command: command_prefix + env[command]})
+            prefixed_binary = command_prefix + env[command]
+            if not env.WhereIs(prefixed_binary):
+                raise StopError(
+                    f"Toolchain binary {prefixed_binary} not found in PATH."
+                )
+            env.Replace(**{command: prefixed_binary})
 
 
 def _get_tool_version(env, tool):
     verstr = "version unknown"
     proc = _subproc(
         env,
-        env.subst("${%s} --version" % tool),
+        [env.subst("${%s}" % tool), "--version"],
         stdout=subprocess.PIPE,
         stderr="devnull",
         stdin="devnull",
         universal_newlines=True,
         error="raise",
-        shell=True,
+        shell=False,
     )
     if proc:
         verstr = proc.stdout.readline()

--- a/scripts/fbt_tools/pvsstudio.py
+++ b/scripts/fbt_tools/pvsstudio.py
@@ -48,6 +48,7 @@ def generate(env):
             "@.pvsoptions",
             "-j${PVSNCORES}",
             # "--incremental", # kinda broken on PVS side
+            "--disableLicenseExpirationCheck",
         ],
         PVSCONVOPTIONS=[
             "-a",


### PR DESCRIPTION
# What's new

- fbt: removed absolute paths from env setup; moved abs paths to cdb tool
- fixes #3054 
- fbt: pvs: temporarily disabled early license expiration checks

# Verification 

- Clone to path with spaces 
- Check that building firmware works
- Check that vscode config works with clangd

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
