### PR TITLE
[FL-3655] Dolphin: Extreme butthurt loop fix

### DIFF
--- a/applications/services/dolphin/dolphin.c
+++ b/applications/services/dolphin/dolphin.c
@@ -155,9 +155,9 @@ int32_t dolphin_srv(void* p) {
     furi_record_create(RECORD_DOLPHIN, dolphin);
 
     dolphin_state_load(dolphin->state);
-    furi_timer_stop(dolphin->butthurt_timer);
+    furi_timer_restart(dolphin->butthurt_timer, HOURS_IN_TICKS(2 * 24));
     dolphin_update_clear_limits_timer_period(dolphin);
-    furi_timer_stop(dolphin->clear_limits_timer);
+    furi_timer_restart(dolphin->clear_limits_timer, HOURS_IN_TICKS(24));
 
     DolphinEvent event;
     while(1) {
@@ -167,8 +167,8 @@ int32_t dolphin_srv(void* p) {
                 dolphin_state_on_deed(dolphin->state, event.deed);
                 DolphinPubsubEvent event = DolphinPubsubEventUpdate;
                 furi_pubsub_publish(dolphin->pubsub, &event);
-                furi_timer_restart(dolphin->butthurt_timer);
-                furi_timer_restart(dolphin->flush_timer);
+                furi_timer_restart(dolphin->butthurt_timer, HOURS_IN_TICKS(2 * 24));
+                furi_timer_restart(dolphin->flush_timer, 30 * 1000);
             } else if(event.type == DolphinEventTypeStats) {
                 event.stats->icounter = dolphin->state->data.icounter;
                 event.stats->butthurt = dolphin->state->data.butthurt;

--- a/furi/core/timer.c
+++ b/furi/core/timer.c
@@ -106,8 +106,8 @@ FuriStatus furi_timer_restart(FuriTimer* instance, uint32_t ticks) {
     TimerHandle_t hTimer = (TimerHandle_t)instance;
     FuriStatus stat;
 
-    if(xTimerChangePeriod(hTimer, ticks, portMAX_DELAY) == pdPASS
-        && xTimerReset(hTimer, portMAX_DELAY) == pdPASS) {
+    if(xTimerChangePeriod(hTimer, ticks, portMAX_DELAY) == pdPASS &&
+       xTimerReset(hTimer, portMAX_DELAY) == pdPASS) {
         stat = FuriStatusOk;
     } else {
         stat = FuriStatusErrorResource;

--- a/furi/core/timer.c
+++ b/furi/core/timer.c
@@ -51,7 +51,7 @@ FuriTimer* furi_timer_alloc(FuriTimerCallback func, FuriTimerType type, void* co
     callb = (TimerCallback_t*)((uint32_t)callb | 1U);
     // TimerCallback function is always provided as a callback and is used to call application
     // specified function with its context both stored in structure callb.
-    hTimer = xTimerCreate(NULL, 1, reload, callb, TimerCallback);
+    hTimer = xTimerCreate(NULL, portMAX_DELAY, reload, callb, TimerCallback);
     furi_check(hTimer);
 
     /* Return timer ID */
@@ -83,6 +83,7 @@ void furi_timer_free(FuriTimer* instance) {
 FuriStatus furi_timer_start(FuriTimer* instance, uint32_t ticks) {
     furi_assert(!furi_kernel_is_irq_or_masked());
     furi_assert(instance);
+    furi_assert(ticks < portMAX_DELAY);
 
     TimerHandle_t hTimer = (TimerHandle_t)instance;
     FuriStatus stat;
@@ -97,14 +98,16 @@ FuriStatus furi_timer_start(FuriTimer* instance, uint32_t ticks) {
     return (stat);
 }
 
-FuriStatus furi_timer_restart(FuriTimer* instance) {
+FuriStatus furi_timer_restart(FuriTimer* instance, uint32_t ticks) {
     furi_assert(!furi_kernel_is_irq_or_masked());
     furi_assert(instance);
+    furi_assert(ticks < portMAX_DELAY);
 
     TimerHandle_t hTimer = (TimerHandle_t)instance;
     FuriStatus stat;
 
-    if(xTimerReset(hTimer, portMAX_DELAY) == pdPASS) {
+    if(xTimerChangePeriod(hTimer, ticks, portMAX_DELAY) == pdPASS
+        && xTimerReset(hTimer, portMAX_DELAY) == pdPASS) {
         stat = FuriStatusOk;
     } else {
         stat = FuriStatusErrorResource;
@@ -163,7 +166,9 @@ void furi_timer_pending_callback(FuriTimerPendigCallback callback, void* context
 
 void furi_timer_set_thread_priority(FuriTimerThreadPriority priority) {
     furi_assert(!furi_kernel_is_irq_or_masked());
-    TaskHandle_t task_handle = xTaskGetHandle(configTIMER_SERVICE_TASK_NAME);
+
+    TaskHandle_t task_handle = xTimerGetTimerDaemonTaskHandle();
+    furi_check(task_handle); // Don't call this method before timer task start
 
     if(priority == FuriTimerThreadPriorityNormal) {
         vTaskPrioritySet(task_handle, configTIMER_TASK_PRIORITY);

--- a/furi/core/timer.h
+++ b/furi/core/timer.h
@@ -34,7 +34,7 @@ void furi_timer_free(FuriTimer* instance);
 /** Start timer
  *
  * @param      instance  The pointer to FuriTimer instance
- * @param[in]  ticks     The ticks
+ * @param[in]  ticks     The interval in ticks
  *
  * @return     The furi status.
  */
@@ -43,6 +43,7 @@ FuriStatus furi_timer_start(FuriTimer* instance, uint32_t ticks);
 /** Restart timer with previous timeout value
  *
  * @param      instance  The pointer to FuriTimer instance
+ * @param[in]  ticks     The interval in ticks
  *
  * @return     The furi status.
  */

--- a/furi/core/timer.h
+++ b/furi/core/timer.h
@@ -46,7 +46,7 @@ FuriStatus furi_timer_start(FuriTimer* instance, uint32_t ticks);
  *
  * @return     The furi status.
  */
-FuriStatus furi_timer_restart(FuriTimer* instance);
+FuriStatus furi_timer_restart(FuriTimer* instance, uint32_t ticks);
 
 /** Stop timer
  *

--- a/targets/f18/api_symbols.csv
+++ b/targets/f18/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,43.2,,
+Version,+,44.0,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,
@@ -1493,7 +1493,7 @@ Function,+,furi_timer_free,void,FuriTimer*
 Function,+,furi_timer_get_expire_time,uint32_t,FuriTimer*
 Function,+,furi_timer_is_running,uint32_t,FuriTimer*
 Function,+,furi_timer_pending_callback,void,"FuriTimerPendigCallback, void*, uint32_t"
-Function,+,furi_timer_restart,FuriStatus,FuriTimer*
+Function,+,furi_timer_restart,FuriStatus,"FuriTimer*, uint32_t"
 Function,+,furi_timer_set_thread_priority,void,FuriTimerThreadPriority
 Function,+,furi_timer_start,FuriStatus,"FuriTimer*, uint32_t"
 Function,+,furi_timer_stop,FuriStatus,FuriTimer*

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,43.2,,
+Version,+,44.0,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
@@ -1688,7 +1688,7 @@ Function,+,furi_timer_free,void,FuriTimer*
 Function,+,furi_timer_get_expire_time,uint32_t,FuriTimer*
 Function,+,furi_timer_is_running,uint32_t,FuriTimer*
 Function,+,furi_timer_pending_callback,void,"FuriTimerPendigCallback, void*, uint32_t"
-Function,+,furi_timer_restart,FuriStatus,FuriTimer*
+Function,+,furi_timer_restart,FuriStatus,"FuriTimer*, uint32_t"
 Function,+,furi_timer_set_thread_priority,void,FuriTimerThreadPriority
 Function,+,furi_timer_start,FuriStatus,"FuriTimer*, uint32_t"
 Function,+,furi_timer_stop,FuriStatus,FuriTimer*


### PR DESCRIPTION
# What's new

- Furi: change timer restart function signature, explicitly require timer time.
- Dolphin: fix incorrect timer usage caused by refactoring.

# Verification 

- According to FL-3655

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
