### PR TITLE
Hide unlock with reader for MFU-C

### DIFF
--- a/applications/main/nfc/scenes/nfc_scene_mf_ultralight_unlock_menu.c
+++ b/applications/main/nfc/scenes/nfc_scene_mf_ultralight_unlock_menu.c
@@ -20,12 +20,17 @@ void nfc_scene_mf_ultralight_unlock_menu_on_enter(void* context) {
     uint32_t state =
         scene_manager_get_scene_state(nfc->scene_manager, NfcSceneMfUltralightUnlockMenu);
     if(nfc_device_get_protocol(nfc->nfc_device) == NfcProtocolMfUltralight) {
-        submenu_add_item(
-            submenu,
-            "Unlock With Reader",
-            SubmenuIndexMfUlUnlockMenuReader,
-            nfc_scene_mf_ultralight_unlock_menu_submenu_callback,
-            nfc);
+        const MfUltralightData* mfu_data =
+            nfc_device_get_data(nfc->nfc_device, NfcProtocolMfUltralight);
+        // Hide for MFU-C since it uses 3DES
+        if(mfu_data->type != MfUltralightTypeMfulC) {
+            submenu_add_item(
+                submenu,
+                "Unlock With Reader",
+                SubmenuIndexMfUlUnlockMenuReader,
+                nfc_scene_mf_ultralight_unlock_menu_submenu_callback,
+                nfc);
+        }
     }
     submenu_add_item(
         submenu,


### PR DESCRIPTION
# What's new

- Hide the "unlock with reader" for MFU-C, which use 3des and not a 32bit password (https://en.wikipedia.org/wiki/MIFARE#MIFARE_Ultralight_family)

# Verification 

- Read MFU-C: confirm "Unlock with Reader" is hidden
- Read MFU EV1, NTAG21x, etc: confirm "Unlock with Reader" is shown

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
