### PR TITLE
Bad USB: fix crash when selecting a keyboard layout

### DIFF
--- a/applications/main/bad_usb/scenes/bad_usb_scene_config_layout.c
+++ b/applications/main/bad_usb/scenes/bad_usb_scene_config_layout.c
@@ -31,7 +31,6 @@ void bad_usb_scene_config_layout_on_enter(void* context) {
     BadUsbApp* bad_usb = context;
 
     if(bad_usb_layout_select(bad_usb)) {
-        bad_usb_script_set_keyboard_layout(bad_usb->bad_usb_script, bad_usb->keyboard_layout);
         scene_manager_search_and_switch_to_previous_scene(bad_usb->scene_manager, BadUsbSceneWork);
     } else {
         scene_manager_previous_scene(bad_usb->scene_manager);


### PR DESCRIPTION
# What's new

Commit 6de2934 (BadUSB: BLE, media keys, Fn/Globe key commands (#3403), 2024-03-25) changed the life-cycle of the bad_usb_script object, so that the bad_usb_script is allocated when entering the work scene, and freed when going to the config scene. It also made it so that the keyboard layout always gets reloaded when entering the work scene.

The logic of the layout config scene, however, assumes that it still needs to reload the keyboard layout after selecting it. The keyboard layout data is stored within bad_usb_script however, which is NULL when within the layout config scene.

The fix is simple. Since we are now reload the keyboard layout anyway when entering the work scene, we can just remove this extra call.

Resolves: #3552

# Verification 

1. Select Bad USB from the main menu
2. Select any script
3. Press left to go to Config
4. Select "Keyboard Layout (global)"
5. Select any keyboard layout
6. Observe that it doesn't crash
7. Run the script
8. Observe that the selected keyboard layout is used

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
