### PR TITLE
NFC: fix crash on save manually added cards

### DIFF
--- a/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
+++ b/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
@@ -518,8 +518,7 @@ static bool
                         DolphinDeedNfcAddSave :
                         DolphinDeedNfcSave);
 
-                const NfcProtocol protocol =
-                    instance->protocols_detected[instance->protocols_detected_selected_idx];
+                const NfcProtocol protocol = nfc_device_get_protocol(instance->nfc_device);
                 consumed =
                     nfc_protocol_support[protocol]->scene_save_name.on_event(instance, event);
             } else {


### PR DESCRIPTION
# What's new

- Fix save manually added cards after reading MFC.

# Verification 

- No crash when saving manually added cards after reading MFC.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
