### PR TITLE
FIX ISO15693 emulation

### DIFF
--- a/lib/signal_reader/signal_reader.c
+++ b/lib/signal_reader/signal_reader.c
@@ -228,6 +228,7 @@ void signal_reader_start(SignalReader* instance, SignalReaderCallback callback, 
     /* We need the EXTI to be configured as interrupt generating line, but no ISR registered */
     furi_hal_gpio_init(
         instance->pin, GpioModeInterruptRiseFall, instance->pull, GpioSpeedVeryHigh);
+    furi_hal_gpio_enable_int_callback(instance->pin);
 
     /* Set DMAMUX request generation signal ID on specified DMAMUX channel */
     LL_DMAMUX_SetRequestSignalID(
@@ -308,6 +309,8 @@ void signal_reader_stop(SignalReader* instance) {
     furi_assert(instance);
 
     furi_hal_interrupt_set_isr(SIGNAL_READER_DMA_GPIO_IRQ, NULL, NULL);
+
+    furi_hal_gpio_disable_int_callback(instance->pin);
 
     // Deinit DMA Rx pin
     LL_DMA_DeInit(SIGNAL_READER_DMA_GPIO_DEF);

--- a/targets/f7/furi_hal/furi_hal_gpio.c
+++ b/targets/f7/furi_hal/furi_hal_gpio.c
@@ -215,11 +215,8 @@ void furi_hal_gpio_enable_int_callback(const GpioPin* gpio) {
 
     FURI_CRITICAL_ENTER();
 
-    uint8_t pin_num = furi_hal_gpio_get_pin_num(gpio);
-    if(gpio_interrupt[pin_num].callback) {
-        const uint32_t exti_line = GET_EXTI_LINE(gpio->pin);
-        LL_EXTI_EnableIT_0_31(exti_line);
-    }
+    const uint32_t exti_line = GET_EXTI_LINE(gpio->pin);
+    LL_EXTI_EnableIT_0_31(exti_line);
 
     FURI_CRITICAL_EXIT();
 }


### PR DESCRIPTION
# What's new

- Allow enabling exti interrupt without handler
- Explicitly enable and disable interrupt in iso15 signal reader

# Verification 

- Iso15693 and slix emulation work

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
