### PR TITLE
Mifare Classic low level poller

### DIFF
--- a/lib/nfc/SConscript
+++ b/lib/nfc/SConscript
@@ -38,6 +38,7 @@ env.Append(
         # Sync API
         File("protocols/iso14443_3a/iso14443_3a_poller_sync_api.h"),
         File("protocols/mf_ultralight/mf_ultralight_poller_sync_api.h"),
+        File("protocols/mf_classic/mf_classic_poller_ll_sync_api.h"),
         File("protocols/mf_classic/mf_classic_poller_sync_api.h"),
         # Misc
         File("helpers/nfc_util.h"),

--- a/lib/nfc/protocols/mf_classic/crypto1.c
+++ b/lib/nfc/protocols/mf_classic/crypto1.c
@@ -143,7 +143,8 @@ void crypto1_encrypt_reader_nonce(
     uint32_t cuid,
     uint8_t* nt,
     uint8_t* nr,
-    BitBuffer* out) {
+    BitBuffer* out,
+    bool is_nested) {
     furi_assert(crypto);
     furi_assert(nt);
     furi_assert(nr);
@@ -153,7 +154,11 @@ void crypto1_encrypt_reader_nonce(
     uint32_t nt_num = nfc_util_bytes2num(nt, sizeof(uint32_t));
 
     crypto1_init(crypto, key);
-    crypto1_word(crypto, nt_num ^ cuid, 0);
+    if(is_nested) {
+        nt_num = crypto1_word(crypto, nt_num ^ cuid, 1) ^ nt_num;
+    } else {
+        crypto1_word(crypto, nt_num ^ cuid, 0);
+    }
 
     for(size_t i = 0; i < 4; i++) {
         uint8_t byte = crypto1_byte(crypto, nr[i], 0) ^ nr[i];

--- a/lib/nfc/protocols/mf_classic/crypto1.h
+++ b/lib/nfc/protocols/mf_classic/crypto1.h
@@ -35,7 +35,8 @@ void crypto1_encrypt_reader_nonce(
     uint32_t cuid,
     uint8_t* nt,
     uint8_t* nr,
-    BitBuffer* out);
+    BitBuffer* out,
+    bool is_nested);
 
 uint32_t prng_successor(uint32_t x, uint32_t n);
 

--- a/lib/nfc/protocols/mf_classic/mf_classic.h
+++ b/lib/nfc/protocols/mf_classic/mf_classic.h
@@ -111,6 +111,7 @@ typedef struct {
     MfClassicNr nr;
     MfClassicAr ar;
     MfClassicAt at;
+    bool is_nested;
 } MfClassicAuthContext;
 
 typedef union {

--- a/lib/nfc/protocols/mf_classic/mf_classic_poller.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller.c
@@ -85,7 +85,8 @@ NfcCommand mf_classic_poller_handler_detect_type(MfClassicPoller* instance) {
         iso14443_3a_copy(
             instance->data->iso14443_3a_data,
             iso14443_3a_poller_get_data(instance->iso14443_3a_poller));
-        MfClassicError error = mf_classic_async_get_nt(instance, 254, MfClassicKeyTypeA, NULL);
+        MfClassicError error =
+            mf_classic_async_get_nt(instance, 254, MfClassicKeyTypeA, NULL, false);
         if(error == MfClassicErrorNone) {
             instance->data->type = MfClassicType4k;
             instance->state = MfClassicPollerStateStart;
@@ -95,7 +96,8 @@ NfcCommand mf_classic_poller_handler_detect_type(MfClassicPoller* instance) {
             instance->current_type_check = MfClassicType1k;
         }
     } else if(instance->current_type_check == MfClassicType1k) {
-        MfClassicError error = mf_classic_async_get_nt(instance, 62, MfClassicKeyTypeA, NULL);
+        MfClassicError error =
+            mf_classic_async_get_nt(instance, 62, MfClassicKeyTypeA, NULL, false);
         if(error == MfClassicErrorNone) {
             instance->data->type = MfClassicType1k;
             FURI_LOG_D(TAG, "1K detected");
@@ -235,7 +237,7 @@ NfcCommand mf_classic_poller_handler_read_block(MfClassicPoller* instance) {
     do {
         // Authenticate to sector
         error = mf_classic_async_auth(
-            instance, write_ctx->current_block, auth_key, write_ctx->key_type_read, NULL);
+            instance, write_ctx->current_block, auth_key, write_ctx->key_type_read, NULL, false);
         if(error != MfClassicErrorNone) {
             FURI_LOG_D(TAG, "Failed to auth to block %d", write_ctx->current_block);
             instance->state = MfClassicPollerStateFail;
@@ -293,7 +295,12 @@ NfcCommand mf_classic_poller_handler_write_block(MfClassicPoller* instance) {
         // Reauth if necessary
         if(write_ctx->need_halt_before_write) {
             error = mf_classic_async_auth(
-                instance, write_ctx->current_block, auth_key, write_ctx->key_type_write, NULL);
+                instance,
+                write_ctx->current_block,
+                auth_key,
+                write_ctx->key_type_write,
+                NULL,
+                false);
             if(error != MfClassicErrorNone) {
                 FURI_LOG_D(
                     TAG, "Failed to auth to block %d for writing", write_ctx->current_block);
@@ -402,8 +409,8 @@ NfcCommand mf_classic_poller_handler_write_value_block(MfClassicPoller* instance
         MfClassicKey* key = (auth_key_type == MfClassicKeyTypeA) ? &write_ctx->sec_tr.key_a :
                                                                    &write_ctx->sec_tr.key_b;
 
-        MfClassicError error =
-            mf_classic_async_auth(instance, write_ctx->current_block, key, auth_key_type, NULL);
+        MfClassicError error = mf_classic_async_auth(
+            instance, write_ctx->current_block, key, auth_key_type, NULL, false);
         if(error != MfClassicErrorNone) break;
 
         error = mf_classic_async_value_cmd(instance, write_ctx->current_block, value_cmd, diff);
@@ -467,7 +474,8 @@ NfcCommand mf_classic_poller_handler_request_read_sector_blocks(MfClassicPoller*
                 sec_read_ctx->current_block,
                 &sec_read_ctx->key,
                 sec_read_ctx->key_type,
-                NULL);
+                NULL,
+                false);
             if(error != MfClassicErrorNone) break;
 
             sec_read_ctx->auth_passed = true;
@@ -533,7 +541,7 @@ NfcCommand mf_classic_poller_handler_auth_a(MfClassicPoller* instance) {
         FURI_LOG_D(TAG, "Auth to block %d with key A: %06llx", block, key);
 
         MfClassicError error = mf_classic_async_auth(
-            instance, block, &dict_attack_ctx->current_key, MfClassicKeyTypeA, NULL);
+            instance, block, &dict_attack_ctx->current_key, MfClassicKeyTypeA, NULL, false);
         if(error == MfClassicErrorNone) {
             FURI_LOG_I(TAG, "Key A found");
             mf_classic_set_key_found(
@@ -571,7 +579,7 @@ NfcCommand mf_classic_poller_handler_auth_b(MfClassicPoller* instance) {
         FURI_LOG_D(TAG, "Auth to block %d with key B: %06llx", block, key);
 
         MfClassicError error = mf_classic_async_auth(
-            instance, block, &dict_attack_ctx->current_key, MfClassicKeyTypeB, NULL);
+            instance, block, &dict_attack_ctx->current_key, MfClassicKeyTypeB, NULL, false);
         if(error == MfClassicErrorNone) {
             FURI_LOG_I(TAG, "Key B found");
             mf_classic_set_key_found(
@@ -626,7 +634,8 @@ NfcCommand mf_classic_poller_handler_read_sector(MfClassicPoller* instance) {
                 block_num,
                 &dict_attack_ctx->current_key,
                 dict_attack_ctx->current_key_type,
-                NULL);
+                NULL,
+                false);
             if(error != MfClassicErrorNone) {
                 instance->state = MfClassicPollerStateNextSector;
                 FURI_LOG_W(TAG, "Failed to re-auth. Go to next sector");
@@ -714,7 +723,7 @@ NfcCommand mf_classic_poller_handler_key_reuse_auth_key_a(MfClassicPoller* insta
         FURI_LOG_D(TAG, "Key attack auth to block %d with key A: %06llx", block, key);
 
         MfClassicError error = mf_classic_async_auth(
-            instance, block, &dict_attack_ctx->current_key, MfClassicKeyTypeA, NULL);
+            instance, block, &dict_attack_ctx->current_key, MfClassicKeyTypeA, NULL, false);
         if(error == MfClassicErrorNone) {
             FURI_LOG_I(TAG, "Key A found");
             mf_classic_set_key_found(
@@ -749,7 +758,7 @@ NfcCommand mf_classic_poller_handler_key_reuse_auth_key_b(MfClassicPoller* insta
         FURI_LOG_D(TAG, "Key attack auth to block %d with key B: %06llx", block, key);
 
         MfClassicError error = mf_classic_async_auth(
-            instance, block, &dict_attack_ctx->current_key, MfClassicKeyTypeB, NULL);
+            instance, block, &dict_attack_ctx->current_key, MfClassicKeyTypeB, NULL, false);
         if(error == MfClassicErrorNone) {
             FURI_LOG_I(TAG, "Key B found");
             mf_classic_set_key_found(
@@ -788,7 +797,8 @@ NfcCommand mf_classic_poller_handler_key_reuse_read_sector(MfClassicPoller* inst
                 block_num,
                 &dict_attack_ctx->current_key,
                 dict_attack_ctx->current_key_type,
-                NULL);
+                NULL,
+                false);
             if(error != MfClassicErrorNone) {
                 instance->state = MfClassicPollerStateKeyReuseStart;
                 break;

--- a/lib/nfc/protocols/mf_classic/mf_classic_poller_i.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller_i.c
@@ -37,7 +37,8 @@ MfClassicError mf_classic_async_get_nt(
     MfClassicPoller* instance,
     uint8_t block_num,
     MfClassicKeyType key_type,
-    MfClassicNt* nt) {
+    MfClassicNt* nt,
+    bool is_nested) {
     MfClassicError ret = MfClassicErrorNone;
     Iso14443_3aError error = Iso14443_3aErrorNone;
 
@@ -47,14 +48,29 @@ MfClassicError mf_classic_async_get_nt(
         uint8_t auth_cmd[2] = {auth_type, block_num};
         bit_buffer_copy_bytes(instance->tx_plain_buffer, auth_cmd, sizeof(auth_cmd));
 
-        error = iso14443_3a_poller_send_standard_frame(
-            instance->iso14443_3a_poller,
-            instance->tx_plain_buffer,
-            instance->rx_plain_buffer,
-            MF_CLASSIC_FWT_FC);
-        if(error != Iso14443_3aErrorWrongCrc) {
-            ret = mf_classic_process_error(error);
-            break;
+        if(is_nested) {
+            iso14443_crc_append(Iso14443CrcTypeA, instance->tx_plain_buffer);
+            crypto1_encrypt(
+                instance->crypto, NULL, instance->tx_plain_buffer, instance->tx_encrypted_buffer);
+            error = iso14443_3a_poller_txrx_custom_parity(
+                instance->iso14443_3a_poller,
+                instance->tx_encrypted_buffer,
+                instance->rx_plain_buffer, // NT gets decrypted by mf_classic_async_auth
+                MF_CLASSIC_FWT_FC);
+            if(error != Iso14443_3aErrorNone) {
+                ret = mf_classic_process_error(error);
+                break;
+            }
+        } else {
+            error = iso14443_3a_poller_send_standard_frame(
+                instance->iso14443_3a_poller,
+                instance->tx_plain_buffer,
+                instance->rx_plain_buffer,
+                MF_CLASSIC_FWT_FC);
+            if(error != Iso14443_3aErrorWrongCrc) {
+                ret = mf_classic_process_error(error);
+                break;
+            }
         }
         if(bit_buffer_get_size_bytes(instance->rx_plain_buffer) != sizeof(MfClassicNt)) {
             ret = MfClassicErrorProtocol;
@@ -74,7 +90,8 @@ MfClassicError mf_classic_async_auth(
     uint8_t block_num,
     MfClassicKey* key,
     MfClassicKeyType key_type,
-    MfClassicAuthContext* data) {
+    MfClassicAuthContext* data,
+    bool is_nested) {
     MfClassicError ret = MfClassicErrorNone;
     Iso14443_3aError error = Iso14443_3aErrorNone;
 
@@ -84,7 +101,7 @@ MfClassicError mf_classic_async_auth(
             iso14443_3a_poller_get_data(instance->iso14443_3a_poller));
 
         MfClassicNt nt = {};
-        ret = mf_classic_async_get_nt(instance, block_num, key_type, &nt);
+        ret = mf_classic_async_get_nt(instance, block_num, key_type, &nt, is_nested);
         if(ret != MfClassicErrorNone) break;
         if(data) {
             data->nt = nt;
@@ -96,7 +113,13 @@ MfClassicError mf_classic_async_auth(
         furi_hal_random_fill_buf(nr.data, sizeof(MfClassicNr));
 
         crypto1_encrypt_reader_nonce(
-            instance->crypto, key_num, cuid, nt.data, nr.data, instance->tx_encrypted_buffer);
+            instance->crypto,
+            key_num,
+            cuid,
+            nt.data,
+            nr.data,
+            instance->tx_encrypted_buffer,
+            is_nested);
         error = iso14443_3a_poller_txrx_custom_parity(
             instance->iso14443_3a_poller,
             instance->tx_encrypted_buffer,

--- a/lib/nfc/protocols/mf_classic/mf_classic_poller_i.h
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller_i.h
@@ -173,14 +173,16 @@ MfClassicError mf_classic_async_get_nt(
     MfClassicPoller* instance,
     uint8_t block_num,
     MfClassicKeyType key_type,
-    MfClassicNt* nt);
+    MfClassicNt* nt,
+    bool is_nested);
 
 MfClassicError mf_classic_async_auth(
     MfClassicPoller* instance,
     uint8_t block_num,
     MfClassicKey* key,
     MfClassicKeyType key_type,
-    MfClassicAuthContext* data);
+    MfClassicAuthContext* data,
+    bool is_nested);
 
 MfClassicError mf_classic_async_halt(MfClassicPoller* instance);
 

--- a/lib/nfc/protocols/mf_classic/mf_classic_poller_i.h
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller_i.h
@@ -149,6 +149,10 @@ typedef struct {
 } MfClassicChangeValueContext;
 
 typedef struct {
+    uint8_t block_num;
+} MfClassicTransferValueContext;
+
+typedef struct {
     MfClassicDeviceKeys keys;
     uint8_t current_sector;
 } MfClassicReadContext;
@@ -160,6 +164,7 @@ typedef union {
     MfClassicWriteBlockContext write_block_context;
     MfClassicReadValueContext read_value_context;
     MfClassicChangeValueContext change_value_context;
+    MfClassicTransferValueContext transfer_value_context;
     MfClassicReadContext read_context;
 } MfClassicPollerContextData;
 

--- a/lib/nfc/protocols/mf_classic/mf_classic_poller_ll_sync_api.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller_ll_sync_api.c
@@ -1,0 +1,280 @@
+#include "mf_classic_poller_i.h"
+
+#include <nfc/nfc_poller.h>
+
+#include <furi.h>
+
+#define TAG "MfClassicPollerLl"
+
+#define MF_CLASSIC_POLLER_LL_COMPLETE_EVENT (1UL << 0)
+
+typedef enum {
+    MfClassicPollerCmdTypeLlAuth,
+    MfClassicPollerCmdTypeLlReadBlock,
+    MfClassicPollerCmdTypeLlWriteBlock,
+    MfClassicPollerCmdTypeLlValueBlockCommand,
+    MfClassicPollerCmdTypeLlValueBlockTransfer,
+    MfClassicPollerCmdTypeLlHalt,
+
+    MfClassicPollerCmdTypeLlNum,
+} MfClassicPollerLlCmdType;
+
+typedef struct {
+    NfcPoller* poller;
+    MfClassicPoller* mfc_poller;
+    FuriMessageQueue* cmd_queue;
+} MfClassicPollerLl;
+
+typedef struct {
+    MfClassicPollerLlCmdType cmd_type;
+    MfClassicPollerContextData* data;
+    MfClassicError* result;
+    FuriThreadId thread_id;
+} MfClassicPollerLlCmd;
+
+typedef MfClassicError (
+    *MfClassicPollerLlCmdHandler)(MfClassicPoller* poller, MfClassicPollerContextData* data);
+
+static MfClassicError
+    mf_classic_poller_ll_auth_handler(MfClassicPoller* poller, MfClassicPollerContextData* data) {
+    return mf_classic_async_auth(
+        poller,
+        data->auth_context.block_num,
+        &data->auth_context.key,
+        data->auth_context.key_type,
+        &data->auth_context,
+        data->auth_context.is_nested);
+}
+
+static MfClassicError mf_classic_poller_ll_read_block_handler(
+    MfClassicPoller* poller,
+    MfClassicPollerContextData* data) {
+    MfClassicError error = mf_classic_async_read_block(
+        poller, data->read_block_context.block_num, &data->read_block_context.block);
+    return error;
+}
+
+static MfClassicError mf_classic_poller_ll_write_block_handler(
+    MfClassicPoller* poller,
+    MfClassicPollerContextData* data) {
+    MfClassicError error = mf_classic_async_write_block(
+        poller, data->read_block_context.block_num, &data->read_block_context.block);
+    return error;
+}
+
+static MfClassicError mf_classic_poller_ll_value_block_command_handler(
+    MfClassicPoller* poller,
+    MfClassicPollerContextData* data) {
+    MfClassicError error = error = mf_classic_async_value_cmd(
+        poller,
+        data->change_value_context.block_num,
+        data->change_value_context.value_cmd,
+        data->change_value_context.data);
+    return error;
+}
+
+static MfClassicError mf_classic_poller_ll_value_block_transfer_handler(
+    MfClassicPoller* poller,
+    MfClassicPollerContextData* data) {
+    MfClassicError error =
+        mf_classic_async_value_transfer(poller, data->transfer_value_context.block_num);
+    return error;
+}
+
+static MfClassicError
+    mf_classic_poller_ll_halt_handler(MfClassicPoller* poller, MfClassicPollerContextData* data) {
+    UNUSED(data);
+    MfClassicError error = mf_classic_async_halt(poller);
+    return error;
+}
+
+static const MfClassicPollerLlCmdHandler
+    mf_classic_poller_ll_cmd_handlers[MfClassicPollerCmdTypeLlNum] = {
+
+        [MfClassicPollerCmdTypeLlAuth] = mf_classic_poller_ll_auth_handler,
+        [MfClassicPollerCmdTypeLlReadBlock] = mf_classic_poller_ll_read_block_handler,
+        [MfClassicPollerCmdTypeLlWriteBlock] = mf_classic_poller_ll_write_block_handler,
+        [MfClassicPollerCmdTypeLlValueBlockCommand] =
+            mf_classic_poller_ll_value_block_command_handler,
+        [MfClassicPollerCmdTypeLlValueBlockTransfer] =
+            mf_classic_poller_ll_value_block_transfer_handler,
+        [MfClassicPollerCmdTypeLlHalt] = mf_classic_poller_ll_halt_handler,
+};
+
+static NfcCommand mf_classic_poller_ll_cmd_callback(NfcGenericEvent event, void* context) {
+    furi_assert(event.instance);
+    furi_assert(event.protocol == NfcProtocolIso14443_3a);
+    furi_assert(event.event_data);
+    furi_assert(context);
+
+    MfClassicPollerLl* poller = context;
+    Iso14443_3aPollerEvent* iso14443_3a_event = event.event_data;
+    Iso14443_3aPoller* iso14443_3a_poller = event.instance;
+
+    if(poller->mfc_poller == NULL) {
+        poller->mfc_poller = mf_classic_poller_alloc(iso14443_3a_poller);
+    }
+
+    MfClassicPollerLlCmd poller_cmd;
+    furi_message_queue_get(poller->cmd_queue, &poller_cmd, FuriWaitForever);
+
+    if(iso14443_3a_event->type == Iso14443_3aPollerEventTypeReady) {
+        *poller_cmd.result = mf_classic_poller_ll_cmd_handlers[poller_cmd.cmd_type](
+            poller->mfc_poller, poller_cmd.data);
+    } else if(iso14443_3a_event->type == Iso14443_3aPollerEventTypeError) {
+        *poller_cmd.result = mf_classic_process_error(iso14443_3a_event->data->error);
+    }
+
+    furi_thread_flags_set(poller_cmd.thread_id, MF_CLASSIC_POLLER_LL_COMPLETE_EVENT);
+
+    return poller_cmd.cmd_type == MfClassicPollerCmdTypeLlHalt ? NfcCommandStop :
+                                                                 NfcCommandContinue;
+}
+
+static MfClassicError mf_classic_poller_ll_cmd_execute(
+    MfClassicPollerLl* poller,
+    MfClassicPollerLlCmdType cmd_type,
+    MfClassicPollerContextData* cmd_data) {
+    furi_assert(cmd_type < MfClassicPollerCmdTypeLlNum);
+
+    MfClassicError result;
+    MfClassicPollerLlCmd cmd = {
+        .cmd_type = cmd_type,
+        .data = cmd_data,
+        .result = &result,
+        .thread_id = furi_thread_get_current_id()};
+
+    furi_message_queue_put(poller->cmd_queue, &cmd, FuriWaitForever);
+
+    furi_thread_flags_wait(MF_CLASSIC_POLLER_LL_COMPLETE_EVENT, FuriFlagWaitAny, FuriWaitForever);
+    furi_thread_flags_clear(MF_CLASSIC_POLLER_LL_COMPLETE_EVENT);
+
+    return result;
+}
+
+MfClassicPollerLl* mf_classic_poller_ll_alloc(Nfc* nfc) {
+    furi_assert(nfc);
+
+    MfClassicPollerLl* poller = malloc(sizeof(MfClassicPollerLl));
+    poller->poller = nfc_poller_alloc(nfc, NfcProtocolIso14443_3a);
+    poller->cmd_queue = furi_message_queue_alloc(1, sizeof(MfClassicPollerLlCmd));
+    poller->mfc_poller = NULL;
+    nfc_poller_start(poller->poller, mf_classic_poller_ll_cmd_callback, poller);
+    return poller;
+}
+
+void mf_classic_poller_ll_free(MfClassicPollerLl* poller) {
+    furi_assert(poller);
+
+    nfc_poller_stop(poller->poller);
+    if(poller->mfc_poller != NULL) {
+        mf_classic_poller_free(poller->mfc_poller);
+    }
+
+    nfc_poller_free(poller->poller);
+    free(poller);
+}
+
+MfClassicError mf_classic_poller_ll_auth(
+    MfClassicPollerLl* poller,
+    uint8_t block_num,
+    MfClassicKey* key,
+    MfClassicKeyType key_type,
+    bool is_nested) {
+    furi_assert(poller);
+    furi_assert(key);
+    MfClassicPollerContextData cmd_data = {
+        .auth_context.block_num = block_num,
+        .auth_context.key = *key,
+        .auth_context.key_type = key_type,
+        .auth_context.is_nested = is_nested,
+    };
+
+    MfClassicError error =
+        mf_classic_poller_ll_cmd_execute(poller, MfClassicPollerCmdTypeLlAuth, &cmd_data);
+
+    return error;
+}
+
+MfClassicError mf_classic_poller_ll_read_block(
+    MfClassicPollerLl* poller,
+    uint8_t block_num,
+    MfClassicBlock* data) {
+    furi_assert(poller);
+    furi_assert(data);
+
+    MfClassicPollerContextData cmd_data = {
+        .read_block_context.block_num = block_num,
+    };
+
+    MfClassicError error =
+        mf_classic_poller_ll_cmd_execute(poller, MfClassicPollerCmdTypeLlReadBlock, &cmd_data);
+
+    if(error == MfClassicErrorNone) {
+        *data = cmd_data.read_block_context.block;
+    }
+
+    return error;
+}
+
+MfClassicError mf_classic_poller_ll_write_block(
+    MfClassicPollerLl* poller,
+    uint8_t block_num,
+    MfClassicBlock* data) {
+    furi_assert(poller);
+    furi_assert(data);
+
+    MfClassicPollerContextData cmd_data = {
+        .write_block_context.block_num = block_num,
+        .write_block_context.block = *data,
+    };
+
+    MfClassicError error =
+        mf_classic_poller_ll_cmd_execute(poller, MfClassicPollerCmdTypeLlWriteBlock, &cmd_data);
+
+    return error;
+}
+
+MfClassicError mf_classic_poller_ll_value_block_command(
+    MfClassicPollerLl* poller,
+    uint8_t block_num,
+    uint8_t operation,
+    uint32_t data) {
+    furi_assert(poller);
+
+    MfClassicPollerContextData cmd_data = {
+        .change_value_context.block_num = block_num,
+        .change_value_context.value_cmd = operation,
+        .change_value_context.data = data,
+    };
+
+    MfClassicError error = mf_classic_poller_ll_cmd_execute(
+        poller, MfClassicPollerCmdTypeLlValueBlockCommand, &cmd_data);
+
+    return error;
+}
+
+MfClassicError
+    mf_classic_poller_ll_value_block_transfer(MfClassicPollerLl* poller, uint8_t block_num) {
+    furi_assert(poller);
+
+    MfClassicPollerContextData cmd_data = {
+        .transfer_value_context.block_num = block_num,
+    };
+
+    MfClassicError error = mf_classic_poller_ll_cmd_execute(
+        poller, MfClassicPollerCmdTypeLlValueBlockTransfer, &cmd_data);
+
+    return error;
+}
+
+MfClassicError mf_classic_poller_ll_halt(MfClassicPollerLl* poller) {
+    furi_assert(poller);
+
+    MfClassicPollerContextData cmd_data = {};
+
+    MfClassicError error =
+        mf_classic_poller_ll_cmd_execute(poller, MfClassicPollerCmdTypeLlHalt, &cmd_data);
+
+    return error;
+}

--- a/lib/nfc/protocols/mf_classic/mf_classic_poller_ll_sync_api.h
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller_ll_sync_api.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "mf_classic.h"
+#include <nfc/nfc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct MfClassicPollerLl MfClassicPollerLl;
+
+MfClassicPollerLl* mf_classic_poller_ll_alloc(Nfc* nfc);
+void mf_classic_poller_ll_free(MfClassicPollerLl* poller);
+
+MfClassicError mf_classic_poller_ll_auth(
+    MfClassicPollerLl* poller,
+    uint8_t block_num,
+    MfClassicKey* key,
+    MfClassicKeyType key_type,
+    bool is_nested);
+
+MfClassicError mf_classic_poller_ll_read_block(
+    MfClassicPollerLl* poller,
+    uint8_t block_num,
+    MfClassicBlock* data);
+
+MfClassicError mf_classic_poller_ll_write_block(
+    MfClassicPollerLl* poller,
+    uint8_t block_num,
+    MfClassicBlock* data);
+
+MfClassicError mf_classic_poller_ll_value_block_command(
+    MfClassicPollerLl* poller,
+    uint8_t block_num,
+    uint8_t operation,
+    uint32_t data);
+
+MfClassicError
+    mf_classic_poller_ll_value_block_transfer(MfClassicPollerLl* poller, uint8_t block_num);
+
+MfClassicError mf_classic_poller_ll_halt(MfClassicPollerLl* poller);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/nfc/protocols/mf_classic/mf_classic_poller_sync_api.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller_sync_api.c
@@ -36,7 +36,8 @@ static MfClassicError mf_classic_poller_collect_nt_handler(
         poller,
         data->collect_nt_context.block,
         data->collect_nt_context.key_type,
-        &data->collect_nt_context.nt);
+        &data->collect_nt_context.nt,
+        false);
 }
 
 static MfClassicError
@@ -46,7 +47,8 @@ static MfClassicError
         data->auth_context.block_num,
         &data->auth_context.key,
         data->auth_context.key_type,
-        &data->auth_context);
+        &data->auth_context,
+        false);
 }
 
 static MfClassicError mf_classic_poller_read_block_handler(
@@ -60,7 +62,8 @@ static MfClassicError mf_classic_poller_read_block_handler(
             data->read_block_context.block_num,
             &data->read_block_context.key,
             data->read_block_context.key_type,
-            NULL);
+            NULL,
+            false);
         if(error != MfClassicErrorNone) break;
 
         error = mf_classic_async_read_block(
@@ -86,7 +89,8 @@ static MfClassicError mf_classic_poller_write_block_handler(
             data->read_block_context.block_num,
             &data->read_block_context.key,
             data->read_block_context.key_type,
-            NULL);
+            NULL,
+            false);
         if(error != MfClassicErrorNone) break;
 
         error = mf_classic_async_write_block(
@@ -112,7 +116,8 @@ static MfClassicError mf_classic_poller_read_value_handler(
             data->read_value_context.block_num,
             &data->read_value_context.key,
             data->read_value_context.key_type,
-            NULL);
+            NULL,
+            false);
         if(error != MfClassicErrorNone) break;
 
         MfClassicBlock block = {};
@@ -143,7 +148,8 @@ static MfClassicError mf_classic_poller_change_value_handler(
             data->change_value_context.block_num,
             &data->change_value_context.key,
             data->change_value_context.key_type,
-            NULL);
+            NULL,
+            false);
         if(error != MfClassicErrorNone) break;
 
         error = mf_classic_async_value_cmd(

--- a/targets/f18/api_symbols.csv
+++ b/targets/f18/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,40.1,,
+Version,+,40.2,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,40.1,,
+Version,+,40.2,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
@@ -128,6 +128,7 @@ Header,+,lib/nfc/protocols/iso14443_4b/iso14443_4b_poller.h,,
 Header,+,lib/nfc/protocols/mf_classic/mf_classic.h,,
 Header,+,lib/nfc/protocols/mf_classic/mf_classic_listener.h,,
 Header,+,lib/nfc/protocols/mf_classic/mf_classic_poller.h,,
+Header,+,lib/nfc/protocols/mf_classic/mf_classic_poller_ll_sync_api.h,,
 Header,+,lib/nfc/protocols/mf_classic/mf_classic_poller_sync_api.h,,
 Header,+,lib/nfc/protocols/mf_desfire/mf_desfire.h,,
 Header,+,lib/nfc/protocols/mf_desfire/mf_desfire_poller.h,,
@@ -2144,6 +2145,14 @@ Function,+,mf_classic_poller_auth,MfClassicError,"Nfc*, uint8_t, MfClassicKey*, 
 Function,+,mf_classic_poller_change_value,MfClassicError,"Nfc*, uint8_t, MfClassicKey*, MfClassicKeyType, int32_t, int32_t*"
 Function,+,mf_classic_poller_collect_nt,MfClassicError,"Nfc*, uint8_t, MfClassicKeyType, MfClassicNt*"
 Function,+,mf_classic_poller_detect_type,MfClassicError,"Nfc*, MfClassicType*"
+Function,+,mf_classic_poller_ll_alloc,MfClassicPollerLl*,Nfc*
+Function,+,mf_classic_poller_ll_auth,MfClassicError,"MfClassicPollerLl*, uint8_t, MfClassicKey*, MfClassicKeyType, _Bool"
+Function,+,mf_classic_poller_ll_free,void,MfClassicPollerLl*
+Function,+,mf_classic_poller_ll_halt,MfClassicError,MfClassicPollerLl*
+Function,+,mf_classic_poller_ll_read_block,MfClassicError,"MfClassicPollerLl*, uint8_t, MfClassicBlock*"
+Function,+,mf_classic_poller_ll_value_block_command,MfClassicError,"MfClassicPollerLl*, uint8_t, uint8_t, uint32_t"
+Function,+,mf_classic_poller_ll_value_block_transfer,MfClassicError,"MfClassicPollerLl*, uint8_t"
+Function,+,mf_classic_poller_ll_write_block,MfClassicError,"MfClassicPollerLl*, uint8_t, MfClassicBlock*"
 Function,+,mf_classic_poller_read,MfClassicError,"Nfc*, const MfClassicDeviceKeys*, MfClassicData*"
 Function,+,mf_classic_poller_read_block,MfClassicError,"Nfc*, uint8_t, MfClassicKey*, MfClassicKeyType, MfClassicBlock*"
 Function,+,mf_classic_poller_read_value,MfClassicError,"Nfc*, uint8_t, MfClassicKey*, MfClassicKeyType, int32_t*"


### PR DESCRIPTION
# What's new

- Low-level poller for mifare classic, allows for doing custom command chaining in user applications with a sync api.
- Add support for nested auth in mifare classic poller

# Verification 

Not sure how to provide verification steps. I developed a small test app that I can either link here or add as part of unit tests, but for that I'll need some advice.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
