### PR TITLE
IR: Remember OTG state

### DIFF
--- a/applications/main/infrared/infrared_app.c
+++ b/applications/main/infrared/infrared_app.c
@@ -13,11 +13,12 @@
 #define INFRARED_TASK_STACK_SIZE (2048UL)
 
 #define INFRARED_SETTINGS_PATH INT_PATH(".infrared.settings")
-#define INFRARED_SETTINGS_VERSION (0)
+#define INFRARED_SETTINGS_VERSION (1)
 #define INFRARED_SETTINGS_MAGIC (0x1F)
 
 typedef struct {
-    uint8_t tx_pin;
+    FuriHalInfraredTxPin tx_pin;
+    bool otg_enabled;
 } InfraredSettings;
 
 static const NotificationSequence*
@@ -488,11 +489,15 @@ static void infrared_load_settings(InfraredApp* infrared) {
     }
 
     infrared_set_tx_pin(infrared, settings.tx_pin);
+    if(settings.tx_pin < FuriHalInfraredTxPinMax) {
+        infrared_enable_otg(infrared, settings.otg_enabled);
+    }
 }
 
 void infrared_save_settings(InfraredApp* infrared) {
     InfraredSettings settings = {
         .tx_pin = infrared->app_state.tx_pin,
+        .otg_enabled = infrared->app_state.is_otg_enabled,
     };
 
     if(!saved_struct_save(


### PR DESCRIPTION
# What's new

- Infrared will remember OTG/5V on/off
- It's weird that output pin is remembered but not otg, then the user could configure ext pin with 5v on, close and reopen, now its on gpio but no 5v, so there is no output at all, not from ext and not from int

# Verification 

- Set infrared output to pa7 and gpio 5v on
- Close and reopen app
- 5v enabled again, module works as expected

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
