### PR TITLE
Quote $FBT_TOOLCHAIN_PATH to avoid splitting

### DIFF
--- a/scripts/toolchain/fbtenv.sh
+++ b/scripts/toolchain/fbtenv.sh
@@ -203,7 +203,7 @@ fbtenv_show_unpack_percentage()
 fbtenv_unpack_toolchain()
 {
     echo "Unpacking toolchain to '$FBT_TOOLCHAIN_PATH/toolchain':";
-    rm $FBT_TOOLCHAIN_PATH/toolchain/current || true;
+    rm "$FBT_TOOLCHAIN_PATH/toolchain/current" || true;
     tar -xvf "$FBT_TOOLCHAIN_PATH/toolchain/$TOOLCHAIN_TAR" -C "$FBT_TOOLCHAIN_PATH/toolchain" 2>&1 | fbtenv_show_unpack_percentage;
     mkdir -p "$FBT_TOOLCHAIN_PATH/toolchain" || return 1;
     mv "$FBT_TOOLCHAIN_PATH/toolchain/$TOOLCHAIN_DIR" "$TOOLCHAIN_ARCH_DIR" || return 1;


### PR DESCRIPTION
# What's new

- Usage of `$FBT_TOOLCHAIN_PATH` is wrapped in quotes to avoid splitting.

(This wasn't caught because shellcheck rule `SC2086` is disabled in this file)

# Reproduction

- From a directory with a space somewhere in the path, and where the toolchain is not already installed, run `fbt`.
- See a failed `rm` in the output, e.g.
  ```
  Unpacking toolchain to '/Users/shreve/Personal and Private/code/flipper/flipperzero-firmware/toolchain':
  rm: /Users/shreve/Personal: No such file or directory
  rm: and: No such file or directory
  rm: Private/code/flipper/flipperzero-firmware/toolchain/current: No such file or directory
  ```

# Verification 

- Repeat the reproduction steps
- See that there is no `rm`-related failure.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
