### PR TITLE
NFC: Display unread Mifare Classic bytes as question marks

### DIFF
--- a/applications/main/nfc/helpers/protocol_support/mf_classic/mf_classic_render.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_classic/mf_classic_render.c
@@ -18,59 +18,48 @@ void nfc_render_mf_classic_info(
     furi_string_cat_printf(str, "\nSectors Read: %u/%u", sectors_read, sectors_total);
 }
 
+static void
+    mf_classic_render_raw_data(const uint8_t* data, size_t size, bool data_read, FuriString* str) {
+    furi_assert((size % 2) == 0);
+
+    for(size_t i = 0; i < size; i += 2) {
+        if(data_read) {
+            furi_string_cat_printf(str, "%02X%02X ", data[i], data[i + 1]);
+        } else {
+            furi_string_cat_printf(str, "???? ");
+        }
+    }
+}
+
+static void
+    mf_classic_render_block(const MfClassicData* data, uint8_t block_num, FuriString* str) {
+    if(mf_classic_is_sector_trailer(block_num)) {
+        uint8_t sec_num = mf_classic_get_sector_by_block(block_num);
+        MfClassicSectorTrailer* sec_tr = mf_classic_get_sector_trailer_by_sector(data, sec_num);
+
+        // Render key A
+        bool key_read = mf_classic_is_key_found(data, sec_num, MfClassicKeyTypeA);
+        mf_classic_render_raw_data(sec_tr->key_a.data, sizeof(MfClassicKey), key_read, str);
+
+        // Render access bits
+        bool access_bits_read = mf_classic_is_block_read(data, block_num);
+        mf_classic_render_raw_data(
+            sec_tr->access_bits.data, sizeof(MfClassicAccessBits), access_bits_read, str);
+
+        // Render key B
+        key_read = mf_classic_is_key_found(data, sec_num, MfClassicKeyTypeB);
+        mf_classic_render_raw_data(sec_tr->key_b.data, sizeof(MfClassicKey), key_read, str);
+    } else {
+        const uint8_t* block_data = data->block[block_num].data;
+        bool block_read = mf_classic_is_block_read(data, block_num);
+        mf_classic_render_raw_data(block_data, sizeof(MfClassicBlock), block_read, str);
+    }
+}
+
 void nfc_render_mf_classic_dump(const MfClassicData* data, FuriString* str) {
     uint16_t total_blocks = mf_classic_get_total_block_num(data->type);
 
     for(size_t i = 0; i < total_blocks; i++) {
-        const uint8_t* block_data = data->block[i].data;
-        if(mf_classic_is_block_read(data, i)) {
-            if(mf_classic_is_sector_trailer(i)) {
-                uint8_t sector = mf_classic_get_sector_by_block(i);
-                // Key A
-                if(mf_classic_is_key_found(data, sector, MfClassicKeyTypeA)) {
-                    furi_string_cat_printf(
-                        str,
-                        "%02X%02X %02X%02X %02X%02X ",
-                        block_data[0],
-                        block_data[1],
-                        block_data[2],
-                        block_data[3],
-                        block_data[4],
-                        block_data[5]);
-                } else {
-                    furi_string_cat(str, "???? ???? ???? ");
-                }
-                // Access bits
-                furi_string_cat_printf(
-                    str,
-                    "%02X%02X %02X%02X ",
-                    block_data[6],
-                    block_data[7],
-                    block_data[8],
-                    block_data[9]);
-                // Key B
-                if(mf_classic_is_key_found(data, sector, MfClassicKeyTypeB)) {
-                    furi_string_cat_printf(
-                        str,
-                        "%02X%02X %02X%02X %02X%02X ",
-                        block_data[10],
-                        block_data[11],
-                        block_data[12],
-                        block_data[13],
-                        block_data[14],
-                        block_data[15]);
-                } else {
-                    furi_string_cat(str, "???? ???? ???? ");
-                }
-            } else {
-                for(size_t j = 0; j < sizeof(MfClassicBlock); j += 2) {
-                    furi_string_cat_printf(str, "%02X%02X ", block_data[j], block_data[j + 1]);
-                }
-            }
-        } else {
-            for(size_t j = 0; j < sizeof(MfClassicBlock); j += 2) {
-                furi_string_cat(str, "???? ");
-            }
-        }
+        mf_classic_render_block(data, i, str);
     }
 }

--- a/applications/main/nfc/helpers/protocol_support/mf_classic/mf_classic_render.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_classic/mf_classic_render.c
@@ -22,9 +22,55 @@ void nfc_render_mf_classic_dump(const MfClassicData* data, FuriString* str) {
     uint16_t total_blocks = mf_classic_get_total_block_num(data->type);
 
     for(size_t i = 0; i < total_blocks; i++) {
-        for(size_t j = 0; j < sizeof(MfClassicBlock); j += 2) {
-            furi_string_cat_printf(
-                str, "%02X%02X ", data->block[i].data[j], data->block[i].data[j + 1]);
+        const uint8_t* block_data = data->block[i].data;
+        if(mf_classic_is_block_read(data, i)) {
+            if(mf_classic_is_sector_trailer(i)) {
+                uint8_t sector = mf_classic_get_sector_by_block(i);
+                // Key A
+                if(mf_classic_is_key_found(data, sector, MfClassicKeyTypeA)) {
+                    furi_string_cat_printf(
+                        str,
+                        "%02X%02X %02X%02X %02X%02X ",
+                        block_data[0],
+                        block_data[1],
+                        block_data[2],
+                        block_data[3],
+                        block_data[4],
+                        block_data[5]);
+                } else {
+                    furi_string_cat(str, "???? ???? ???? ");
+                }
+                // Access bits
+                furi_string_cat_printf(
+                    str,
+                    "%02X%02X %02X%02X ",
+                    block_data[6],
+                    block_data[7],
+                    block_data[8],
+                    block_data[9]);
+                // Key B
+                if(mf_classic_is_key_found(data, sector, MfClassicKeyTypeB)) {
+                    furi_string_cat_printf(
+                        str,
+                        "%02X%02X %02X%02X %02X%02X ",
+                        block_data[10],
+                        block_data[11],
+                        block_data[12],
+                        block_data[13],
+                        block_data[14],
+                        block_data[15]);
+                } else {
+                    furi_string_cat(str, "???? ???? ???? ");
+                }
+            } else {
+                for(size_t j = 0; j < sizeof(MfClassicBlock); j += 2) {
+                    furi_string_cat_printf(str, "%02X%02X ", block_data[j], block_data[j + 1]);
+                }
+            }
+        } else {
+            for(size_t j = 0; j < sizeof(MfClassicBlock); j += 2) {
+                furi_string_cat(str, "???? ");
+            }
         }
     }
 }


### PR DESCRIPTION
# What's new

- Before, the Mifare Classic data view displayed bytes that hadn't been read from the card as `00`, now they display as `??`

# Verification 

- Open Mifare Classic files in the NFC app that are missing different parts, such as a key, a single block, or an entire sector
- Verify that the bytes are correctly displayed as `??` and line up with the known bytes

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
