### PR TITLE
fbt: fixed missing FBT_FAP_DEBUG_ELF_ROOT to dist env

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -230,6 +230,7 @@ firmware_debug = distenv.PhonyTarget(
     source=firmware_env["FW_ELF"],
     GDBOPTS="${GDBOPTS_BASE}",
     GDBREMOTE="${OPENOCD_GDB_PIPE}",
+    FBT_FAP_DEBUG_ELF_ROOT=firmware_env["FBT_FAP_DEBUG_ELF_ROOT"],
 )
 distenv.Depends(firmware_debug, firmware_flash)
 
@@ -239,6 +240,7 @@ distenv.PhonyTarget(
     source=firmware_env["FW_ELF"],
     GDBOPTS="${GDBOPTS_BASE} ${GDBOPTS_BLACKMAGIC}",
     GDBREMOTE="${BLACKMAGIC_ADDR}",
+    FBT_FAP_DEBUG_ELF_ROOT=firmware_env["FBT_FAP_DEBUG_ELF_ROOT"],
 )
 
 # Debug alien elf


### PR DESCRIPTION
# What's new

- fbt: fixed missing FBT_FAP_DEBUG_ELF_ROOT forward to dist env (introduced in #3360)

# Verification 

- Try debugging any .fap using CLI - should work now

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
