### PR TITLE
fix crash after st25tb save

### DIFF
--- a/applications/main/nfc/helpers/protocol_support/st25tb/st25tb.c
+++ b/applications/main/nfc/helpers/protocol_support/st25tb/st25tb.c
@@ -95,6 +95,11 @@ const NfcProtocolSupportBase nfc_protocol_support_st25tb = {
             .on_enter = nfc_protocol_support_common_on_enter_empty,
             .on_event = nfc_scene_saved_menu_on_event_st25tb,
         },
+    .scene_save_name =
+        {
+            .on_enter = nfc_protocol_support_common_on_enter_empty,
+            .on_event = nfc_protocol_support_common_on_event_empty,
+        },
     .scene_emulate =
         {
             .on_enter = nfc_protocol_support_common_on_enter_empty,


### PR DESCRIPTION
# What's new

- Fix crash occurring after st25tb save 

# Verification 

- Read st25tb tag
- Hit save
- Flipper shouldn't crash

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
