### PR TITLE
assets: checking limits on image size; ufbt: cdb target

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -369,7 +369,7 @@ vscode_dist = distenv.Install(
 )
 distenv.Precious(vscode_dist)
 distenv.NoClean(vscode_dist)
-distenv.Alias("vscode_dist", vscode_dist)
+distenv.Alias("vscode_dist", (vscode_dist, firmware_env["FW_CDB"]))
 
 # Configure shell with build tools
 distenv.PhonyTarget(

--- a/firmware.scons
+++ b/firmware.scons
@@ -249,7 +249,7 @@ fw_artifacts.extend(
 )
 
 
-fwcdb = fwenv.CompilationDatabase()
+fwcdb = fwenv["FW_CDB"] = fwenv.CompilationDatabase()
 # without filtering, both updater & firmware commands would be generated in same file
 fwenv.Replace(
     COMPILATIONDB_PATH_FILTER=fwenv.subst("*${FW_FLAVOR}*"),

--- a/scripts/assets.py
+++ b/scripts/assets.py
@@ -24,6 +24,9 @@ ICONS_TEMPLATE_C_FRAME = "const uint8_t {name}[] = {data};\n"
 ICONS_TEMPLATE_C_DATA = "const uint8_t* const {name}[] = {data};\n"
 ICONS_TEMPLATE_C_ICONS = "const Icon {name} = {{.width={width},.height={height},.frame_count={frame_count},.frame_rate={frame_rate},.frames=_{name}}};\n"
 
+MAX_IMAGE_WIDTH = 128
+MAX_IMAGE_HEIGHT = 64
+
 
 class Main(App):
     def init(self):
@@ -102,6 +105,10 @@ class Main(App):
 
     def _icon2header(self, file):
         image = file2image(file)
+        if image.width > MAX_IMAGE_WIDTH or image.height > MAX_IMAGE_HEIGHT:
+            raise Exception(
+                f"Image {file} is too big ({image.width}x{image.height} vs. {MAX_IMAGE_WIDTH}x{MAX_IMAGE_HEIGHT})"
+            )
         return image.width, image.height, image.data_as_carray()
 
     def _iconIsSupported(self, filename):

--- a/scripts/ufbt/SConstruct
+++ b/scripts/ufbt/SConstruct
@@ -275,15 +275,16 @@ Default(install_and_check)
 
 # Compilation database
 
-fwcdb = appenv.CompilationDatabase(
+app_cdb = appenv.CompilationDatabase(
     original_app_dir.Dir(".vscode").File("compile_commands.json")
 )
 
-AlwaysBuild(fwcdb)
-Precious(fwcdb)
-NoClean(fwcdb)
+AlwaysBuild(app_cdb)
+Precious(app_cdb)
+NoClean(app_cdb)
 if len(apps_artifacts):
-    Default(fwcdb)
+    Default(app_cdb)
+Alias("cdb", app_cdb)
 
 
 # launch handler
@@ -381,7 +382,7 @@ for config_file in project_template_dir.glob(".*"):
 
 dist_env.Precious(vscode_dist)
 dist_env.NoClean(vscode_dist)
-dist_env.Alias("vscode_dist", vscode_dist)
+dist_env.Alias("vscode_dist", (vscode_dist, app_cdb))
 
 
 # Creating app from base template

--- a/scripts/ufbt/site_tools/ufbt_help.py
+++ b/scripts/ufbt/site_tools/ufbt_help.py
@@ -18,6 +18,8 @@ Building:
         Build all FAP apps
     fap_{APPID}, launch APPSRC={APPID}:
         Build FAP app with appid={APPID}; upload & start it over USB
+    cdb:
+        regenerate "compile_commands.json" file (for IDE integration)
 
 Flashing & debugging:
     flash, *jflash:


### PR DESCRIPTION
# What's new

- scripts: assets: checking limits on image size
- fixes #3357 
- added "cdb" target to ufbt
- now also generated compilation database on "vscode_dist" ufbt & fbt targets

# Verification 

- put an image larger than 128x64 in assets or app's private images 
- build
- install SDK for ufbt; check `vscode_dist` and new `cdb` targets
- try `vscode_dist` on clean clone - should also create cdb.json

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
