### PR TITLE
GUI: Fix textbox overflow/crash/hang with 256+ lines

### DIFF
--- a/applications/services/gui/modules/text_box.c
+++ b/applications/services/gui/modules/text_box.c
@@ -100,7 +100,7 @@ static void text_box_insert_endline(Canvas* canvas, TextBoxModel* model) {
     line_num++;
     model->text = furi_string_get_cstr(model->text_formatted);
     model->text_pos = (char*)model->text;
-    uint8_t lines_on_screen = 56 / canvas_current_font_height(canvas);
+    size_t lines_on_screen = 56 / canvas_current_font_height(canvas);
     if(model->focus == TextBoxFocusEnd && line_num > lines_on_screen) {
         // Set text position to 5th line from the end
         const char* end = model->text + furi_string_size(model->text_formatted);

--- a/applications/services/gui/modules/text_box.c
+++ b/applications/services/gui/modules/text_box.c
@@ -100,18 +100,19 @@ static void text_box_insert_endline(Canvas* canvas, TextBoxModel* model) {
     line_num++;
     model->text = furi_string_get_cstr(model->text_formatted);
     model->text_pos = (char*)model->text;
-    if(model->focus == TextBoxFocusEnd && line_num > 5) {
+    uint8_t lines_on_screen = 56 / canvas_current_font_height(canvas);
+    if(model->focus == TextBoxFocusEnd && line_num > lines_on_screen) {
         // Set text position to 5th line from the end
         const char* end = model->text + furi_string_size(model->text_formatted);
-        for(size_t i = 0; i < line_num - 5; i++) {
+        for(size_t i = 0; i < line_num - lines_on_screen; i++) {
             while(model->text_pos < end) {
                 if(*model->text_pos++ == '\n') break;
             }
         }
-        model->scroll_num = line_num - 4;
-        model->scroll_pos = line_num - 5;
+        model->scroll_num = line_num - (lines_on_screen - 1);
+        model->scroll_pos = line_num - lines_on_screen;
     } else {
-        model->scroll_num = MAX(line_num - 4, 0u);
+        model->scroll_num = MAX(line_num - (lines_on_screen - 1), 0u);
         model->scroll_pos = 0;
     }
 }

--- a/applications/services/gui/modules/text_box.c
+++ b/applications/services/gui/modules/text_box.c
@@ -102,9 +102,11 @@ static void text_box_insert_endline(Canvas* canvas, TextBoxModel* model) {
     model->text_pos = (char*)model->text;
     if(model->focus == TextBoxFocusEnd && line_num > 5) {
         // Set text position to 5th line from the end
-        for(uint8_t i = 0; i < line_num - 5; i++) {
-            while(*model->text_pos++ != '\n') {
-            };
+        const char* end = model->text + furi_string_size(model->text_formatted);
+        for(size_t i = 0; i < line_num - 5; i++) {
+            while(model->text_pos < end) {
+                if(*model->text_pos++ == '\n') break;
+            }
         }
         model->scroll_num = line_num - 4;
         model->scroll_pos = line_num - 5;


### PR DESCRIPTION
# What's new

- While searching for focus at end of text, `i` is `uint8_t` while `line_num` is `size_t`
- This means that if `line_num - 5 > 255`, then the loop will continue endlessly, causing a `BusFault`
- This fixes the `uint8_t` to a `size_t`, as well as add an `end` check for the end of the text buffer
- Also in 6cbad6d3ff5ed2968909e46c66e47db6ba4fcee2, replaced the hardcoded `5` and `4` with calculations based on font height for how many lines are visible on screen (we have custom font support on Momentum, has been working great to support smaller font, we get up to 7 or 8 lines on screen, while default font remains 5 as before) (optional, feel free to revert that commit, just thought I'd throw it in)

# Verification 

- Set textbox focus to `TextBoxFocusEnd`
- Feed more than 260 (max uint8_t + 5 lines on screen) lines to textbox
- No BusFault crash
- No hang in draw loop

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
