### PR TITLE
[FL-3803] NFC: Fix mf desfire detect

### DIFF
--- a/lib/nfc/protocols/mf_desfire/mf_desfire_poller.c
+++ b/lib/nfc/protocols/mf_desfire/mf_desfire_poller.c
@@ -225,9 +225,17 @@ static bool mf_desfire_poller_detect(NfcGenericEvent event, void* context) {
     bool protocol_detected = false;
 
     if(iso14443_4a_event->type == Iso14443_4aPollerEventTypeReady) {
-        MfDesfireKeyVersion key_version = {0};
-        MfDesfireError error = mf_desfire_poller_read_key_version(instance, 0, &key_version);
-        protocol_detected = (error == MfDesfireErrorNone);
+        do {
+            MfDesfireKeyVersion key_version = 0;
+            MfDesfireError error = mf_desfire_poller_read_key_version(instance, 0, &key_version);
+            if(error != MfDesfireErrorNone) break;
+
+            MfDesfireVersion version = {};
+            error = mf_desfire_poller_read_version(instance, &version);
+            if(error != MfDesfireErrorNone) break;
+
+            protocol_detected = true;
+        } while(false);
     }
 
     return protocol_detected;


### PR DESCRIPTION
# What's new

- More strict mf desfire detect function

# Verification 

- Emv cards are not detected as desfire

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
