### PR TITLE
[FL-3706], [FL-3674] NFC NTAG and ISO14443-3b reading fix

### DIFF
--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.c
@@ -371,11 +371,14 @@ static NfcCommand mf_ultralight_poller_handler_read_counters(MfUltralightPoller*
 }
 
 static NfcCommand mf_ultralight_poller_handler_read_tearing_flags(MfUltralightPoller* instance) {
+    NfcCommand command = NfcCommandContinue;
+
     if(mf_ultralight_support_feature(
            instance->feature_set,
            MfUltralightFeatureSupportCheckTearingFlag | MfUltralightFeatureSupportSingleCounter)) {
         if(instance->tearing_flag_read == instance->tearing_flag_total) {
             instance->state = MfUltralightPollerStateTryDefaultPass;
+            command = NfcCommandReset;
         } else {
             bool single_counter = mf_ultralight_support_feature(
                 instance->feature_set, MfUltralightFeatureSupportSingleCounter);
@@ -391,6 +394,7 @@ static NfcCommand mf_ultralight_poller_handler_read_tearing_flags(MfUltralightPo
             } else if(instance->error != MfUltralightErrorNone) {
                 FURI_LOG_D(TAG, "Reading tearing flag %d failed", instance->tearing_flag_read);
                 instance->state = MfUltralightPollerStateTryDefaultPass;
+                command = NfcCommandReset;
             } else {
                 instance->tearing_flag_read++;
             }
@@ -398,9 +402,10 @@ static NfcCommand mf_ultralight_poller_handler_read_tearing_flags(MfUltralightPo
     } else {
         FURI_LOG_D(TAG, "Skip reading tearing flags");
         instance->state = MfUltralightPollerStateTryDefaultPass;
+        command = NfcCommandReset;
     }
 
-    return NfcCommandContinue;
+    return command;
 }
 
 static NfcCommand mf_ultralight_poller_handler_auth(MfUltralightPoller* instance) {


### PR DESCRIPTION
# What's new

- Fix reading NTAG cards with default password by resetting field after reading tearing flag
- Fix ISO14443-3b poller. Now poller checks only 7 bits CID in ATTRIB response since last bit is RFU

# Verification 

- Read NTAGs with default password, no locking configuration and unset AUTHLIM. Flipper should try default password and fully read tag
- Read Iso14443-3b tags which respond to ATTRIB command with MSB set in CID. Flipper should complete anticollision successfully.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
