### PR TITLE
[FL-3643] Fix crash when reading files > 64B

### DIFF
--- a/applications/main/nfc/helpers/protocol_support/mf_desfire/mf_desfire_render.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_desfire/mf_desfire_render.c
@@ -190,6 +190,8 @@ void nfc_render_mf_desfire_file_settings_data(
     uint32_t record_count = 1;
     uint32_t record_size = 0;
 
+    const uint32_t total_size = simple_array_get_count(data->data);
+
     switch(settings->type) {
     case MfDesfireFileTypeStandard:
     case MfDesfireFileTypeBackup:
@@ -219,9 +221,20 @@ void nfc_render_mf_desfire_file_settings_data(
     }
 
     for(uint32_t rec = 0; rec < record_count; rec++) {
-        furi_string_cat_printf(str, "record %lu\n", rec);
+        const uint32_t size_offset = rec * record_size;
+        const uint32_t size_remaining = total_size > size_offset ? total_size - size_offset : 0;
+
+        if(size_remaining < record_size) {
+            furi_string_cat_printf(
+                str, "record %lu (partial %lu of %lu)\n", rec, size_remaining, record_size);
+            record_size = size_remaining;
+        } else {
+            furi_string_cat_printf(str, "record %lu\n", rec);
+        }
+
         for(uint32_t ch = 0; ch < record_size; ch += 4) {
             furi_string_cat_printf(str, "%03lx|", ch);
+
             for(uint32_t i = 0; i < 4; i++) {
                 if(ch + i < record_size) {
                     const uint32_t data_index = rec * record_size + ch + i;
@@ -232,6 +245,7 @@ void nfc_render_mf_desfire_file_settings_data(
                     furi_string_cat_printf(str, "   ");
                 }
             }
+
             for(uint32_t i = 0; i < 4 && ch + i < record_size; i++) {
                 const uint32_t data_index = rec * record_size + ch + i;
                 const uint8_t data_byte =
@@ -242,8 +256,10 @@ void nfc_render_mf_desfire_file_settings_data(
                     furi_string_cat_printf(str, ".");
                 }
             }
+
             furi_string_push_back(str, '\n');
         }
+
         furi_string_push_back(str, '\n');
     }
 }

--- a/lib/nfc/protocols/mf_desfire/mf_desfire_poller.c
+++ b/lib/nfc/protocols/mf_desfire/mf_desfire_poller.c
@@ -6,7 +6,8 @@
 
 #define TAG "MfDesfirePoller"
 
-#define MF_DESFIRE_BUF_SIZE_MAX (64U)
+#define MF_DESFIRE_BUF_SIZE (64U)
+#define MF_DESFIRE_RESULT_BUF_SIZE (512U)
 
 typedef NfcCommand (*MfDesfirePollerReadHandler)(MfDesfirePoller* instance);
 
@@ -20,10 +21,10 @@ static MfDesfirePoller* mf_desfire_poller_alloc(Iso14443_4aPoller* iso14443_4a_p
     MfDesfirePoller* instance = malloc(sizeof(MfDesfirePoller));
     instance->iso14443_4a_poller = iso14443_4a_poller;
     instance->data = mf_desfire_alloc();
-    instance->tx_buffer = bit_buffer_alloc(MF_DESFIRE_BUF_SIZE_MAX);
-    instance->rx_buffer = bit_buffer_alloc(MF_DESFIRE_BUF_SIZE_MAX);
-    instance->input_buffer = bit_buffer_alloc(MF_DESFIRE_BUF_SIZE_MAX);
-    instance->result_buffer = bit_buffer_alloc(MF_DESFIRE_BUF_SIZE_MAX);
+    instance->tx_buffer = bit_buffer_alloc(MF_DESFIRE_BUF_SIZE);
+    instance->rx_buffer = bit_buffer_alloc(MF_DESFIRE_BUF_SIZE);
+    instance->input_buffer = bit_buffer_alloc(MF_DESFIRE_BUF_SIZE);
+    instance->result_buffer = bit_buffer_alloc(MF_DESFIRE_RESULT_BUF_SIZE);
 
     instance->mf_desfire_event.data = &instance->mf_desfire_event_data;
 

--- a/lib/nfc/protocols/mf_desfire/mf_desfire_poller_i.c
+++ b/lib/nfc/protocols/mf_desfire/mf_desfire_poller_i.c
@@ -59,7 +59,15 @@ MfDesfireError mf_desfire_send_chunks(
                 break;
             }
 
-            bit_buffer_append_right(rx_buffer, instance->rx_buffer, sizeof(uint8_t));
+            const size_t rx_size = bit_buffer_get_size_bytes(instance->rx_buffer);
+            const size_t rx_capacity_remaining =
+                bit_buffer_get_capacity_bytes(rx_buffer) - bit_buffer_get_size_bytes(rx_buffer);
+
+            if(rx_size <= rx_capacity_remaining) {
+                bit_buffer_append_right(rx_buffer, instance->rx_buffer, sizeof(uint8_t));
+            } else {
+                FURI_LOG_W(TAG, "RX buffer overflow: ignoring %zu bytes", rx_size);
+            }
         }
     } while(false);
 


### PR DESCRIPTION
# What's new

- Support files up to 512B
- Larger files are truncated, which is reflected both in the logs and GUI.
- Support for saving and loading truncated files.

# Verification 

 1. Read a MF DESFire card with at least one regular file (size > 64B) on it.
 2. To check file truncation, a card with a file of size > 512B is needed. Create one from a blank card using Proxmark:
 ```
 hf mfdes createapp --aid 123456
 hf mfdes createfile --aid 123456 --fid 01 --size 000300
 ```
 4. Save MF DESFire card (it must have at least one regular file), then remove some data bytes from the saved file. Load it back in the app, it should mention "partial" in the file info.


# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
