### PR TITLE
Cleanup RTC registers on factory reset

### DIFF
--- a/applications/services/rpc/rpc_system.c
+++ b/applications/services/rpc/rpc_system.c
@@ -179,7 +179,8 @@ static void rpc_system_system_factory_reset_process(const PB_Main* request, void
     RpcSession* session = (RpcSession*)context;
     furi_assert(session);
 
-    furi_hal_rtc_set_flag(FuriHalRtcFlagFactoryReset);
+    furi_hal_rtc_reset_registers();
+    furi_hal_rtc_set_flag(FuriHalRtcFlagStorageFormatInternal);
     power_reboot(PowerBootModeNormal);
 
     (void)session;

--- a/applications/services/storage/storage_cli.c
+++ b/applications/services/storage/storage_cli.c
@@ -603,7 +603,8 @@ static void storage_cli_factory_reset(Cli* cli, FuriString* args, void* context)
     char c = cli_getc(cli);
     if(c == 'y' || c == 'Y') {
         printf("Data will be wiped after reboot.\r\n");
-        furi_hal_rtc_set_flag(FuriHalRtcFlagFactoryReset);
+        furi_hal_rtc_reset_registers();
+        furi_hal_rtc_set_flag(FuriHalRtcFlagStorageFormatInternal);
         power_reboot(PowerBootModeNormal);
     } else {
         printf("Safe choice.\r\n");

--- a/applications/services/storage/storages/storage_int.c
+++ b/applications/services/storage/storages/storage_int.c
@@ -189,7 +189,7 @@ static void storage_int_lfs_mount(LFSData* lfs_data, StorageData* storage) {
     lfs_t* lfs = &lfs_data->lfs;
 
     bool was_fingerprint_outdated = storage_int_check_and_set_fingerprint(lfs_data);
-    bool need_format = furi_hal_rtc_is_flag_set(FuriHalRtcFlagFactoryReset) ||
+    bool need_format = furi_hal_rtc_is_flag_set(FuriHalRtcFlagStorageFormatInternal) ||
                        was_fingerprint_outdated;
 
     if(need_format) {
@@ -197,7 +197,7 @@ static void storage_int_lfs_mount(LFSData* lfs_data, StorageData* storage) {
         err = lfs_format(lfs, &lfs_data->config);
         if(err == 0) {
             FURI_LOG_I(TAG, "Factory reset: Format successful, trying to mount");
-            furi_hal_rtc_reset_flag(FuriHalRtcFlagFactoryReset);
+            furi_hal_rtc_reset_flag(FuriHalRtcFlagStorageFormatInternal);
             err = lfs_mount(lfs, &lfs_data->config);
             if(err == 0) {
                 FURI_LOG_I(TAG, "Factory reset: Mounted");

--- a/applications/settings/storage_settings/scenes/storage_settings_scene_factory_reset.c
+++ b/applications/settings/storage_settings/scenes/storage_settings_scene_factory_reset.c
@@ -63,7 +63,8 @@ bool storage_settings_scene_factory_reset_on_event(void* context, SceneManagerEv
                 scene_manager_set_scene_state(
                     app->scene_manager, StorageSettingsFactoryReset, counter);
             } else {
-                furi_hal_rtc_set_flag(FuriHalRtcFlagFactoryReset);
+                furi_hal_rtc_reset_registers();
+                furi_hal_rtc_set_flag(FuriHalRtcFlagStorageFormatInternal);
                 power_reboot(PowerBootModeNormal);
             }
 

--- a/applications/system/updater/util/update_task_worker_flasher.c
+++ b/applications/system/updater/util/update_task_worker_flasher.c
@@ -343,7 +343,7 @@ int32_t update_task_worker_flash_writer(void* context) {
 
         furi_hal_rtc_set_boot_mode(FuriHalRtcBootModePostUpdate);
         // Format LFS before restoring backup on next boot
-        furi_hal_rtc_set_flag(FuriHalRtcFlagFactoryReset);
+        furi_hal_rtc_set_flag(FuriHalRtcFlagStorageFormatInternal);
 #ifdef FURI_NDEBUG
         // Production
         furi_hal_rtc_set_log_level(FuriLogLevelDefault);

--- a/targets/f18/api_symbols.csv
+++ b/targets/f18/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,49.1,,
+Version,+,49.2,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,
@@ -1247,6 +1247,7 @@ Function,-,furi_hal_rtc_init_early,void,
 Function,+,furi_hal_rtc_is_flag_set,_Bool,FuriHalRtcFlag
 Function,+,furi_hal_rtc_is_leap_year,_Bool,uint16_t
 Function,+,furi_hal_rtc_reset_flag,void,FuriHalRtcFlag
+Function,+,furi_hal_rtc_reset_registers,void,
 Function,+,furi_hal_rtc_set_boot_mode,void,FuriHalRtcBootMode
 Function,+,furi_hal_rtc_set_datetime,void,FuriHalRtcDateTime*
 Function,+,furi_hal_rtc_set_fault_data,void,uint32_t

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,49.1,,
+Version,+,49.2,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
@@ -1414,6 +1414,7 @@ Function,-,furi_hal_rtc_init_early,void,
 Function,+,furi_hal_rtc_is_flag_set,_Bool,FuriHalRtcFlag
 Function,+,furi_hal_rtc_is_leap_year,_Bool,uint16_t
 Function,+,furi_hal_rtc_reset_flag,void,FuriHalRtcFlag
+Function,+,furi_hal_rtc_reset_registers,void,
 Function,+,furi_hal_rtc_set_boot_mode,void,FuriHalRtcBootMode
 Function,+,furi_hal_rtc_set_datetime,void,FuriHalRtcDateTime*
 Function,+,furi_hal_rtc_set_fault_data,void,uint32_t
@@ -2289,8 +2290,8 @@ Function,+,mf_classic_is_value_block,_Bool,"MfClassicSectorTrailer*, uint8_t"
 Function,+,mf_classic_load,_Bool,"MfClassicData*, FlipperFormat*, uint32_t"
 Function,+,mf_classic_poller_auth,MfClassicError,"MfClassicPoller*, uint8_t, MfClassicKey*, MfClassicKeyType, MfClassicAuthContext*"
 Function,+,mf_classic_poller_auth_nested,MfClassicError,"MfClassicPoller*, uint8_t, MfClassicKey*, MfClassicKeyType, MfClassicAuthContext*"
-Function,+,mf_classic_poller_get_nt_nested,MfClassicError,"MfClassicPoller*, uint8_t, MfClassicKeyType, MfClassicNt*"
 Function,+,mf_classic_poller_get_nt,MfClassicError,"MfClassicPoller*, uint8_t, MfClassicKeyType, MfClassicNt*"
+Function,+,mf_classic_poller_get_nt_nested,MfClassicError,"MfClassicPoller*, uint8_t, MfClassicKeyType, MfClassicNt*"
 Function,+,mf_classic_poller_halt,MfClassicError,MfClassicPoller*
 Function,+,mf_classic_poller_read_block,MfClassicError,"MfClassicPoller*, uint8_t, MfClassicBlock*"
 Function,+,mf_classic_poller_sync_auth,MfClassicError,"Nfc*, uint8_t, MfClassicKey*, MfClassicKeyType, MfClassicAuthContext*"

--- a/targets/f7/furi_hal/furi_hal_rtc.c
+++ b/targets/f7/furi_hal/furi_hal_rtc.c
@@ -132,13 +132,7 @@ void furi_hal_rtc_init_early() {
     uint32_t data_reg = furi_hal_rtc_get_register(FuriHalRtcRegisterHeader);
     FuriHalRtcHeader* data = (FuriHalRtcHeader*)&data_reg;
     if(data->magic != FURI_HAL_RTC_HEADER_MAGIC || data->version != FURI_HAL_RTC_HEADER_VERSION) {
-        // Reset all our registers to ensure consistency
-        for(size_t i = 0; i < FuriHalRtcRegisterMAX; i++) {
-            furi_hal_rtc_set_register(i, 0);
-        }
-        data->magic = FURI_HAL_RTC_HEADER_MAGIC;
-        data->version = FURI_HAL_RTC_HEADER_VERSION;
-        furi_hal_rtc_set_register(FuriHalRtcRegisterHeader, data_reg);
+        furi_hal_rtc_reset_registers();
     }
 
     if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagDebug)) {
@@ -169,6 +163,18 @@ void furi_hal_rtc_sync_shadow() {
         while(!LL_RTC_IsActiveFlag_RS(RTC)) {
         };
     }
+}
+
+void furi_hal_rtc_reset_registers() {
+    for(size_t i = 0; i < RTC_BKP_NUMBER; i++) {
+        furi_hal_rtc_set_register(i, 0);
+    }
+
+    uint32_t data_reg = 0;
+    FuriHalRtcHeader* data = (FuriHalRtcHeader*)&data_reg;
+    data->magic = FURI_HAL_RTC_HEADER_MAGIC;
+    data->version = FURI_HAL_RTC_HEADER_VERSION;
+    furi_hal_rtc_set_register(FuriHalRtcRegisterHeader, data_reg);
 }
 
 uint32_t furi_hal_rtc_get_register(FuriHalRtcRegister reg) {

--- a/targets/f7/src/recovery.c
+++ b/targets/f7/src/recovery.c
@@ -56,8 +56,7 @@ void flipper_boot_recovery_exec() {
     }
 
     if(!counter) {
-        furi_hal_rtc_set_flag(FuriHalRtcFlagFactoryReset);
-        furi_hal_rtc_set_pin_fails(0);
-        furi_hal_rtc_reset_flag(FuriHalRtcFlagLock);
+        furi_hal_rtc_reset_registers();
+        furi_hal_rtc_set_flag(FuriHalRtcFlagStorageFormatInternal);
     }
 }

--- a/targets/furi_hal_include/furi_hal_rtc.h
+++ b/targets/furi_hal_include/furi_hal_rtc.h
@@ -26,7 +26,7 @@ typedef struct {
 
 typedef enum {
     FuriHalRtcFlagDebug = (1 << 0),
-    FuriHalRtcFlagFactoryReset = (1 << 1),
+    FuriHalRtcFlagStorageFormatInternal = (1 << 1),
     FuriHalRtcFlagLock = (1 << 2),
     FuriHalRtcFlagC2Update = (1 << 3),
     FuriHalRtcFlagHandOrient = (1 << 4),
@@ -90,6 +90,9 @@ void furi_hal_rtc_init();
 
 /** Force sync shadow registers */
 void furi_hal_rtc_sync_shadow();
+
+/** Reset ALL RTC registers content */
+void furi_hal_rtc_reset_registers();
 
 /** Get RTC register content
  *


### PR DESCRIPTION
# What's new

- FuriHal: RTC register reset API
- New factory reset routine that wipes all RTC backup registers content

# Verification 

- Check all factory reset variants

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
