### PR TITLE
Allow console USB output when serial is disabled

### DIFF
--- a/applications/debug/uart_echo/uart_echo.c
+++ b/applications/debug/uart_echo/uart_echo.c
@@ -221,7 +221,7 @@ static UartEchoApp* uart_echo_app_alloc(uint32_t baudrate) {
     furi_thread_start(app->worker_thread);
 
     // Enable uart listener
-    furi_hal_console_disable();
+    furi_hal_console_disable_serial();
     furi_hal_uart_set_br(FuriHalUartIdUSART1, baudrate);
     furi_hal_uart_set_irq_cb(FuriHalUartIdUSART1, uart_echo_on_irq_cb, app);
 
@@ -231,7 +231,7 @@ static UartEchoApp* uart_echo_app_alloc(uint32_t baudrate) {
 static void uart_echo_app_free(UartEchoApp* app) {
     furi_assert(app);
 
-    furi_hal_console_enable(); // this will also clear IRQ callback so thread is no longer referenced
+    furi_hal_console_enable_serial(); // this will also clear IRQ callback so thread is no longer referenced
 
     furi_thread_flags_set(furi_thread_get_id(app->worker_thread), WorkerEventStop);
     furi_thread_join(app->worker_thread);

--- a/applications/main/gpio/usb_uart_bridge.c
+++ b/applications/main/gpio/usb_uart_bridge.c
@@ -112,7 +112,7 @@ static void usb_uart_vcp_deinit(UsbUartBridge* usb_uart, uint8_t vcp_ch) {
 
 static void usb_uart_serial_init(UsbUartBridge* usb_uart, uint8_t uart_ch) {
     if(uart_ch == FuriHalUartIdUSART1) {
-        furi_hal_console_disable();
+        furi_hal_console_disable_serial();
     } else if(uart_ch == FuriHalUartIdLPUART1) {
         furi_hal_uart_init(uart_ch, 115200);
     }
@@ -123,7 +123,7 @@ static void usb_uart_serial_deinit(UsbUartBridge* usb_uart, uint8_t uart_ch) {
     UNUSED(usb_uart);
     furi_hal_uart_set_irq_cb(uart_ch, NULL, NULL);
     if(uart_ch == FuriHalUartIdUSART1)
-        furi_hal_console_enable();
+        furi_hal_console_enable_serial();
     else if(uart_ch == FuriHalUartIdLPUART1)
         furi_hal_uart_deinit(uart_ch);
 }

--- a/firmware/targets/f18/api_symbols.csv
+++ b/firmware/targets/f18/api_symbols.csv
@@ -1061,8 +1061,8 @@ Function,-,furi_hal_clock_switch_hse2hsi,void,
 Function,-,furi_hal_clock_switch_hse2pll,_Bool,
 Function,-,furi_hal_clock_switch_hsi2hse,void,
 Function,-,furi_hal_clock_switch_pll2hse,_Bool,
-Function,+,furi_hal_console_disable,void,
-Function,+,furi_hal_console_enable,void,
+Function,+,furi_hal_console_disable_serial,void,
+Function,+,furi_hal_console_enable_serial,void,
 Function,+,furi_hal_console_init,void,
 Function,+,furi_hal_console_printf,void,"const char[], ..."
 Function,+,furi_hal_console_puts,void,const char*

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1149,8 +1149,8 @@ Function,-,furi_hal_clock_switch_hse2hsi,void,
 Function,-,furi_hal_clock_switch_hse2pll,_Bool,
 Function,-,furi_hal_clock_switch_hsi2hse,void,
 Function,-,furi_hal_clock_switch_pll2hse,_Bool,
-Function,+,furi_hal_console_disable,void,
-Function,+,furi_hal_console_enable,void,
+Function,+,furi_hal_console_disable_serial,void,
+Function,+,furi_hal_console_enable_serial,void,
 Function,+,furi_hal_console_init,void,
 Function,+,furi_hal_console_printf,void,"const char[], ..."
 Function,+,furi_hal_console_puts,void,const char*

--- a/firmware/targets/f7/furi_hal/furi_hal_console.h
+++ b/firmware/targets/f7/furi_hal/furi_hal_console.h
@@ -12,10 +12,18 @@ typedef void (*FuriHalConsoleTxCallback)(const uint8_t* buffer, size_t size, voi
 
 void furi_hal_console_init();
 
-void furi_hal_console_enable();
+/// Enable the console output through the serial TX pin
+void furi_hal_console_enable_serial();
 
-void furi_hal_console_disable();
+/// Disable the console output through the serial TX pin
+void furi_hal_console_disable_serial();
 
+/**
+ * Add an alternative output to the console
+ * To remove it, call this function again with NULL pointers
+ *
+ * @note Only one callback can be active at a time
+ */
 void furi_hal_console_set_tx_callback(FuriHalConsoleTxCallback callback, void* context);
 
 void furi_hal_console_tx(const uint8_t* buffer, size_t buffer_size);

--- a/firmware/targets/f7/furi_hal/furi_hal_uart.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_uart.c
@@ -170,7 +170,7 @@ void furi_hal_uart_resume(FuriHalUartId channel) {
     furi_hal_usart_prev_enabled[channel] = false;
 }
 
-void furi_hal_uart_tx(FuriHalUartId ch, uint8_t* buffer, size_t buffer_size) {
+void furi_hal_uart_tx(FuriHalUartId ch, uint8_t const* buffer, size_t buffer_size) {
     if(ch == FuriHalUartIdUSART1) {
         if(LL_USART_IsEnabled(USART1) == 0) return;
 

--- a/firmware/targets/f7/furi_hal/furi_hal_uart.h
+++ b/firmware/targets/f7/furi_hal/furi_hal_uart.h
@@ -71,7 +71,7 @@ void furi_hal_uart_set_br(FuriHalUartId channel, uint32_t baud);
  * @param buffer data
  * @param buffer_size data size (in bytes)
  */
-void furi_hal_uart_tx(FuriHalUartId channel, uint8_t* buffer, size_t buffer_size);
+void furi_hal_uart_tx(FuriHalUartId channel, uint8_t const* buffer, size_t buffer_size);
 
 /**
  * Sets UART event callback


### PR DESCRIPTION
# What's new

- Allow the console's `tx_callback` to be enabled independently of the serial output. This allows programs using the TX pin for other purposes to get debug logs through USB.
- Fixes `furi_hal_console_tx_with_new_line` only sending its output through the TX pin.

# Verification 

Monitor the console both through the TX pin and using the `log` command through USB.
Check that after calling `furi_hal_console_disable_serial`, the console output only shows on the USB side, and that after calling `furi_hal_console_enable_serial`, both sides show the same output.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
