### PR TITLE
Archive: fixed Apps tab ext filter

### DIFF
--- a/applications/main/archive/helpers/archive_browser.h
+++ b/applications/main/archive/helpers/archive_browser.h
@@ -33,6 +33,7 @@ static const char* known_ext[] = {
     [ArchiveFileTypeUpdateManifest] = ".fuf",
     [ArchiveFileTypeFolder] = "?",
     [ArchiveFileTypeUnknown] = "*",
+    [ArchiveFileTypeAppOrJs] = ".fap|.js",
 };
 
 static const ArchiveFileTypeEnum known_type[] = {
@@ -44,7 +45,7 @@ static const ArchiveFileTypeEnum known_type[] = {
     [ArchiveTabInfrared] = ArchiveFileTypeInfrared,
     [ArchiveTabBadUsb] = ArchiveFileTypeBadUsb,
     [ArchiveTabU2f] = ArchiveFileTypeU2f,
-    [ArchiveTabApplications] = ArchiveFileTypeApplication,
+    [ArchiveTabApplications] = ArchiveFileTypeAppOrJs,
     [ArchiveTabBrowser] = ArchiveFileTypeUnknown,
 };
 

--- a/applications/main/archive/helpers/archive_files.h
+++ b/applications/main/archive/helpers/archive_files.h
@@ -19,6 +19,7 @@ typedef enum {
     ArchiveFileTypeJS,
     ArchiveFileTypeFolder,
     ArchiveFileTypeUnknown,
+    ArchiveFileTypeAppOrJs,
     ArchiveFileTypeLoading,
 } ArchiveFileTypeEnum;
 

--- a/applications/main/archive/views/archive_browser_view.c
+++ b/applications/main/archive/views/archive_browser_view.c
@@ -35,6 +35,7 @@ static const Icon* ArchiveItemIcons[] = {
     [ArchiveFileTypeLoading] = &I_loading_10px,
     [ArchiveFileTypeApplication] = &I_unknown_10px,
     [ArchiveFileTypeJS] = &I_js_script_10px,
+    [ArchiveFileTypeAppOrJs] = &I_unknown_10px,
 };
 
 void archive_browser_set_callback(


### PR DESCRIPTION
# What's new

- Fixed archive apps tab extension filter to show js files

# Verification 

- Try running apps and JS scripts from both Browser and Apps tabs of archive

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
