### PR TITLE
[FL-3717] MFC emulation fix

### DIFF
--- a/applications/main/nfc/plugins/supported_cards/mykey.c
+++ b/applications/main/nfc/plugins/supported_cards/mykey.c
@@ -52,7 +52,7 @@ static bool mykey_parse(const NfcDevice* device, FuriString* parsed_data) {
     }
 
     bool is_blank = mykey_is_blank(data);
-    furi_string_cat_printf(parsed_data, "Serial#: %08lX\n", __bswap32(data->blocks[7]));
+    furi_string_cat_printf(parsed_data, "Serial#: %08X\n", __bswap32(data->blocks[7]));
     furi_string_cat_printf(parsed_data, "Blank: %s\n", is_blank ? "yes" : "no");
     furi_string_cat_printf(parsed_data, "LockID: %s\n", mykey_has_lockid(data) ? "maybe" : "no");
 
@@ -66,7 +66,7 @@ static bool mykey_parse(const NfcDevice* device, FuriString* parsed_data) {
 
     if(!is_blank) {
         furi_string_cat_printf(
-            parsed_data, "\nOp. count: %ld\n", __bswap32(data->blocks[0x12] & 0xFFFFFF00));
+            parsed_data, "\nOp. count: %zu\n", (size_t)__bswap32(data->blocks[0x12] & 0xFFFFFF00));
 
         uint32_t block3C = data->blocks[0x3C];
         if(block3C == 0xFFFFFFFF) {
@@ -75,7 +75,7 @@ static bool mykey_parse(const NfcDevice* device, FuriString* parsed_data) {
             block3C ^= data->blocks[0x07];
             uint32_t startingOffset = ((block3C & 0x30000000) >> 28) |
                                       ((block3C & 0x00100000) >> 18);
-            furi_check(startingOffset < 8);
+            furi_check(startingOffset < 8); //-V547
             for(int txnOffset = 8; txnOffset > 0; txnOffset--) {
                 uint32_t txnBlock =
                     __bswap32(data->blocks[0x34 + ((startingOffset + txnOffset) % 8)]);

--- a/applications/main/nfc/plugins/supported_cards/mykey.c
+++ b/applications/main/nfc/plugins/supported_cards/mykey.c
@@ -52,7 +52,7 @@ static bool mykey_parse(const NfcDevice* device, FuriString* parsed_data) {
     }
 
     bool is_blank = mykey_is_blank(data);
-    furi_string_cat_printf(parsed_data, "Serial#: %08X\n", __bswap32(data->blocks[7]));
+    furi_string_cat_printf(parsed_data, "Serial#: %08lX\n", (uint32_t)__bswap32(data->blocks[7]));
     furi_string_cat_printf(parsed_data, "Blank: %s\n", is_blank ? "yes" : "no");
     furi_string_cat_printf(parsed_data, "LockID: %s\n", mykey_has_lockid(data) ? "maybe" : "no");
 

--- a/lib/nfc/helpers/nfc_util.c
+++ b/lib/nfc/helpers/nfc_util.c
@@ -42,7 +42,7 @@ uint64_t nfc_util_bytes2num_little_endian(const uint8_t* src, uint8_t len) {
     uint64_t res = 0;
     uint8_t shift = 0;
     while(len--) {
-        res |= *src << (8 * shift++);
+        res |= ((uint64_t)*src) << (8 * shift++);
         src++;
     }
     return res;

--- a/lib/nfc/protocols/mf_classic/mf_classic_listener.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic_listener.c
@@ -40,10 +40,11 @@ static void mf_classic_listener_reset_state(MfClassicListener* instance) {
 
 static MfClassicListenerCommand
     mf_classic_listener_halt_handler(MfClassicListener* instance, BitBuffer* buff) {
+    UNUSED(instance);
+
     MfClassicListenerCommand command = MfClassicListenerCommandNack;
 
     if(bit_buffer_get_byte(buff, 1) == MF_CLASSIC_CMD_HALT_LSB) {
-        mf_classic_listener_reset_state(instance);
         command = MfClassicListenerCommandSleep;
     }
 
@@ -59,10 +60,7 @@ static MfClassicListenerCommand mf_classic_listener_auth_first_part_handler(
     do {
         instance->state = MfClassicListenerStateIdle;
 
-        if(block_num >= instance->total_block_num) {
-            mf_classic_listener_reset_state(instance);
-            break;
-        }
+        if(block_num >= instance->total_block_num) break;
 
         uint8_t sector_num = mf_classic_get_sector_by_block(block_num);
 
@@ -135,7 +133,7 @@ static MfClassicListenerCommand
         instance->cmd_in_progress = false;
 
         if(bit_buffer_get_size_bytes(buff) != (sizeof(MfClassicNr) + sizeof(MfClassicAr))) {
-            mf_classic_listener_reset_state(instance);
+            command = MfClassicListenerCommandSleep;
             break;
         }
         bit_buffer_write_bytes_mid(buff, instance->auth_context.nr.data, 0, sizeof(MfClassicNr));
@@ -157,7 +155,7 @@ static MfClassicListenerCommand
         if(secret_poller != prng_successor(nt_num, 64)) {
             FURI_LOG_T(
                 TAG, "Wrong reader key: %08lX != %08lX", secret_poller, prng_successor(nt_num, 64));
-            mf_classic_listener_reset_state(instance);
+            command = MfClassicListenerCommandSleep;
             break;
         }
 
@@ -610,9 +608,11 @@ NfcCommand mf_classic_listener_run(NfcGenericEvent event, void* context) {
             }
 
             mf_classic_listener_send_short_frame(instance, nack);
+            mf_classic_listener_reset_state(instance);
         } else if(mfc_command == MfClassicListenerCommandSilent) {
             command = NfcCommandReset;
         } else if(mfc_command == MfClassicListenerCommandSleep) {
+            mf_classic_listener_reset_state(instance);
             command = NfcCommandSleep;
         }
     } else if(iso3_event->type == Iso14443_3aListenerEventTypeHalted) {


### PR DESCRIPTION
# What's new

- Reset emulation state after NACK and before Sleep

# Verification 

- All phones can read emulation

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
