### PR TITLE
NFC: Fix washcity plugin verify function being to greedy

### DIFF
--- a/applications/main/nfc/plugins/supported_cards/washcity.c
+++ b/applications/main/nfc/plugins/supported_cards/washcity.c
@@ -57,37 +57,17 @@ static bool washcity_verify(Nfc* nfc) {
     bool verified = false;
 
     do {
-        MfClassicAuthContext auth_context;
+        const uint8_t verify_sector_number = 1;
+        const uint8_t verify_block_number =
+            mf_classic_get_first_block_num_of_sector(verify_sector_number);
+        FURI_LOG_D(TAG, "Verifying sector %u", verify_sector_number);
+
         MfClassicKey key = {0};
-        uint8_t verify_sector_number = 0;
-        uint8_t verify_block_number = 0;
-        MfClassicError error = MfClassicErrorNone;
-
-        // verify first key thats not a commonly used key
-        verify_sector_number = 1;
-        verify_block_number = mf_classic_get_first_block_num_of_sector(verify_sector_number) + 1;
-        FURI_LOG_D(TAG, "Verifying sector %u", verify_sector_number);
-
         bit_lib_num_to_bytes_be(
             washcity_1k_keys[verify_sector_number].a, COUNT_OF(key.data), key.data);
 
-        error = mf_classic_poller_sync_auth(
-            nfc, verify_block_number, &key, MfClassicKeyTypeA, &auth_context);
-        if(error != MfClassicErrorNone) {
-            FURI_LOG_D(TAG, "Failed to read block %u: %d", verify_block_number, error);
-            break;
-        }
-
-        // verify a second key to reduce chance of false-positive hit by chance dramatically
-        key = (MfClassicKey){0};
-        verify_sector_number = 9;
-        verify_block_number = mf_classic_get_first_block_num_of_sector(verify_sector_number) + 1;
-        FURI_LOG_D(TAG, "Verifying sector %u", verify_sector_number);
-
-        bit_lib_num_to_bytes_be(
-            washcity_1k_keys[verify_sector_number].a, COUNT_OF(key.data), key.data);
-
-        error = mf_classic_poller_sync_auth(
+        MfClassicAuthContext auth_context;
+        MfClassicError error = mf_classic_poller_sync_auth(
             nfc, verify_block_number, &key, MfClassicKeyTypeA, &auth_context);
         if(error != MfClassicErrorNone) {
             FURI_LOG_D(TAG, "Failed to read block %u: %d", verify_block_number, error);

--- a/applications/main/nfc/plugins/supported_cards/washcity.c
+++ b/applications/main/nfc/plugins/supported_cards/washcity.c
@@ -57,20 +57,40 @@ static bool washcity_verify(Nfc* nfc) {
     bool verified = false;
 
     do {
-        const uint8_t ticket_sector_number = 0;
-        const uint8_t ticket_block_number =
-            mf_classic_get_first_block_num_of_sector(ticket_sector_number) + 1;
-        FURI_LOG_D(TAG, "Verifying sector %u", ticket_sector_number);
-
-        MfClassicKey key = {0};
-        bit_lib_num_to_bytes_be(
-            washcity_1k_keys[ticket_sector_number].a, COUNT_OF(key.data), key.data);
-
         MfClassicAuthContext auth_context;
-        MfClassicError error = mf_classic_poller_sync_auth(
-            nfc, ticket_block_number, &key, MfClassicKeyTypeA, &auth_context);
+        MfClassicKey key = {0};
+        uint8_t verify_sector_number = 0;
+        uint8_t verify_block_number = 0;
+        MfClassicError error = MfClassicErrorNone;
+
+        // verify first key thats not a commonly used key
+        verify_sector_number = 1;
+        verify_block_number = mf_classic_get_first_block_num_of_sector(verify_sector_number) + 1;
+        FURI_LOG_D(TAG, "Verifying sector %u", verify_sector_number);
+
+        bit_lib_num_to_bytes_be(
+            washcity_1k_keys[verify_sector_number].a, COUNT_OF(key.data), key.data);
+
+        error = mf_classic_poller_sync_auth(
+            nfc, verify_block_number, &key, MfClassicKeyTypeA, &auth_context);
         if(error != MfClassicErrorNone) {
-            FURI_LOG_D(TAG, "Failed to read block %u: %d", ticket_block_number, error);
+            FURI_LOG_D(TAG, "Failed to read block %u: %d", verify_block_number, error);
+            break;
+        }
+
+        // verify a second key to reduce chance of false-positive hit by chance dramatically
+        key = (MfClassicKey){0};
+        verify_sector_number = 9;
+        verify_block_number = mf_classic_get_first_block_num_of_sector(verify_sector_number) + 1;
+        FURI_LOG_D(TAG, "Verifying sector %u", verify_sector_number);
+
+        bit_lib_num_to_bytes_be(
+            washcity_1k_keys[verify_sector_number].a, COUNT_OF(key.data), key.data);
+
+        error = mf_classic_poller_sync_auth(
+            nfc, verify_block_number, &key, MfClassicKeyTypeA, &auth_context);
+        if(error != MfClassicErrorNone) {
+            FURI_LOG_D(TAG, "Failed to read block %u: %d", verify_block_number, error);
             break;
         }
 


### PR DESCRIPTION
washcity plugin verify func only checks authing a single block with a single key. and that key being a very commonly used one. thus potentially breaking reading of alot MFC cards by dicts

**I have built this with `./fbt && ./fbt flash_usb_full` and verified it working**

fixes #3422 
obsoletes #3457 with proper code

# What's new

- use two blocks and keys for verification
- avoid using a commonly used key at all

# Verification 

- read a MFC with 0xA0A1A2A3A4A5 A-key for sector0 thats not a WashCity card: should now use user/system dict ✅

# Checklist (For Reviewer)

- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
