### PR TITLE
FuriHal: various GPIO improvements

### DIFF
--- a/targets/f7/furi_hal/furi_hal_gpio.c
+++ b/targets/f7/furi_hal/furi_hal_gpio.c
@@ -5,6 +5,11 @@
 #include <stm32wbxx_ll_comp.h>
 #include <stm32wbxx_ll_pwr.h>
 
+static uint32_t furi_hal_gpio_invalid_argument_crash() {
+    furi_crash("Invalid argument");
+    return 0;
+}
+
 #define GPIO_PORT_MAP(port, prefix)    \
     (((port) == (GPIOA)) ? prefix##A : \
      ((port) == (GPIOB)) ? prefix##B : \
@@ -12,7 +17,7 @@
      ((port) == (GPIOD)) ? prefix##D : \
      ((port) == (GPIOE)) ? prefix##E : \
      ((port) == (GPIOH)) ? prefix##H : \
-                           *(uint32_t*)0x0)
+                           furi_hal_gpio_invalid_argument_crash())
 
 #define GPIO_PIN_MAP(pin, prefix)               \
     (((pin) == (LL_GPIO_PIN_0))  ? prefix##0 :  \
@@ -31,7 +36,7 @@
      ((pin) == (LL_GPIO_PIN_13)) ? prefix##13 : \
      ((pin) == (LL_GPIO_PIN_14)) ? prefix##14 : \
      ((pin) == (LL_GPIO_PIN_15)) ? prefix##15 : \
-                                   *(uint32_t*)0x0)
+                                   furi_hal_gpio_invalid_argument_crash())
 
 #define GET_SYSCFG_EXTI_PORT(port) GPIO_PORT_MAP(port, LL_SYSCFG_EXTI_PORT)
 #define GET_SYSCFG_EXTI_LINE(pin) GPIO_PIN_MAP(pin, LL_SYSCFG_EXTI_LINE)

--- a/targets/f7/furi_hal/furi_hal_gpio.c
+++ b/targets/f7/furi_hal/furi_hal_gpio.c
@@ -72,9 +72,11 @@ void furi_hal_gpio_init_ex(
     const GpioPull pull,
     const GpioSpeed speed,
     const GpioAltFn alt_fn) {
-    uint32_t sys_exti_port = GET_SYSCFG_EXTI_PORT(gpio->port);
-    uint32_t sys_exti_line = GET_SYSCFG_EXTI_LINE(gpio->pin);
-    uint32_t exti_line = GET_EXTI_LINE(gpio->pin);
+    const uint32_t sys_exti_port = GET_SYSCFG_EXTI_PORT(gpio->port);
+    const uint32_t sys_exti_line = GET_SYSCFG_EXTI_LINE(gpio->pin);
+    const uint32_t exti_line = GET_EXTI_LINE(gpio->pin);
+    const uint32_t pwr_port = GET_PWR_PORT(gpio->port);
+    const uint32_t pwr_pin = GET_PWR_PIN(gpio->pin);
 
     // Configure gpio with interrupts disabled
     FURI_CRITICAL_ENTER();
@@ -99,18 +101,18 @@ void furi_hal_gpio_init_ex(
     switch(pull) {
     case GpioPullNo:
         LL_GPIO_SetPinPull(gpio->port, gpio->pin, LL_GPIO_PULL_NO);
-        LL_PWR_DisableGPIOPullUp(GET_PWR_PORT(gpio->port), GET_PWR_PIN(gpio->pin));
-        LL_PWR_DisableGPIOPullDown(GET_PWR_PORT(gpio->port), GET_PWR_PIN(gpio->pin));
+        LL_PWR_DisableGPIOPullUp(pwr_port, pwr_pin);
+        LL_PWR_DisableGPIOPullDown(pwr_port, pwr_pin);
         break;
     case GpioPullUp:
         LL_GPIO_SetPinPull(gpio->port, gpio->pin, LL_GPIO_PULL_UP);
-        LL_PWR_DisableGPIOPullDown(GET_PWR_PORT(gpio->port), GET_PWR_PIN(gpio->pin));
-        LL_PWR_EnableGPIOPullUp(GET_PWR_PORT(gpio->port), GET_PWR_PIN(gpio->pin));
+        LL_PWR_DisableGPIOPullDown(pwr_port, pwr_pin);
+        LL_PWR_EnableGPIOPullUp(pwr_port, pwr_pin);
         break;
     case GpioPullDown:
         LL_GPIO_SetPinPull(gpio->port, gpio->pin, LL_GPIO_PULL_DOWN);
-        LL_PWR_DisableGPIOPullUp(GET_PWR_PORT(gpio->port), GET_PWR_PIN(gpio->pin));
-        LL_PWR_EnableGPIOPullDown(GET_PWR_PORT(gpio->port), GET_PWR_PIN(gpio->pin));
+        LL_PWR_DisableGPIOPullUp(pwr_port, pwr_pin);
+        LL_PWR_EnableGPIOPullDown(pwr_port, pwr_pin);
         break;
     default:
         furi_crash("Incorrect GpioPull");


### PR DESCRIPTION
# What's new

- FuriHal: add alternative gpio pulls that covers special cases, extra checks and crash on inalid parameters.

# Verification 

- GPIO analog mode now supports pull-up/pull-down
- Check everything that uses GPIO
- Full set of test

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
