### PR TITLE
fix: build on windows gives datetime format error

### DIFF
--- a/scripts/version.py
+++ b/scripts/version.py
@@ -45,10 +45,16 @@ class GitVersion:
                 int(os.environ["SOURCE_DATE_EPOCH"])
             )
         else:
-            commit_date = datetime.strptime(
-                self._exec_git("log -1 --format=%cd").strip(),
-                "%a %b %d %H:%M:%S %Y %z",
-            )
+            if os.name == 'nt':
+                commit_date = datetime.strptime(
+                    self._exec_git("log -1 --format=%cd").strip(),
+                    "%a %b %d %H:%M:%S %Y",
+                )
+            else:
+                commit_date = datetime.strptime(
+                    self._exec_git("log -1 --format=%cd").strip(),
+                    "%a %b %d %H:%M:%S %Y %z",
+                )
 
         return {
             "GIT_COMMIT": commit,

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -45,7 +45,8 @@ class GitVersion:
                 int(os.environ["SOURCE_DATE_EPOCH"])
             )
         else:
-            if os.name == 'nt':
+            dateSettings = self._exec_git("config --get log.date").strip()
+            if dateSettings == "local":
                 commit_date = datetime.strptime(
                     self._exec_git("log -1 --format=%cd").strip(),
                     "%a %b %d %H:%M:%S %Y",
@@ -55,7 +56,6 @@ class GitVersion:
                     self._exec_git("log -1 --format=%cd").strip(),
                     "%a %b %d %H:%M:%S %Y %z",
                 )
-
         return {
             "GIT_COMMIT": commit,
             "GIT_BRANCH": branch,


### PR DESCRIPTION
# What's new

- Fixed build on Windows #3195
- Tested on Windows and Debian

# Verification 

- `git clone`
- run `./fbt`

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
