### PR TITLE
Ble: fix null-ptr dereference in bt_change_profile

### DIFF
--- a/applications/services/bt/bt_service/bt.c
+++ b/applications/services/bt/bt_service/bt.c
@@ -359,13 +359,13 @@ static void bt_change_profile(Bt* bt, BtMessage* message) {
             *message->result = false;
         }
     }
-    api_lock_unlock(message->lock);
+    if(message->lock) api_lock_unlock(message->lock);
 }
 
 static void bt_close_connection(Bt* bt, BtMessage* message) {
     bt_close_rpc_connection(bt);
     furi_hal_bt_stop_advertising();
-    api_lock_unlock(message->lock);
+    if(message->lock) api_lock_unlock(message->lock);
 }
 
 int32_t bt_srv(void* p) {


### PR DESCRIPTION
# What's new

- Ble: fix null-ptr dereference in bt_change_profile

# Verification 

- Initiate BLE RPC session force restart from mobile companion

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
