### PR TITLE
[FL-3657] Fix NFC unit tests

### DIFF
--- a/lib/nfc/helpers/nfc_data_generator.c
+++ b/lib/nfc/helpers/nfc_data_generator.c
@@ -28,6 +28,7 @@ static const uint8_t default_config_ntag_i2c[] = {0x01, 0x00, 0xF8, 0x48, 0x08, 
 static void nfc_generate_mf_ul_uid(uint8_t* uid) {
     uid[0] = NXP_MANUFACTURER_ID;
     furi_hal_random_fill_buf(&uid[1], 6);
+    uid[3] |= 0x01; // To avoid forbidden 0x88 value
     // I'm not sure how this is generated, but the upper nybble always seems to be 8
     uid[6] &= 0x0F;
     uid[6] |= 0x80;
@@ -322,6 +323,7 @@ static void nfc_generate_ntag_i2c_plus_2k(NfcDevice* nfc_device) {
 static void nfc_generate_mf_classic_uid(uint8_t* uid, uint8_t length) {
     uid[0] = NXP_MANUFACTURER_ID;
     furi_hal_random_fill_buf(&uid[1], length - 1);
+    uid[3] |= 0x01; // To avoid forbidden 0x88 value
 }
 
 static void


### PR DESCRIPTION
# What's new

- Change 4th uid byte setting rule as 0x88 value is forbidden for new uid cascade and breaks iso14443-3a poller

# Verification 

- NFC unit tests work all the time

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
