### PR TITLE
ufbt: fixes for generated vscode project

### DIFF
--- a/.vscode/example/settings.json
+++ b/.vscode/example/settings.json
@@ -14,7 +14,7 @@
         "*.scons": "python",
         "SConscript": "python",
         "SConstruct": "python",
-        "*.fam": "python",
+        "*.fam": "python"
     },
     "clangd.arguments": [
         // We might be able to tighten this a bit more to only include the correct toolchain.

--- a/scripts/ufbt/SConstruct
+++ b/scripts/ufbt/SConstruct
@@ -393,7 +393,9 @@ for template_file in project_template_dir.Dir(".vscode").glob("*"):
                 ),
                 "@UFBT_APP_DIR@": PosixPathWrapper.fix_path(original_app_dir.abspath),
                 "@UFBT_ROOT_DIR@": PosixPathWrapper.fix_path(Dir("#").abspath),
-                "@UFBT_DEBUG_DIR@": dist_env.subst("FBT_DEBUG_DIR"),
+                "@UFBT_DEBUG_DIR@": PosixPathWrapper.fix_path(
+                    dist_env.subst("$FBT_DEBUG_DIR")
+                ),
                 "@UFBT_DEBUG_ELF_DIR@": PosixPathWrapper.fix_path(
                     dist_env["FBT_FAP_DEBUG_ELF_ROOT"].abspath
                 ),

--- a/scripts/ufbt/project_template/.vscode/tasks.json
+++ b/scripts/ufbt/project_template/.vscode/tasks.json
@@ -31,22 +31,10 @@
             "command": "ufbt -c"
         },
         {
-            "label": "Flash FW (ST-Link)",
+            "label": "Flash FW (SWD)",
             "group": "build",
             "type": "shell",
             "command": "ufbt FORCE=1 flash"
-        },
-        {
-            "label": "Flash FW (blackmagic)",
-            "group": "build",
-            "type": "shell",
-            "command": "ufbt flash_blackmagic"
-        },
-        {
-            "label": "Flash FW (JLink)",
-            "group": "build",
-            "type": "shell",
-            "command": "ufbt FORCE=1 jflash"
         },
         {
             "label": "Flash FW (USB, with resources)",
@@ -55,13 +43,19 @@
             "command": "ufbt FORCE=1 flash_usb"
         },
         {
+            "label": "Open Flipper CLI session",
+            "group": "build",
+            "type": "shell",
+            "command": "ufbt cli"
+        },
+        {
             "label": "Update uFBT SDK",
             "group": "build",
             "type": "shell",
             "command": "ufbt update"
         },
         {
-            "label": "Update VSCode config for current SDK",
+            "label": "Update VSCode config",
             "group": "build",
             "type": "shell",
             "command": "ufbt vscode_dist"


### PR DESCRIPTION
# What's new

- ufbt: fixes for generated vscode project (invalid script dir path, outdated targets)

# Verification 

- `mkdir test && cd $_`
- `ufbt vscode_dist create APPID=test`
- `code .`
- run various build tasks

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
