### PR TITLE
[FL-3681] SubGhz: changed the name of the button when sending RAW to SubGhz

### DIFF
--- a/applications/main/subghz/views/subghz_read_raw.c
+++ b/applications/main/subghz/views/subghz_read_raw.c
@@ -329,7 +329,7 @@ void subghz_read_raw_draw(Canvas* canvas, SubGhzReadRAWModel* model) {
     case SubGhzReadRAWStatusLoadKeyTX:
     case SubGhzReadRAWStatusLoadKeyTXRepeat:
         graphics_mode = 0;
-        elements_button_center(canvas, "Send");
+        elements_button_center(canvas, "Hold to repeat");
         break;
 
     case SubGhzReadRAWStatusStart:


### PR DESCRIPTION
# What's new

-  [FL-3681] SubGhz: changed the name of the button when sending RAW to SubGhz

# Verification 

- Play the recorded Raw file, during file playback the name of the "Send" button should change to "Hold to repeat"
![image](https://github.com/flipperdevices/flipperzero-firmware/assets/85568270/9233d932-e7be-485d-898d-f430a94f2fb0)


# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-3681]: https://flipperzero.atlassian.net/browse/FL-3681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ