### PR TITLE
Gui: reset canvas orientation and frame when entering direct draw mode

### DIFF
--- a/applications/services/gui/gui.c
+++ b/applications/services/gui/gui.c
@@ -499,6 +499,8 @@ Canvas* gui_direct_draw_acquire(Gui* gui) {
     gui->direct_draw = true;
     gui_unlock(gui);
 
+    canvas_set_orientation(gui->canvas, CanvasOrientationHorizontal);
+    canvas_frame_set(gui->canvas, 0, 0, GUI_DISPLAY_WIDTH, GUI_DISPLAY_HEIGHT);
     canvas_reset(gui->canvas);
     canvas_commit(gui->canvas);
 


### PR DESCRIPTION
# What's new

- Gui: reset canvas orientation and frame when entering direct draw mode.

# Verification 

- Launch any app that uses direct draw

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
