### PR TITLE
fix: Fix use bitwise AND instead of logical AND for logical operations

### DIFF
--- a/lib/fatfs/ff.c
+++ b/lib/fatfs/ff.c
@@ -3048,7 +3048,7 @@ FRESULT find_volume (	/* FR_OK(0): successful, !=0: any error occurred */
 	/* Find an FAT partition on the drive. Supports only generic partitioning rules, FDISK and SFD. */
 	bsect = 0;
 	fmt = check_fs(fs, bsect);			/* Load sector 0 and check if it is an FAT-VBR as SFD */
-	if (fmt == 2 || (fmt < 2 && LD2PT(vol) != 0)) {	/* Not an FAT-VBR or forced partition number */
+	if (fmt == 2 || (fmt < 2 & LD2PT(vol) != 0)) {	/* Not an FAT-VBR or forced partition number */
 		for (i = 0; i < 4; i++) {		/* Get partition offset */
 			pt = fs->win + (MBR_Table + i * SZ_PTE);
 			br[i] = pt[PTE_System] ? ld_dword(pt + PTE_StLba) : 0;


### PR DESCRIPTION
# What's new

I fixed to use bitwise AND instead of logical AND for logical operations `int lib/fatfs/ff.c` file

# Verification 

This current code, could got an errors with those flags: `-std=c2x -Wconstant-logical-operand -Werror` (on clang 16.0.0)
```
<source>:5:34: error: use of logical '&&' with constant operand [-Werror,-Wconstant-logical-operand]
    if ((fmt == 2) || ((fmt < 2) && (LD2PT(vol) != 0))) {       /* Not an FAT-VBR or forced partition number */
                                 ^  ~~~~~~~~~~~~~~~~~
<source>:5:34: note: use '&' for a bitwise operation
    if ((fmt == 2) || ((fmt < 2) && (LD2PT(vol) != 0))) {       /* Not an FAT-VBR or forced partition number */
                                 ^~
                                 &
<source>:5:34: note: remove constant to silence this warning
    if ((fmt == 2) || ((fmt < 2) && (LD2PT(vol) != 0))) {       /* Not an FAT-VBR or forced partition number */
                                ~^~~~~~~~~~~~~~~~~~~~
1 error generated.
Compiler returned: 1
```

After patch, there are no compile errors.

Quick godbolt sample:
https://godbolt.org/z/8M3W6ThKv 

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
