### PR TITLE
fix #3141: 12-bits is 0xFFF (or 0xFF0) CAME/NICE 12-bit

### DIFF
--- a/applications/main/subghz/scenes/subghz_scene_set_type.c
+++ b/applications/main/subghz/scenes/subghz_scene_set_type.c
@@ -134,7 +134,7 @@ bool subghz_scene_set_type_on_event(void* context, SceneManagerEvent event) {
                 subghz->txrx, "AM650", 315000000, SUBGHZ_PROTOCOL_PRINCETON_NAME, key, 24, 400);
             break;
         case SubmenuIndexNiceFlo12bit:
-            key = (key & 0x0000FFF0) | 0x1; //btn 0x1, 0x2, 0x4
+            key = (key & 0x00000FF0) | 0x1; //btn 0x1, 0x2, 0x4
             generated_protocol = subghz_txrx_gen_data_protocol(
                 subghz->txrx, "AM650", 433920000, SUBGHZ_PROTOCOL_NICE_FLO_NAME, key, 12);
             break;
@@ -144,7 +144,7 @@ bool subghz_scene_set_type_on_event(void* context, SceneManagerEvent event) {
                 subghz->txrx, "AM650", 433920000, SUBGHZ_PROTOCOL_NICE_FLO_NAME, key, 24);
             break;
         case SubmenuIndexCAME12bit:
-            key = (key & 0x0000FFF0) | 0x1; //btn 0x1, 0x2, 0x4
+            key = (key & 0x00000FF0) | 0x1; //btn 0x1, 0x2, 0x4
             generated_protocol = subghz_txrx_gen_data_protocol(
                 subghz->txrx, "AM650", 433920000, SUBGHZ_PROTOCOL_CAME_NAME, key, 12);
             break;

--- a/applications/main/subghz/scenes/subghz_scene_set_type.c
+++ b/applications/main/subghz/scenes/subghz_scene_set_type.c
@@ -198,14 +198,17 @@ bool subghz_scene_set_type_on_event(void* context, SceneManagerEvent event) {
                 subghz_txrx_gen_secplus_v1_protocol(subghz->txrx, "AM650", 390000000);
             break;
         case SubmenuIndexSecPlus_v2_310_00:
+            key = (key & 0x7FFFF3FC); // 850LM pairing
             generated_protocol = subghz_txrx_gen_secplus_v2_protocol(
                 subghz->txrx, "AM650", 310000000, key, 0x68, 0xE500000);
             break;
         case SubmenuIndexSecPlus_v2_315_00:
+            key = (key & 0x7FFFF3FC); // 850LM pairing
             generated_protocol = subghz_txrx_gen_secplus_v2_protocol(
                 subghz->txrx, "AM650", 315000000, key, 0x68, 0xE500000);
             break;
         case SubmenuIndexSecPlus_v2_390_00:
+            key = (key & 0x7FFFF3FC); // 850LM pairing
             generated_protocol = subghz_txrx_gen_secplus_v2_protocol(
                 subghz->txrx, "AM650", 390000000, key, 0x68, 0xE500000);
             break;


### PR DESCRIPTION
# What's new
- Fixes CAME 12-bit and NICE 12-bit to generate a random 12-bit key instead of a 16-bit key.  The code was already only transmitting a 12-bit key, so this just makes the generated .SUB file 12-bits.  Loading a previously generated .SUB file will still show the 16-bit key (the user can manually edit their .SUB file to only have the last three digits set if they care).

# Verification 
- Sub-GHz, Add Manually, Nice Flo 12-bit_433, save file, load file, KEY should be 12-bits (3 digits) and YEK should be 12-bits.  Writing out the binary for the KEY and reversing it should give you the YEK.  Transmitting the signal should display matching KEY on second Flipper Zero.
- Sub-GHz, Add Manually, CAME 12-bit_433, save file, load file, KEY should be 12-bits (3 digits) and YEK should be 12-bits.  Writing out the binary for the KEY and reversing it should give you the YEK.  Transmitting the signal should display matching KEY on second Flipper Zero.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
