### PR TITLE
[FL-3701] NFC fixes

### DIFF
--- a/applications/main/nfc/nfc_app.c
+++ b/applications/main/nfc/nfc_app.c
@@ -400,15 +400,16 @@ bool nfc_load_from_file_select(NfcApp* instance) {
     browser_options.base_path = NFC_APP_FOLDER;
     browser_options.hide_dot_files = true;
 
-    // Input events and views are managed by file_browser
-    bool result = dialog_file_browser_show(
-        instance->dialogs, instance->file_path, instance->file_path, &browser_options);
+    bool success = false;
+    do {
+        // Input events and views are managed by file_browser
+        if(!dialog_file_browser_show(
+               instance->dialogs, instance->file_path, instance->file_path, &browser_options))
+            break;
+        success = nfc_load_file(instance, instance->file_path, true);
+    } while(!success);
 
-    if(result) {
-        result = nfc_load_file(instance, instance->file_path, true);
-    }
-
-    return result;
+    return success;
 }
 
 void nfc_show_loading_popup(void* context, bool show) {

--- a/applications/main/nfc/plugins/supported_cards/aime.c
+++ b/applications/main/nfc/plugins/supported_cards/aime.c
@@ -120,10 +120,15 @@ static bool aime_parse(const NfcDevice* device, FuriString* parsed_data) {
             aime_accesscode[9]);
 
         // validate decimal hex representation
+        bool code_is_hex = true;
         for(int i = 0; i < 24; i++) {
             if(aime_accesscode_str[i] == ' ') continue;
-            if(aime_accesscode_str[i] < '0' || aime_accesscode_str[i] > '9') return false;
+            if(aime_accesscode_str[i] < '0' || aime_accesscode_str[i] > '9') {
+                code_is_hex = false;
+                break;
+            }
         }
+        if(!code_is_hex) break;
 
         // Note: Aime access code has some other self-check algorithms that are not public.
         // This parser does not try to verify the number.

--- a/applications/main/nfc/scenes/nfc_scene_detect.c
+++ b/applications/main/nfc/scenes/nfc_scene_detect.c
@@ -37,6 +37,7 @@ bool nfc_scene_detect_on_event(void* context, SceneManagerEvent event) {
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == NfcCustomEventWorkerExit) {
             if(instance->protocols_detected_num > 1) {
+                notification_message(instance->notifications, &sequence_single_vibro);
                 scene_manager_next_scene(instance->scene_manager, NfcSceneSelectProtocol);
             } else {
                 scene_manager_next_scene(instance->scene_manager, NfcSceneRead);

--- a/applications/main/nfc/scenes/nfc_scene_extra_actions.c
+++ b/applications/main/nfc/scenes/nfc_scene_extra_actions.c
@@ -45,11 +45,7 @@ bool nfc_scene_extra_actions_on_event(void* context, SceneManagerEvent event) {
 
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == SubmenuIndexMfClassicKeys) {
-            if(nfc_dict_check_presence(NFC_APP_MF_CLASSIC_DICT_USER_PATH)) {
-                scene_manager_next_scene(instance->scene_manager, NfcSceneMfClassicKeys);
-            } else {
-                scene_manager_previous_scene(instance->scene_manager);
-            }
+            scene_manager_next_scene(instance->scene_manager, NfcSceneMfClassicKeys);
             consumed = true;
         } else if(event.event == SubmenuIndexMfUltralightUnlock) {
             mf_ultralight_auth_reset(instance->mf_ul_auth);

--- a/applications/main/nfc/scenes/nfc_scene_mf_ultralight_unlock_warn.c
+++ b/applications/main/nfc/scenes/nfc_scene_mf_ultralight_unlock_warn.c
@@ -52,11 +52,12 @@ bool nfc_scene_mf_ultralight_unlock_warn_on_event(void* context, SceneManagerEve
 
     bool consumed = false;
 
-    nfc->protocols_detected[0] = nfc_device_get_protocol(nfc->nfc_device);
     MfUltralightAuthType type = nfc->mf_ul_auth->type;
     if((type == MfUltralightAuthTypeReader) || (type == MfUltralightAuthTypeManual)) {
         if(event.type == SceneManagerEventTypeCustom) {
             if(event.event == DialogExResultRight) {
+                const NfcProtocol mfu_protocol[] = {NfcProtocolMfUltralight};
+                nfc_app_set_detected_protocols(nfc, mfu_protocol, COUNT_OF(mfu_protocol));
                 scene_manager_next_scene(nfc->scene_manager, NfcSceneRead);
                 dolphin_deed(DolphinDeedNfcRead);
                 consumed = true;

--- a/applications/main/nfc/scenes/nfc_scene_select_protocol.c
+++ b/applications/main/nfc/scenes/nfc_scene_select_protocol.c
@@ -21,7 +21,6 @@ void nfc_scene_select_protocol_on_enter(void* context) {
     } else {
         prefix = "Read as";
         submenu_set_header(submenu, "Multi-protocol card");
-        notification_message(instance->notifications, &sequence_single_vibro);
     }
 
     for(uint32_t i = 0; i < instance->protocols_detected_num; i++) {

--- a/applications/main/nfc/views/dict_attack.c
+++ b/applications/main/nfc/views/dict_attack.c
@@ -125,7 +125,6 @@ void dict_attack_reset(DictAttack* instance) {
         instance->view,
         DictAttackViewModel * model,
         {
-            model->card_detected = false;
             model->sectors_total = 0;
             model->sectors_read = 0;
             model->current_sector = 0;

--- a/lib/nfc/protocols/iso14443_3b/iso14443_3b_poller_i.c
+++ b/lib/nfc/protocols/iso14443_3b/iso14443_3b_poller_i.c
@@ -134,7 +134,7 @@ Iso14443_3bError iso14443_3b_poller_activate(Iso14443_3bPoller* instance, Iso144
         if(bit_buffer_get_size_bytes(instance->rx_buffer) != 1) {
             FURI_LOG_W(
                 TAG,
-                "Unexpected ATTRIB response length: %d",
+                "Unexpected ATTRIB response length: %zu",
                 bit_buffer_get_size_bytes(instance->rx_buffer));
         }
 

--- a/lib/nfc/protocols/iso14443_3b/iso14443_3b_poller_i.c
+++ b/lib/nfc/protocols/iso14443_3b/iso14443_3b_poller_i.c
@@ -131,9 +131,18 @@ Iso14443_3bError iso14443_3b_poller_activate(Iso14443_3bPoller* instance, Iso144
             break;
         }
 
-        if(bit_buffer_get_size_bytes(instance->rx_buffer) != 1 ||
-           bit_buffer_get_byte(instance->rx_buffer, 0) != 0) {
-            FURI_LOG_D(TAG, "Unexpected ATTRIB response");
+        if(bit_buffer_get_size_bytes(instance->rx_buffer) != 1) {
+            FURI_LOG_W(
+                TAG,
+                "Unexpected ATTRIB response length: %d",
+                bit_buffer_get_size_bytes(instance->rx_buffer));
+        }
+
+        if(bit_buffer_get_byte(instance->rx_buffer, 0) != 0) {
+            FURI_LOG_D(
+                TAG,
+                "Incorrect CID in ATTRIB response: %02X",
+                bit_buffer_get_byte(instance->rx_buffer, 0));
             instance->state = Iso14443_3bPollerStateActivationFailed;
             ret = Iso14443_3bErrorCommunication;
             break;

--- a/lib/nfc/protocols/mf_classic/mf_classic_listener.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic_listener.c
@@ -482,6 +482,13 @@ static const MfClassicListenerCmd mf_classic_listener_cmd_handlers[] = {
         .handler = mf_classic_listener_halt_handlers,
     },
     {
+        // This crutch is necessary since some devices (like Pixel) send 15-bit "HALT" command ...
+        .cmd_start_byte = MF_CLASSIC_CMD_HALT_MSB,
+        .cmd_len_bits = 15,
+        .command_num = COUNT_OF(mf_classic_listener_halt_handlers),
+        .handler = mf_classic_listener_halt_handlers,
+    },
+    {
         .cmd_start_byte = MF_CLASSIC_CMD_AUTH_KEY_A,
         .cmd_len_bits = 2 * 8,
         .command_num = COUNT_OF(mf_classic_listener_auth_key_a_handlers),


### PR DESCRIPTION
# What's new

- Fix navigation after loading broken file
- Change Iso14443-3b poller activation logic
- Fix "Lost tag" view appearance after dict attack
- Fix Mf Ultralight crash after entering password manually from extra actions
- Fix Mf keys scene if there is no User dictionary
- Fix multiple protocol tag notification.
- Clean up aime parser

# Verification 

- All fixes work correctly

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
