### PR TITLE
Fix various crashes if debug libraries used

### DIFF
--- a/applications/main/bad_usb/helpers/ducky_script.c
+++ b/applications/main/bad_usb/helpers/ducky_script.c
@@ -290,7 +290,7 @@ static int32_t ducky_script_execute_next(BadUsbScript* bad_usb, File* script_fil
             return delay_val;
         } else if(delay_val < 0) { // Script error
             bad_usb->st.error_line = bad_usb->st.line_cur - 1;
-            FURI_LOG_E(WORKER_TAG, "Unknown command at line %u", bad_usb->st.line_cur - 1U);
+            FURI_LOG_E(WORKER_TAG, "Unknown command at line %zu", bad_usb->st.line_cur - 1U);
             return SCRIPT_STATE_ERROR;
         } else {
             return (delay_val + bad_usb->defdelay);
@@ -329,7 +329,7 @@ static int32_t ducky_script_execute_next(BadUsbScript* bad_usb, File* script_fil
                     return delay_val;
                 } else if(delay_val < 0) {
                     bad_usb->st.error_line = bad_usb->st.line_cur;
-                    FURI_LOG_E(WORKER_TAG, "Unknown command at line %u", bad_usb->st.line_cur);
+                    FURI_LOG_E(WORKER_TAG, "Unknown command at line %zu", bad_usb->st.line_cur);
                     return SCRIPT_STATE_ERROR;
                 } else {
                     return (delay_val + bad_usb->defdelay);

--- a/applications/main/bad_usb/helpers/ducky_script.h
+++ b/applications/main/bad_usb/helpers/ducky_script.h
@@ -24,10 +24,10 @@ typedef enum {
 
 typedef struct {
     BadUsbWorkerState state;
-    uint16_t line_cur;
-    uint16_t line_nb;
+    size_t line_cur;
+    size_t line_nb;
     uint32_t delay_remain;
-    uint16_t error_line;
+    size_t error_line;
     char error[64];
 } BadUsbState;
 

--- a/applications/main/bad_usb/views/bad_usb_view.c
+++ b/applications/main/bad_usb/views/bad_usb_view.c
@@ -82,7 +82,7 @@ static void bad_usb_draw_callback(Canvas* canvas, void* _model) {
         canvas_set_font(canvas, FontPrimary);
         canvas_draw_str_aligned(canvas, 127, 33, AlignRight, AlignBottom, "ERROR:");
         canvas_set_font(canvas, FontSecondary);
-        furi_string_printf(disp_str, "line %u", model->state.error_line);
+        furi_string_printf(disp_str, "line %zu", model->state.error_line);
         canvas_draw_str_aligned(
             canvas, 127, 46, AlignRight, AlignBottom, furi_string_get_cstr(disp_str));
         furi_string_reset(disp_str);
@@ -105,7 +105,7 @@ static void bad_usb_draw_callback(Canvas* canvas, void* _model) {
         }
         canvas_set_font(canvas, FontBigNumbers);
         furi_string_printf(
-            disp_str, "%u", ((model->state.line_cur - 1) * 100) / model->state.line_nb);
+            disp_str, "%zu", ((model->state.line_cur - 1) * 100) / model->state.line_nb);
         canvas_draw_str_aligned(
             canvas, 114, 40, AlignRight, AlignBottom, furi_string_get_cstr(disp_str));
         furi_string_reset(disp_str);
@@ -124,7 +124,7 @@ static void bad_usb_draw_callback(Canvas* canvas, void* _model) {
         }
         canvas_set_font(canvas, FontBigNumbers);
         furi_string_printf(
-            disp_str, "%u", ((model->state.line_cur - 1) * 100) / model->state.line_nb);
+            disp_str, "%zu", ((model->state.line_cur - 1) * 100) / model->state.line_nb);
         canvas_draw_str_aligned(
             canvas, 114, 40, AlignRight, AlignBottom, furi_string_get_cstr(disp_str));
         furi_string_reset(disp_str);
@@ -142,7 +142,7 @@ static void bad_usb_draw_callback(Canvas* canvas, void* _model) {
         }
         canvas_set_font(canvas, FontBigNumbers);
         furi_string_printf(
-            disp_str, "%u", ((model->state.line_cur - 1) * 100) / model->state.line_nb);
+            disp_str, "%zu", ((model->state.line_cur - 1) * 100) / model->state.line_nb);
         canvas_draw_str_aligned(
             canvas, 114, 40, AlignRight, AlignBottom, furi_string_get_cstr(disp_str));
         furi_string_reset(disp_str);

--- a/applications/main/subghz/helpers/subghz_frequency_analyzer_log_item_array.h
+++ b/applications/main/subghz/helpers/subghz_frequency_analyzer_log_item_array.h
@@ -19,7 +19,7 @@ typedef enum {
 const char*
     subghz_frequency_analyzer_log_get_order_name(SubGhzFrequencyAnalyzerLogOrderBy order_by);
 
-TUPLE_DEF2(
+TUPLE_DEF2( //-V1048
     SubGhzFrequencyAnalyzerLogItem,
     (seq, uint8_t),
     (frequency, uint32_t),

--- a/applications/main/subghz/subghz_cli.c
+++ b/applications/main/subghz/subghz_cli.c
@@ -565,7 +565,7 @@ void subghz_cli_command_decode_raw(Cli* cli, FuriString* args, void* context) {
             }
         }
 
-        printf("\r\nPackets received \033[0;32m%u\033[0m\r\n", instance->packet_count);
+        printf("\r\nPackets received \033[0;32m%zu\033[0m\r\n", instance->packet_count);
 
         // Cleanup
         subghz_receiver_free(receiver);

--- a/applications/services/storage/storage_external_api.c
+++ b/applications/services/storage/storage_external_api.c
@@ -869,7 +869,7 @@ bool storage_simply_remove_recursive(Storage* storage, const char* path) {
 
         while(storage_dir_read(dir, &fileinfo, name, MAX_NAME_LENGTH)) {
             if(file_info_is_dir(&fileinfo)) {
-                furi_string_cat_printf(cur_dir, "/%s", name);
+                furi_string_cat_printf(cur_dir, "/%s", name); //-V576
                 go_deeper = true;
                 break;
             }

--- a/firmware/targets/f7/furi_hal/furi_hal_clock.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_clock.c
@@ -118,7 +118,6 @@ void furi_hal_clock_init() {
     NVIC_EnableIRQ(SysTick_IRQn);
 
     LL_RCC_SetCLK48ClockSource(LL_RCC_CLK48_CLKSOURCE_PLLSAI1);
-    LL_RCC_HSI_EnableInStopMode(); // Ensure that MR is capable of work in STOP0
     LL_RCC_SetSMPSClockSource(LL_RCC_SMPS_CLKSOURCE_HSI);
     LL_RCC_SetSMPSPrescaler(LL_RCC_SMPS_DIV_1);
     LL_RCC_SetRFWKPClockSource(LL_RCC_RFWKP_CLKSOURCE_LSE);
@@ -133,7 +132,7 @@ void furi_hal_clock_switch_hse2hsi() {
         ;
 
     LL_RCC_SetSysClkSource(LL_RCC_SYS_CLKSOURCE_HSI);
-    furi_assert(LL_RCC_GetSMPSClockSource() == LL_RCC_SMPS_CLKSOURCE_HSI);
+    furi_assert(LL_RCC_GetSMPSClockSelection() == LL_RCC_SMPS_CLKSOURCE_HSI);
 
     while(LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_HSI)
         ;

--- a/firmware/targets/f7/furi_hal/furi_hal_usb_ccid.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_usb_ccid.c
@@ -331,13 +331,12 @@ void CALLBACK_CCID_IccPowerOn(
             if(callbacks[CCID_SLOT_INDEX] != NULL) {
                 callbacks[CCID_SLOT_INDEX]->icc_power_on_callback(
                     responseDataBlock->abData, &responseDataBlock->dwLength, NULL);
+                responseDataBlock->bStatus = CCID_COMMANDSTATUS_PROCESSEDWITHOUTERROR |
+                                             CCID_ICCSTATUS_PRESENTANDACTIVE;
             } else {
                 responseDataBlock->bStatus = CCID_COMMANDSTATUS_PROCESSEDWITHOUTERROR |
                                              CCID_ICCSTATUS_PRESENTANDINACTIVE;
             }
-
-            responseDataBlock->bStatus = CCID_COMMANDSTATUS_PROCESSEDWITHOUTERROR |
-                                         CCID_ICCSTATUS_PRESENTANDACTIVE;
         } else {
             responseDataBlock->bStatus = CCID_COMMANDSTATUS_PROCESSEDWITHOUTERROR |
                                          CCID_ICCSTATUS_NOICCPRESENT;
@@ -366,13 +365,12 @@ void CALLBACK_CCID_XfrBlock(
                     responseDataBlock->abData,
                     &responseDataBlock->dwLength,
                     NULL);
+                responseDataBlock->bStatus = CCID_COMMANDSTATUS_PROCESSEDWITHOUTERROR |
+                                             CCID_ICCSTATUS_PRESENTANDACTIVE;
             } else {
                 responseDataBlock->bStatus = CCID_COMMANDSTATUS_PROCESSEDWITHOUTERROR |
                                              CCID_ICCSTATUS_PRESENTANDINACTIVE;
             }
-
-            responseDataBlock->bStatus = CCID_COMMANDSTATUS_PROCESSEDWITHOUTERROR |
-                                         CCID_ICCSTATUS_PRESENTANDACTIVE;
         } else {
             responseDataBlock->bStatus = CCID_COMMANDSTATUS_PROCESSEDWITHOUTERROR |
                                          CCID_ICCSTATUS_NOICCPRESENT;
@@ -413,11 +411,11 @@ static void ccid_tx_ep_callback(usbd_device* dev, uint8_t event, uint8_t ep) {
             usb_dev, ep, &ReceiveBuffer, sizeof(ccid_bulk_message_header_t) + CCID_DATABLOCK_SIZE);
         //minimum request size is header size
         furi_assert((uint16_t)bytes_read >= sizeof(ccid_bulk_message_header_t));
-        ccid_bulk_message_header_t* message = (ccid_bulk_message_header_t*)&ReceiveBuffer;
+        ccid_bulk_message_header_t* message = (ccid_bulk_message_header_t*)&ReceiveBuffer; //-V641
 
         if(message->bMessageType == PC_TO_RDR_ICCPOWERON) {
             struct pc_to_rdr_icc_power_on* requestDataBlock =
-                (struct pc_to_rdr_icc_power_on*)message;
+                (struct pc_to_rdr_icc_power_on*)message; //-V641
             struct rdr_to_pc_data_block* responseDataBlock =
                 (struct rdr_to_pc_data_block*)&SendBuffer;
 
@@ -432,9 +430,9 @@ static void ccid_tx_ep_callback(usbd_device* dev, uint8_t event, uint8_t ep) {
                     (sizeof(uint8_t) * responseDataBlock->dwLength));
         } else if(message->bMessageType == PC_TO_RDR_ICCPOWEROFF) {
             struct pc_to_rdr_icc_power_off* requestIccPowerOff =
-                (struct pc_to_rdr_icc_power_off*)message;
+                (struct pc_to_rdr_icc_power_off*)message; //-V641
             struct rdr_to_pc_slot_status* responseSlotStatus =
-                (struct rdr_to_pc_slot_status*)&SendBuffer;
+                (struct rdr_to_pc_slot_status*)&SendBuffer; //-V641
 
             CALLBACK_CCID_GetSlotStatus(
                 requestIccPowerOff->bSlot, requestIccPowerOff->bSeq, responseSlotStatus);
@@ -443,9 +441,9 @@ static void ccid_tx_ep_callback(usbd_device* dev, uint8_t event, uint8_t ep) {
                 usb_dev, CCID_IN_EPADDR, responseSlotStatus, sizeof(struct rdr_to_pc_slot_status));
         } else if(message->bMessageType == PC_TO_RDR_GETSLOTSTATUS) {
             struct pc_to_rdr_get_slot_status* requestSlotStatus =
-                (struct pc_to_rdr_get_slot_status*)message;
+                (struct pc_to_rdr_get_slot_status*)message; //-V641
             struct rdr_to_pc_slot_status* responseSlotStatus =
-                (struct rdr_to_pc_slot_status*)&SendBuffer;
+                (struct rdr_to_pc_slot_status*)&SendBuffer; //-V641
 
             CALLBACK_CCID_GetSlotStatus(
                 requestSlotStatus->bSlot, requestSlotStatus->bSeq, responseSlotStatus);
@@ -474,9 +472,9 @@ static void ccid_tx_ep_callback(usbd_device* dev, uint8_t event, uint8_t ep) {
                     (sizeof(uint8_t) * responseDataBlock->dwLength));
         } else if(message->bMessageType == PC_TO_RDR_SETPARAMETERS) {
             struct pc_to_rdr_set_parameters_t0* requestSetParametersT0 =
-                (struct pc_to_rdr_set_parameters_t0*)message;
+                (struct pc_to_rdr_set_parameters_t0*)message; //-V641
             struct rdr_to_pc_parameters_t0* responseSetParametersT0 =
-                (struct rdr_to_pc_parameters_t0*)&SendBuffer;
+                (struct rdr_to_pc_parameters_t0*)&SendBuffer; //-V641
 
             furi_assert(requestSetParametersT0->dwLength <= CCID_DATABLOCK_SIZE);
             furi_assert(

--- a/firmware/targets/f7/src/update.c
+++ b/firmware/targets/f7/src/update.c
@@ -70,13 +70,13 @@ static bool flipper_update_load_stage(const FuriString* work_dir, UpdateManifest
 
     if((f_stat(furi_string_get_cstr(loader_img_path), &stat) != FR_OK) ||
        (f_open(&file, furi_string_get_cstr(loader_img_path), FA_OPEN_EXISTING | FA_READ) !=
-        FR_OK)) {
+        FR_OK) ||
+       (stat.fsize == 0)) {
         furi_string_free(loader_img_path);
         return false;
     }
     furi_string_free(loader_img_path);
 
-    furi_check(stat.fsize);
     void* img = malloc(stat.fsize);
     uint32_t bytes_read = 0;
     const uint16_t MAX_READ = 0xFFFF;

--- a/firmware/targets/f7/src/update.c
+++ b/firmware/targets/f7/src/update.c
@@ -76,6 +76,7 @@ static bool flipper_update_load_stage(const FuriString* work_dir, UpdateManifest
     }
     furi_string_free(loader_img_path);
 
+    furi_check(stat.fsize);
     void* img = malloc(stat.fsize);
     uint32_t bytes_read = 0;
     const uint16_t MAX_READ = 0xFFFF;
@@ -83,7 +84,7 @@ static bool flipper_update_load_stage(const FuriString* work_dir, UpdateManifest
     uint32_t crc = 0;
     do {
         uint16_t size_read = 0;
-        if(f_read(&file, img + bytes_read, MAX_READ, &size_read) != FR_OK) {
+        if(f_read(&file, img + bytes_read, MAX_READ, &size_read) != FR_OK) { //-V769
             break;
         }
         crc = crc32_calc_buffer(crc, img + bytes_read, size_read);

--- a/furi/core/check.c
+++ b/furi/core/check.c
@@ -153,18 +153,18 @@ FURI_NORETURN void __furi_crash() {
     __furi_print_heap_info();
     __furi_print_bt_stack_info();
 
-#ifndef FURI_DEBUG
     // Check if debug enabled by DAP
     // https://developer.arm.com/documentation/ddi0403/d/Debug-Architecture/ARMv7-M-Debug/Debug-register-support-in-the-SCS/Debug-Halting-Control-and-Status-Register--DHCSR?lang=en
     bool debug = CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk;
+#ifdef FURI_NDEBUG
     if(debug) {
 #endif
         furi_hal_console_puts("\r\nSystem halted. Connect debugger for more info\r\n");
         furi_hal_console_puts("\033[0m\r\n");
         furi_hal_debug_enable();
 
-        RESTORE_REGISTERS_AND_HALT_MCU(true);
-#ifndef FURI_DEBUG
+        RESTORE_REGISTERS_AND_HALT_MCU(debug);
+#ifdef FURI_NDEBUG
     } else {
         uint32_t ptr = (uint32_t)__furi_check_message;
         if(ptr < FLASH_BASE || ptr > (FLASH_BASE + FLASH_SIZE)) {

--- a/furi/core/memmgr_heap.c
+++ b/furi/core/memmgr_heap.c
@@ -115,8 +115,9 @@ static size_t xBlockAllocatedBit = 0;
 #include <m-dict.h>
 
 /* Allocation tracking types */
-DICT_DEF2(MemmgrHeapAllocDict, uint32_t, uint32_t)
-DICT_DEF2(
+DICT_DEF2(MemmgrHeapAllocDict, uint32_t, uint32_t) //-V1048
+
+DICT_DEF2( //-V1048
     MemmgrHeapThreadDict,
     uint32_t,
     M_DEFAULT_OPLIST,

--- a/lib/flipper_application/elf/elf_file.c
+++ b/lib/flipper_application/elf/elf_file.c
@@ -853,7 +853,7 @@ ElfProcessSectionResult elf_process_section(
         if(process_section(elf->fd, section_header.sh_offset, section_header.sh_size, context)) {
             result = ElfProcessSectionResultSuccess;
         } else {
-            result = ElfProcessSectionResultCannotProcess;
+            result = ElfProcessSectionResultCannotProcess; //-V1048
         }
     }
 

--- a/lib/flipper_application/elf/elf_file_i.h
+++ b/lib/flipper_application/elf/elf_file_i.h
@@ -6,7 +6,7 @@
 extern "C" {
 #endif
 
-DICT_DEF2(AddressCache, int, M_DEFAULT_OPLIST, Elf32_Addr, M_DEFAULT_OPLIST)
+DICT_DEF2(AddressCache, int, M_DEFAULT_OPLIST, Elf32_Addr, M_DEFAULT_OPLIST) //-V1048
 
 /**
  * Callable elf entry type

--- a/lib/lfrfid/lfrfid_worker.c
+++ b/lib/lfrfid/lfrfid_worker.c
@@ -118,7 +118,6 @@ void lfrfid_worker_start_thread(LFRFIDWorker* worker) {
 }
 
 void lfrfid_worker_stop_thread(LFRFIDWorker* worker) {
-    furi_assert(worker->mode_index == LFRFIDWorkerIdle);
     furi_thread_flags_set(furi_thread_get_id(worker->thread), LFRFIDEventStopThread);
     furi_thread_join(worker->thread);
 }

--- a/lib/nfc/protocols/slix.c
+++ b/lib/nfc/protocols/slix.c
@@ -197,7 +197,7 @@ ReturnCode slix_get_random(NfcVData* data) {
 }
 
 ReturnCode slix_unlock(NfcVData* data, uint32_t password_id) {
-    furi_assert(rand);
+    furi_assert(data);
 
     uint16_t received = 0;
     uint8_t rxBuf[32];

--- a/lib/u8g2/u8g2_glue.c
+++ b/lib/u8g2/u8g2_glue.c
@@ -2,8 +2,8 @@
 
 #include <furi_hal.h>
 
-#define CONTRAST_ERC 31
-#define CONTRAST_MGG 27
+#define CONTRAST_ERC 32
+#define CONTRAST_MGG 28
 
 uint8_t u8g2_gpio_and_delay_stm32(u8x8_t* u8x8, uint8_t msg, uint8_t arg_int, void* arg_ptr) {
     UNUSED(u8x8);


### PR DESCRIPTION
# What's new

- Fix various crashes with LIB_DEBUG=1
- Libs: update ERC and MGG contrast
- Furi: fix double crash caused by `bkpt` use outside of debug session
- FuriHal: enable HSI in stop mode only if we use STOP0, proper SMPS selected clock assert
- Various PVS warning fixes
- FuriHal: fix incorrect CCID statuses returned in some cases
- Update display contrast

# Verification 

-  `./fbt LIB_DEBUG=1 flash_usb_full` 
- full set of tests 

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
