### PR TITLE
Various Fixes for 0.95

### DIFF
--- a/furi/core/timer.c
+++ b/furi/core/timer.c
@@ -122,17 +122,10 @@ FuriStatus furi_timer_stop(FuriTimer* instance) {
     furi_assert(instance);
 
     TimerHandle_t hTimer = (TimerHandle_t)instance;
-    FuriStatus stat;
 
-    if(xTimerIsTimerActive(hTimer) == pdFALSE) {
-        stat = FuriStatusErrorResource;
-    } else {
-        furi_check(xTimerStop(hTimer, portMAX_DELAY) == pdPASS);
-        stat = FuriStatusOk;
-    }
+    furi_check(xTimerStop(hTimer, portMAX_DELAY) == pdPASS);
 
-    /* Return execution status */
-    return (stat);
+    return FuriStatusOk;
 }
 
 uint32_t furi_timer_is_running(FuriTimer* instance) {

--- a/furi/core/timer.h
+++ b/furi/core/timer.h
@@ -33,6 +33,9 @@ void furi_timer_free(FuriTimer* instance);
 
 /** Start timer
  *
+ * @warning    This is asynchronous call, real operation will happen as soon as
+ *             timer service process this request.
+ *
  * @param      instance  The pointer to FuriTimer instance
  * @param[in]  ticks     The interval in ticks
  *
@@ -41,6 +44,9 @@ void furi_timer_free(FuriTimer* instance);
 FuriStatus furi_timer_start(FuriTimer* instance, uint32_t ticks);
 
 /** Restart timer with previous timeout value
+ *
+ * @warning    This is asynchronous call, real operation will happen as soon as
+ *             timer service process this request.
  *
  * @param      instance  The pointer to FuriTimer instance
  * @param[in]  ticks     The interval in ticks
@@ -51,6 +57,9 @@ FuriStatus furi_timer_restart(FuriTimer* instance, uint32_t ticks);
 
 /** Stop timer
  *
+ * @warning    This is asynchronous call, real operation will happen as soon as
+ *             timer service process this request.
+ *
  * @param      instance  The pointer to FuriTimer instance
  *
  * @return     The furi status.
@@ -58,6 +67,10 @@ FuriStatus furi_timer_restart(FuriTimer* instance, uint32_t ticks);
 FuriStatus furi_timer_stop(FuriTimer* instance);
 
 /** Is timer running
+ *
+ * @warning    This cal may and will return obsolete timer state if timer
+ *             commands are still in the queue. Please read FreeRTOS timer
+ *             documentation first.
  *
  * @param      instance  The pointer to FuriTimer instance
  *

--- a/targets/f7/furi_hal/furi_hal_flash.c
+++ b/targets/f7/furi_hal/furi_hal_flash.c
@@ -101,7 +101,7 @@ void furi_hal_flash_init() {
     // WRITE_REG(FLASH->SR, FLASH_SR_OPTVERR);
     /* Actually, reset all error flags on start */
     if(READ_BIT(FLASH->SR, FURI_HAL_FLASH_SR_ERRORS)) {
-        FURI_LOG_E(TAG, "FLASH->SR 0x%08lX", FLASH->SR);
+        FURI_LOG_W(TAG, "FLASH->SR 0x%08lX(Known ERRATA)", FLASH->SR);
         WRITE_REG(FLASH->SR, FURI_HAL_FLASH_SR_ERRORS);
     }
 }


### PR DESCRIPTION
# What's new

- FuriHal: retry gauge/charger initialization
- FuriHal: lower logging level for flash known errata
- FuriHal: graceful fail if subghz chip is not working
- Furi: issue stop command even if timer is not active, document timer behavior

# Verification 

- Full set of tests
- Ensure that are no more random power-off / input events appear

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
