### PR TITLE
FuriHa, BleGlue: new transport locking, fix random lockups 

### DIFF
--- a/applications/services/bt/bt_service/bt.c
+++ b/applications/services/bt/bt_service/bt.c
@@ -359,13 +359,13 @@ static void bt_change_profile(Bt* bt, BtMessage* message) {
             *message->result = false;
         }
     }
-    furi_event_flag_set(bt->api_event, BT_API_UNLOCK_EVENT);
+    api_lock_unlock(message->lock);
 }
 
-static void bt_close_connection(Bt* bt) {
+static void bt_close_connection(Bt* bt, BtMessage* message) {
     bt_close_rpc_connection(bt);
     furi_hal_bt_stop_advertising();
-    furi_event_flag_set(bt->api_event, BT_API_UNLOCK_EVENT);
+    api_lock_unlock(message->lock);
 }
 
 int32_t bt_srv(void* p) {
@@ -432,7 +432,7 @@ int32_t bt_srv(void* p) {
         } else if(message.type == BtMessageTypeSetProfile) {
             bt_change_profile(bt, &message);
         } else if(message.type == BtMessageTypeDisconnect) {
-            bt_close_connection(bt);
+            bt_close_connection(bt, &message);
         } else if(message.type == BtMessageTypeForgetBondedDevices) {
             bt_keys_storage_delete(bt->keys_storage);
         }

--- a/applications/services/bt/bt_service/bt_i.h
+++ b/applications/services/bt/bt_service/bt_i.h
@@ -4,6 +4,7 @@
 
 #include <furi.h>
 #include <furi_hal.h>
+#include <api_lock.h>
 
 #include <gui/gui.h>
 #include <gui/view_port.h>
@@ -21,8 +22,6 @@
 #include "bt_keys_filename.h"
 
 #define BT_KEYS_STORAGE_PATH INT_PATH(BT_KEYS_STORAGE_FILE_NAME)
-
-#define BT_API_UNLOCK_EVENT (1UL << 0)
 
 typedef enum {
     BtMessageTypeUpdateStatus,
@@ -48,6 +47,7 @@ typedef union {
 } BtMessageData;
 
 typedef struct {
+    FuriApiLock lock;
     BtMessageType type;
     BtMessageData data;
     bool* result;

--- a/applications/system/hid_app/hid.c
+++ b/applications/system/hid_app/hid.c
@@ -422,9 +422,7 @@ int32_t hid_ble_app(void* p) {
 
     furi_record_close(RECORD_STORAGE);
 
-    if(!bt_set_profile(app->bt, BtProfileHidKeyboard)) {
-        FURI_LOG_E(TAG, "Failed to switch to HID profile");
-    }
+    furi_check(bt_set_profile(app->bt, BtProfileHidKeyboard));
 
     furi_hal_bt_start_advertising();
     bt_set_status_changed_callback(app->bt, bt_hid_connection_status_changed_callback, app);
@@ -442,9 +440,7 @@ int32_t hid_ble_app(void* p) {
 
     bt_keys_storage_set_default_path(app->bt);
 
-    if(!bt_set_profile(app->bt, BtProfileSerial)) {
-        FURI_LOG_E(TAG, "Failed to switch to Serial profile");
-    }
+    furi_check(bt_set_profile(app->bt, BtProfileSerial));
 
     hid_free(app);
 

--- a/firmware/targets/f7/ble_glue/ble_app.c
+++ b/firmware/targets/f7/ble_glue/ble_app.c
@@ -181,9 +181,11 @@ static void ble_app_hci_event_handler(void* pPayload) {
 
 static void ble_app_hci_status_not_handler(HCI_TL_CmdStatus_t status) {
     if(status == HCI_TL_CmdBusy) {
+        furi_hal_power_insomnia_enter();
         furi_mutex_acquire(ble_app->hci_mtx, FuriWaitForever);
     } else if(status == HCI_TL_CmdAvailable) {
         furi_mutex_release(ble_app->hci_mtx);
+        furi_hal_power_insomnia_exit();
     }
 }
 

--- a/firmware/targets/f7/furi_hal/furi_hal_bt.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_bt.c
@@ -9,6 +9,7 @@
 #include <hsem_map.h>
 
 #include <furi_hal_version.h>
+#include <furi_hal_power.h>
 #include <furi_hal_bt_hid.h>
 #include <furi_hal_bt_serial.h>
 #include <furi_hal_bus.c>
@@ -269,6 +270,7 @@ bool furi_hal_bt_start_app(FuriHalBtProfile profile, GapEventCallback event_cb, 
 }
 
 void furi_hal_bt_reinit() {
+    furi_hal_power_insomnia_enter();
     FURI_LOG_I(TAG, "Disconnect and stop advertising");
     furi_hal_bt_stop_advertising();
 
@@ -298,6 +300,7 @@ void furi_hal_bt_reinit() {
     furi_hal_bt_init();
 
     furi_hal_bt_start_radio_stack();
+    furi_hal_power_insomnia_exit();
 }
 
 bool furi_hal_bt_change_app(FuriHalBtProfile profile, GapEventCallback event_cb, void* context) {


### PR DESCRIPTION
# What's new

- FuriHal,BleGlue: prevent sleep while HCI command executed, proper bt api rpc locking. Fixes random system lockups.

# Verification 

- Full set of tests.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
