### PR TITLE
Fix nfc_protocol_support_scene_save_name_on_event crash

### DIFF
--- a/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
+++ b/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
@@ -521,8 +521,7 @@ static bool
                     scene_manager_has_previous_scene(instance->scene_manager, NfcSceneSetType) ?
                         DolphinDeedNfcAddSave :
                         DolphinDeedNfcSave);
-                const NfcProtocol protocol =
-                    instance->protocols_detected[instance->protocols_detected_selected_idx];
+                const NfcProtocol protocol = nfc_device_get_protocol(instance->nfc_device);
                 consumed = nfc_protocol_support[protocol]->scene_save_name.on_event(
                     instance, event.event);
             } else {

--- a/applications/main/nfc/scenes/nfc_scene_start.c
+++ b/applications/main/nfc/scenes/nfc_scene_start.c
@@ -24,6 +24,9 @@ void nfc_scene_start_on_enter(void* context) {
     furi_string_reset(nfc->file_name);
     nfc_device_clear(nfc->nfc_device);
     iso14443_3a_reset(nfc->iso14443_3a_edit_data);
+    // Clear detected protocols list
+    memset(nfc->protocols_detected, NfcProtocolIso14443_3a, NfcProtocolNum);
+    nfc_app_reset_detected_protocols(nfc);
 
     submenu_add_item(submenu, "Read", SubmenuIndexRead, nfc_scene_start_submenu_callback, nfc);
     submenu_add_item(

--- a/applications/main/nfc/scenes/nfc_scene_start.c
+++ b/applications/main/nfc/scenes/nfc_scene_start.c
@@ -24,8 +24,7 @@ void nfc_scene_start_on_enter(void* context) {
     furi_string_reset(nfc->file_name);
     nfc_device_clear(nfc->nfc_device);
     iso14443_3a_reset(nfc->iso14443_3a_edit_data);
-    // Clear detected protocols list
-    memset(nfc->protocols_detected, NfcProtocolIso14443_3a, NfcProtocolNum);
+    // Reset detected protocols list
     nfc_app_reset_detected_protocols(nfc);
 
     submenu_add_item(submenu, "Read", SubmenuIndexRead, nfc_scene_start_submenu_callback, nfc);


### PR DESCRIPTION
# What's new

- Fixed crash with wrong (leftover from previous reading) `protocols_detected` list being used in `Add manually` Scene (in save_name -> on event call) after reading mifare classic tag and going to add manually with selecting other protocol

# Verification 

- Open NFC app
- Select Read -> Apply any mifare classic tag -> After read press back, Select Cancel
- Select Add manually -> NFC-A 4-bytes UID
- Don't enter any data or enter any data - doesnt matter. click save until it reaches file name
- Click save, oh, we are crashed
- Verify same steps with PR applied, all should work without any crashes

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
