### PR TITLE
Bluetooth: Add OpenHaystack implementation

### DIFF
--- a/applications/services/bt/bt_service/bt.h
+++ b/applications/services/bt/bt_service/bt.h
@@ -8,6 +8,7 @@ extern "C" {
 #endif
 
 #define RECORD_BT "bt"
+#define BT_LE_MAX_LENGTH 31
 
 typedef struct Bt Bt;
 

--- a/targets/f7/ble_glue/gap.c
+++ b/targets/f7/ble_glue/gap.c
@@ -5,7 +5,8 @@
 
 #include <furi_hal.h>
 #include <furi.h>
-#include <bt/bt_service/bt_i.h>
+#include <bt/bt_service/bt.h>
+#include <storage/storage.h>
 
 #define TAG "BtGap"
 

--- a/targets/f7/ble_glue/gap.h
+++ b/targets/f7/ble_glue/gap.h
@@ -39,7 +39,6 @@ typedef enum {
     GapStateStartingAdv,
     GapStateAdvFast,
     GapStateAdvLowPower,
-    GapStateAdvOHS, // Alias for low power adv, just used to enable OHS features
     GapStateConnected,
 } GapState;
 

--- a/targets/f7/ble_glue/gap.h
+++ b/targets/f7/ble_glue/gap.h
@@ -39,6 +39,7 @@ typedef enum {
     GapStateStartingAdv,
     GapStateAdvFast,
     GapStateAdvLowPower,
+    GapStateAdvOHS, // Alias for low power adv, just used to enable OHS features
     GapStateConnected,
 } GapState;
 
@@ -69,6 +70,7 @@ typedef struct {
     uint8_t mac_address[GAP_MAC_ADDR_SIZE];
     char adv_name[FURI_HAL_VERSION_DEVICE_NAME_LENGTH];
     GapConnectionParamsRequest conn_param;
+    bool disable_haystack;
 } GapConfig;
 
 bool gap_init(GapConfig* config, GapEventCallback on_event_cb, void* context);

--- a/targets/f7/furi_hal/furi_hal_bt.c
+++ b/targets/f7/furi_hal/furi_hal_bt.c
@@ -68,6 +68,7 @@ FuriHalBtProfileConfig profile_config[FuriHalBtProfileNumber] = {
                             .slave_latency = 0,
                             .supervisor_timeout = 0,
                         },
+                    .disable_haystack = false
                 },
         },
     [FuriHalBtProfileHidKeyboard] =
@@ -88,6 +89,7 @@ FuriHalBtProfileConfig profile_config[FuriHalBtProfileNumber] = {
                             .slave_latency = 0,
                             .supervisor_timeout = 0,
                         },
+                    .disable_haystack = true
                 },
         },
 };


### PR DESCRIPTION
# What's new

- Modify gap.c to add OpenHaystack-related defines, such as the key path and length
- Add the max BLE packet length to bt.h (Do I change that location and/or name?)
- Add an advertisement data template for OpenHaystack
- Add a bool for when the keyfile is detected, and therefor OpenHaystack gets enabled.
- Change the mac address to the first 6 key bytes, with a bitmask over the first. (Required by AirTags)
- Add a flag for disabling the OpenHaystack implementation for a profile, OpenHaystack for the HID profile for example is disabled.

# Verification

- A lot of people can't use OpenHaystack because of the expensive hardware surrounding it, but using [this project](https://github.com/dchristl/macless-haystack), you just need Docker and Python
- Clone the repo, run generate-keys.py from the repo with Python
- ./generate-keys.py -p haystack
- Find the out directory in the repo, copy the keyfile and the json file to a safe location
- Copy the haystack_keyfile to ext root
- Reboot the Flipper Zero, enable Bluetooth
- Follow the instructions on the repo as detailed [here](https://github.com/dchristl/macless-haystack?tab=readme-ov-file#set-up-endpointfetch-location-server)
- Import the JSON file into [here](https://dchristl.github.io/macless-haystack/)
- If reports do not appear after a refresh, see the last note below

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix

# Note
Current issue that I could use help finding a way around; You can't connect to the mobile app because the service UUID and the broadcasting name are not set while Haystack is on, and the mac address is not the same to stock. You *can* connect to the Flipper if you reenable service UUID in gap.c, connect to the mobile app, then disable services again. It will even reconnect even with the service disabled.

One more thing, until [this issue](https://github.com/biemster/FindMy/issues/40) gets resolved, iOS 17 devices will not report the "AirTag" frequently. It will see it, and give you the "someone is tracking you" notification, but I guess the Apple Servers don't like it? Either way, without a iOS <= 16 phone around, this is practically useless. Mostly posting this now so when the issue *is* fixed, all issues with this PR will be resolved and can be merged.
