### PR TITLE
IR: Fix crash on duty_cycle=1

### DIFF
--- a/lib/infrared/worker/infrared_worker.c
+++ b/lib/infrared/worker/infrared_worker.c
@@ -612,7 +612,7 @@ void infrared_worker_set_raw_signal(
     furi_check(timings);
     furi_check(timings_cnt > 0);
     furi_check((frequency <= INFRARED_MAX_FREQUENCY) && (frequency >= INFRARED_MIN_FREQUENCY));
-    furi_check((duty_cycle < 1.0f) && (duty_cycle > 0.0f));
+    furi_check((duty_cycle <= 1.0f) && (duty_cycle > 0.0f));
 
     size_t max_copy_num = COUNT_OF(instance->signal.raw.timings) - 1;
     furi_check(timings_cnt <= max_copy_num);

--- a/targets/f7/furi_hal/furi_hal_infrared.c
+++ b/targets/f7/furi_hal/furi_hal_infrared.c
@@ -357,7 +357,7 @@ static void furi_hal_infrared_configure_tim_pwm_tx(uint32_t freq, float duty_cyc
     if(infrared_tx_output == FuriHalInfraredTxPinInternal) {
         LL_TIM_OC_SetCompareCH3(
             INFRARED_DMA_TIMER,
-            ((LL_TIM_GetAutoReload(INFRARED_DMA_TIMER) + 1) * (1 - duty_cycle)));
+            ((LL_TIM_GetAutoReload(INFRARED_DMA_TIMER) + 1) * (1.0f - duty_cycle)));
         LL_TIM_OC_EnablePreload(INFRARED_DMA_TIMER, LL_TIM_CHANNEL_CH3);
         /* LL_TIM_OCMODE_PWM2 set by DMA */
         LL_TIM_OC_SetMode(INFRARED_DMA_TIMER, LL_TIM_CHANNEL_CH3, LL_TIM_OCMODE_FORCED_INACTIVE);
@@ -368,7 +368,7 @@ static void furi_hal_infrared_configure_tim_pwm_tx(uint32_t freq, float duty_cyc
     } else if(infrared_tx_output == FuriHalInfraredTxPinExtPA7) {
         LL_TIM_OC_SetCompareCH1(
             INFRARED_DMA_TIMER,
-            ((LL_TIM_GetAutoReload(INFRARED_DMA_TIMER) + 1) * (1 - duty_cycle)));
+            ((LL_TIM_GetAutoReload(INFRARED_DMA_TIMER) + 1) * (1.0f - duty_cycle)));
         LL_TIM_OC_EnablePreload(INFRARED_DMA_TIMER, LL_TIM_CHANNEL_CH1);
         /* LL_TIM_OCMODE_PWM2 set by DMA */
         LL_TIM_OC_SetMode(INFRARED_DMA_TIMER, LL_TIM_CHANNEL_CH1, LL_TIM_OCMODE_FORCED_INACTIVE);
@@ -609,7 +609,7 @@ static void furi_hal_infrared_async_tx_free_resources(void) {
 }
 
 void furi_hal_infrared_async_tx_start(uint32_t freq, float duty_cycle) {
-    if((duty_cycle > 1) || (duty_cycle <= 0) || (freq > INFRARED_MAX_FREQUENCY) ||
+    if((duty_cycle > 1.0f) || (duty_cycle <= 0.0f) || (freq > INFRARED_MAX_FREQUENCY) ||
        (freq < INFRARED_MIN_FREQUENCY) || (infrared_tim_tx.data_callback == NULL)) {
         furi_crash();
     }


### PR DESCRIPTION
# What's new

- `infrared_signal_is_raw_valid()` says that `duty_cycle > 1` is invalid
- `infrared_worker_set_raw_signal()` checks `duty_cycle < 1`
- therefore, `duty_cycle == 1` fails the check, when really it should be accepted

# Verification 

- send an infrared raw with `duty_cycle: 1`

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
