### PR TITLE
[FL-3656] Fix crash when exiting write mode

### DIFF
--- a/applications/main/ibutton/ibutton_custom_event.h
+++ b/applications/main/ibutton/ibutton_custom_event.h
@@ -1,6 +1,6 @@
 #pragma once
 
-enum iButtonCustomEvent {
+typedef enum {
     // Reserve first 100 events for button types and indexes, starting from 0
     iButtonCustomEventReserved = 100,
 
@@ -10,8 +10,12 @@ enum iButtonCustomEvent {
     iButtonCustomEventByteEditResult,
     iButtonCustomEventWorkerEmulated,
     iButtonCustomEventWorkerRead,
+    iButtonCustomEventWorkerWriteOK,
+    iButtonCustomEventWorkerWriteSameKey,
+    iButtonCustomEventWorkerWriteNoDetect,
+    iButtonCustomEventWorkerWriteCannotWrite,
 
     iButtonCustomEventRpcLoad,
     iButtonCustomEventRpcExit,
     iButtonCustomEventRpcSessionClose,
-};
+} iButtonCustomEvent;


### PR DESCRIPTION
# What's new

- Fixed iButton crash upon exit from the Write screen.

# Verification 
1. Go to `iButton -> Add Manually` and add a new DS1990 key.
2. Select it and press `Write Blank` to enter the Write screen.
3. Press `back` once to exit the screen.
4. Repeat 2 and 3 over 9000 times (unfixed version will crash eventually).
5. The application should not crash.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
