### PR TITLE
infrared_transmit.h was missing `#pragma once`

### DIFF
--- a/lib/infrared/worker/infrared_transmit.h
+++ b/lib/infrared/worker/infrared_transmit.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <furi_hal_infrared.h>
 #include <infrared.h>
 #include <stdint.h>


### PR DESCRIPTION
Trivial improvement.

The `infrared_transmit.h` header file could cause errors of re-declarartion because it was missing `#pragma once`.