### PR TITLE
Archive: Fix item focus after aborting the Delete operation

### DIFF
--- a/applications/main/archive/scenes/archive_scene_browser.c
+++ b/applications/main/archive/scenes/archive_scene_browser.c
@@ -157,6 +157,7 @@ bool archive_scene_browser_on_event(void* context, SceneManagerEvent event) {
             break;
         case ArchiveBrowserEventFileMenuDelete:
             if(archive_get_tab(browser) != ArchiveTabFavorites) {
+                archive_show_file_menu(browser, false);
                 scene_manager_set_scene_state(
                     archive->scene_manager, ArchiveAppSceneBrowser, SCENE_STATE_NEED_REFRESH);
                 scene_manager_next_scene(archive->scene_manager, ArchiveAppSceneDelete);

--- a/applications/main/archive/scenes/archive_scene_delete.c
+++ b/applications/main/archive/scenes/archive_scene_delete.c
@@ -29,6 +29,12 @@ void archive_scene_delete_on_enter(void* context) {
     filename = furi_string_alloc();
 
     ArchiveFile_t* current = archive_get_current_file(app->browser);
+
+    FuriString* filename_no_ext = furi_string_alloc();
+    path_extract_filename(current->path, filename_no_ext, true);
+    strlcpy(app->text_store, furi_string_get_cstr(filename_no_ext), MAX_NAME_LEN);
+    furi_string_free(filename_no_ext);
+
     path_extract_filename(current->path, filename, false);
 
     char delete_str[64];


### PR DESCRIPTION
# What's new

This PR fixes a bug in the Browser where cancelling a Delete operation made the Browser focus on the first item on the list, with the Pin/Rename/Delete context menu still open. This PR fixes the focus issue, and hides the context menu when Delete is selected, so the behaviour is consistent with Rename where it was happening already.

# Verification 

1. Open Browser and navigate anywhere where there are multiple items on the screen. In my test, it was `apps`\Games.
2. Focus on any entry that is **not** the first.
3. Select the entry and choose `Delete`, then `Cancel`.
4. Observe that:
   * Without this PR, the context menu is still open, and the menu is focused on the top entry.
   * With this PR, the context menu is not open, and the menu is focused on the previously selected entry.

I have verified that deleting items does not break the flow and the menu remains usable (just focuses on the entry that used to be next to the deleted one).

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
