### PR TITLE
Sending notification of a new release for f7

### DIFF
--- a/.github/actions/send_notifications/action.yml
+++ b/.github/actions/send_notifications/action.yml
@@ -1,0 +1,30 @@
+name: Send FCM notification
+author: lionzxy
+description: |
+  This action sends emails about the release of a new firmware version to FCM devices such as Android or iOS devices
+
+inputs:
+  google-credentials:
+    description: The Google Cloud Service Account Key JSON to use for authentication
+    required: true
+  firmware-version:
+    description: Firmware's version, e.g. 0.13.37
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Auth in Google Cloud
+      uses: 'google-github-actions/auth@v2'
+      id: google_auth
+      with:
+        credentials_json: '${{ inputs.google-credentials }}'
+        token_format: "access_token"
+        create_credentials_file: false
+    - name: Send push to FCM
+      shell: bash
+      run: |
+        curl -X POST -H "Authorization: Bearer ${{ steps.google_auth.outputs.access_token }}" \
+          -H "Content-Type: application/json" \
+          -d '{"message":{"notification":{"title":"Firmware Update Available","body":"New firmware version is ready to install: ${{ inputs.firmware-version }}"},"condition":"'flipper_update_firmware_release' in topics"}}' \
+          https://fcm.googleapis.com/v1/projects/flipper-zero-app/messages:send

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,5 +172,5 @@ jobs:
         if: ${{ steps.names.outputs.event_type == 'tag' && matrix.target == env.DEFAULT_TARGET && endsWith(github.ref,'-rc') != true }}
         uses: ./.github/actions/send_notifications
         with:
-          google-credentials: ${{ secrets.GOOGLE_CREDENTIALS }}
+          google-credentials: ${{ secrets.GOOGLE_CLOUD_NOTIFIER_CREDENTIALS }}
           firmware-version: ${{ steps.names.outputs.suffix }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,3 +168,9 @@ jobs:
           firmware-api: ${{ steps.build-fw.outputs.firmware_api }}
           firmware-target: ${{ matrix.target }}
           firmware-version: ${{ steps.names.outputs.suffix }}
+      - name: 'Send FCM notification about new release'
+        if: ${{ steps.names.outputs.event_type == 'tag' && matrix.target == env.DEFAULT_TARGET && endsWith(github.ref,'-rc') != true }}
+        uses: ./.github/actions/send_notifications
+        with:
+          google-credentials: ${{ secrets.GOOGLE_CREDENTIALS }}
+          firmware-version: ${{ steps.names.outputs.suffix }}


### PR DESCRIPTION
# What's new

- A new step in the `build.yml` workflow - if the action was triggered by adding a new tag and the version does not end in `-rc` (release), we send a push to Android and iOS devices subscribed to the update

Note: the `GOOGLE_CLOUD_NOTIFIER_CREDENTIALS` secret must be added before merge

# Verification 

- Made a test repository with a test environment

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
