### PR TITLE
NFC: system dict skip when user dict is skipped fix

### DIFF
--- a/applications/main/nfc/scenes/nfc_scene_mf_classic_dict_attack.c
+++ b/applications/main/nfc/scenes/nfc_scene_mf_classic_dict_attack.c
@@ -173,6 +173,7 @@ void nfc_scene_mf_classic_dict_attack_on_enter(void* context) {
 
     instance->poller = nfc_poller_alloc(instance->nfc, NfcProtocolMfClassic);
     nfc_poller_start(instance->poller, nfc_dict_attack_worker_callback, instance);
+    instance->nfc_dict_context.is_card_present = true;
 }
 
 static void nfc_scene_mf_classic_dict_attack_notify_read(NfcApp* instance) {

--- a/applications/main/nfc/scenes/nfc_scene_mf_classic_dict_attack.c
+++ b/applications/main/nfc/scenes/nfc_scene_mf_classic_dict_attack.c
@@ -173,7 +173,6 @@ void nfc_scene_mf_classic_dict_attack_on_enter(void* context) {
 
     instance->poller = nfc_poller_alloc(instance->nfc, NfcProtocolMfClassic);
     nfc_poller_start(instance->poller, nfc_dict_attack_worker_callback, instance);
-    instance->nfc_dict_context.is_card_present = true;
 }
 
 static void nfc_scene_mf_classic_dict_attack_notify_read(NfcApp* instance) {

--- a/lib/nfc/protocols/mf_classic/mf_classic_poller.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller.c
@@ -22,6 +22,7 @@ MfClassicPoller* mf_classic_poller_alloc(Iso14443_3aPoller* iso14443_3a_poller) 
     instance->rx_plain_buffer = bit_buffer_alloc(MF_CLASSIC_MAX_BUFF_SIZE);
     instance->rx_encrypted_buffer = bit_buffer_alloc(MF_CLASSIC_MAX_BUFF_SIZE);
     instance->current_type_check = MfClassicType4k;
+    instance->card_state = MfClassicCardStateLost;
 
     instance->mfc_event.data = &instance->mfc_event_data;
 


### PR DESCRIPTION
# Issue
At the moment, when performing a dictionary attack on MF Classic, when you try to skip the user dictionary, the system dictionary is also skipped after it. This bug is not reproduced if you attach the card to the flipper after reading has started, or if you remove it and reapply it while reading with a user dictionary.

The bug is due to the fact that when an NfcCustomEventDictAttackSkip event occurs with the DictAttackStateUserDictInProgress state, instance->nfc_dict_context.is_card_present is false (see line 226 on nfc_scene_mf_classic_dict_attack.c)

##Issue verification:
- Create manually MF Classic 1k 4byte UID dump
- Write it to magic card
- Try to read it
- Skip user dict

System dict will also be skipped

# What's new

The issue described above is fixed

# Verification 

Same as issue verification. After user dict skipping, system dict attack must be started

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
