### PR TITLE
FBT/uFBT: Enable C++20/GNU23 in VSCode IntelliSense

### DIFF
--- a/.vscode/example/cpptools/c_cpp_properties.json
+++ b/.vscode/example/cpptools/c_cpp_properties.json
@@ -5,7 +5,6 @@
             "compilerPath": "${workspaceFolder}/toolchain/x86_64-windows/bin/arm-none-eabi-gcc.exe",
             "intelliSenseMode": "gcc-arm",
             "compileCommands": "${workspaceFolder}/build/latest/compile_commands.json",
-            "configurationProvider": "ms-vscode.cpptools",
             "cStandard": "gnu17",
             "cppStandard": "c++17"
         },
@@ -14,7 +13,6 @@
             "compilerPath": "${workspaceFolder}/toolchain/x86_64-linux/bin/arm-none-eabi-gcc",
             "intelliSenseMode": "gcc-arm",
             "compileCommands": "${workspaceFolder}/build/latest/compile_commands.json",
-            "configurationProvider": "ms-vscode.cpptools",
             "cStandard": "gnu17",
             "cppStandard": "c++17"
         },
@@ -23,7 +21,6 @@
             "compilerPath": "${workspaceFolder}/toolchain/x86_64-darwin/bin/arm-none-eabi-gcc",
             "intelliSenseMode": "gcc-arm",
             "compileCommands": "${workspaceFolder}/build/latest/compile_commands.json",
-            "configurationProvider": "ms-vscode.cpptools",
             "cStandard": "gnu17",
             "cppStandard": "c++17"
         }

--- a/.vscode/example/cpptools/c_cpp_properties.json
+++ b/.vscode/example/cpptools/c_cpp_properties.json
@@ -5,24 +5,24 @@
             "compilerPath": "${workspaceFolder}/toolchain/x86_64-windows/bin/arm-none-eabi-gcc.exe",
             "intelliSenseMode": "gcc-arm",
             "compileCommands": "${workspaceFolder}/build/latest/compile_commands.json",
-            "cStandard": "gnu17",
-            "cppStandard": "c++17"
+            "cStandard": "gnu23",
+            "cppStandard": "c++20"
         },
         {
             "name": "Linux",
             "compilerPath": "${workspaceFolder}/toolchain/x86_64-linux/bin/arm-none-eabi-gcc",
             "intelliSenseMode": "gcc-arm",
             "compileCommands": "${workspaceFolder}/build/latest/compile_commands.json",
-            "cStandard": "gnu17",
-            "cppStandard": "c++17"
+            "cStandard": "gnu23",
+            "cppStandard": "c++20"
         },
         {
             "name": "Mac",
             "compilerPath": "${workspaceFolder}/toolchain/x86_64-darwin/bin/arm-none-eabi-gcc",
             "intelliSenseMode": "gcc-arm",
             "compileCommands": "${workspaceFolder}/build/latest/compile_commands.json",
-            "cStandard": "gnu17",
-            "cppStandard": "c++17"
+            "cStandard": "gnu23",
+            "cppStandard": "c++20"
         }
     ],
     "version": 4

--- a/.vscode/example/settings.json
+++ b/.vscode/example/settings.json
@@ -1,6 +1,6 @@
 {
-    "C_Cpp.default.cStandard": "gnu17",
-    "C_Cpp.default.cppStandard": "c++17",
+    "C_Cpp.default.cStandard": "gnu23",
+    "C_Cpp.default.cppStandard": "c++20",
     "python.formatting.provider": "black",
     "workbench.tree.indent": 12,
     "cortex-debug.enableTelemetry": false,

--- a/scripts/ufbt/project_template/.vscode/c_cpp_properties.json
+++ b/scripts/ufbt/project_template/.vscode/c_cpp_properties.json
@@ -5,8 +5,8 @@
             "compilerPath": "@UFBT_TOOLCHAIN_GCC@",
             "intelliSenseMode": "gcc-arm",
             "compileCommands": "${workspaceFolder}/.vscode/compile_commands.json",
-            "cStandard": "gnu17",
-            "cppStandard": "c++17"
+            "cStandard": "gnu23",
+            "cppStandard": "c++20"
         }
     ],
     "version": 4

--- a/scripts/ufbt/project_template/.vscode/c_cpp_properties.json
+++ b/scripts/ufbt/project_template/.vscode/c_cpp_properties.json
@@ -5,7 +5,6 @@
             "compilerPath": "@UFBT_TOOLCHAIN_GCC@",
             "intelliSenseMode": "gcc-arm",
             "compileCommands": "${workspaceFolder}/.vscode/compile_commands.json",
-            "configurationProvider": "ms-vscode.cpptools",
             "cStandard": "gnu17",
             "cppStandard": "c++17"
         }


### PR DESCRIPTION
# What's new

This PR corrects two VSCode configuration issues:
1. `ms-vscode.cpptools` can't be a configuration provider to itself, so it has been removed. See also: https://github.com/microsoft/vscode-cpptools/issues/11889#issuecomment-1911159040
2. #3451 upgraded the codebase to C++20/GNU2x, but the VSCode templates remained at C++17/GNU17. This has been corrected. GNU2x is a deprecated alias for GNU23, but it's not supported yet by GCC in use, yet the VSCode extension requires it. Those should be aliases anyway so despite different naming, there should be no behaviour disparity.

**Original PR below:**

~~According to Microsoft, `"compilerPath"` overrides `compile_commands.json`, so just set it to be empty. Do note this is different to not setting `"compilerPath"` at all, as this will make VSCode fall back to the platform's default compiler, while an empty path will specifically tell it not to try to do anything.~~

~~For a detailed discussion on the VSCode extension, see this GitHub issue, especially the last few posts:
https://github.com/microsoft/vscode-cpptools/issues/11889~~

~~Notably:~~
> The current behavior of the compilerPath overriding the compiler in compile_commands.json **is expected and not a defect**.

# Verification 

~~1. Use `./fbt vscode_dist` or `ufbt vscode_dist`.
3. Observe that VSCode's IntelliSense now uses system defines specific to Cortex M4:
![image](https://github.com/flipperdevices/flipperzero-firmware/assets/7947461/789a82a8-98f4-4505-b47f-a10513b8cf42)~~

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
