### PR TITLE
[FL-3647] Rename menu items related to dummy mode and sound

### DIFF
--- a/applications/services/desktop/views/desktop_view_lock_menu.c
+++ b/applications/services/desktop/views/desktop_view_lock_menu.c
@@ -60,13 +60,13 @@ void desktop_lock_menu_draw_callback(Canvas* canvas, void* model) {
             str = "Lock";
         } else if(i == DesktopLockMenuIndexStealth) {
             if(m->stealth_mode) {
-                str = "Sound Mode";
+                str = "Unmute";
             } else {
-                str = "Stealth Mode";
+                str = "Mute";
             }
         } else if(i == DesktopLockMenuIndexDummy) { //-V547
             if(m->dummy_mode) {
-                str = "Brainiac Mode";
+                str = "Default Mode";
             } else {
                 str = "Dummy Mode";
             }


### PR DESCRIPTION
# What's new

- Brainiac Mode renamed to Default Mode
- Stealth Mode renamed to Mute
- Sound Mode renamed to Unmute

# Verification 

- Check that the names have changed

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
