### PR TITLE
[FL-3765][FL-3737] Desktop: ensure that animation is unloaded before app start

### DIFF
--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -122,7 +122,9 @@ static bool desktop_custom_event_callback(void* context, uint32_t event) {
 
     switch(event) {
     case DesktopGlobalBeforeAppStarted:
-        animation_manager_unload_and_stall_animation(desktop->animation_manager);
+        if(animation_manager_is_animation_loaded(desktop->animation_manager)) {
+            animation_manager_unload_and_stall_animation(desktop->animation_manager);
+        }
         desktop_auto_lock_inhibit(desktop);
         furi_semaphore_release(desktop->animation_semaphore);
         return true;

--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -34,10 +34,12 @@ static void desktop_loader_callback(const void* message, void* context) {
 
     if(event->type == LoaderEventTypeApplicationStarted) {
         view_dispatcher_send_custom_event(desktop->view_dispatcher, DesktopGlobalBeforeAppStarted);
+        furi_check(furi_semaphore_acquire(desktop->animation_semaphore, 3000) == FuriStatusOk);
     } else if(event->type == LoaderEventTypeApplicationStopped) {
         view_dispatcher_send_custom_event(desktop->view_dispatcher, DesktopGlobalAfterAppFinished);
     }
 }
+
 static void desktop_lock_icon_draw_callback(Canvas* canvas, void* context) {
     UNUSED(context);
     furi_assert(canvas);
@@ -122,6 +124,7 @@ static bool desktop_custom_event_callback(void* context, uint32_t event) {
     case DesktopGlobalBeforeAppStarted:
         animation_manager_unload_and_stall_animation(desktop->animation_manager);
         desktop_auto_lock_inhibit(desktop);
+        furi_semaphore_release(desktop->animation_semaphore);
         return true;
     case DesktopGlobalAfterAppFinished:
         animation_manager_load_and_continue_animation(desktop->animation_manager);
@@ -270,6 +273,7 @@ void desktop_set_stealth_mode_state(Desktop* desktop, bool enabled) {
 Desktop* desktop_alloc(void) {
     Desktop* desktop = malloc(sizeof(Desktop));
 
+    desktop->animation_semaphore = furi_semaphore_alloc(1, 0);
     desktop->animation_manager = animation_manager_alloc();
     desktop->gui = furi_record_open(RECORD_GUI);
     desktop->scene_thread = furi_thread_alloc();

--- a/applications/services/desktop/desktop_i.h
+++ b/applications/services/desktop/desktop_i.h
@@ -80,6 +80,8 @@ struct Desktop {
     bool time_format_12 : 1; // 1 - 12 hour, 0 - 24H
 
     bool in_transition : 1;
+
+    FuriSemaphore* animation_semaphore;
 };
 
 Desktop* desktop_alloc(void);


### PR DESCRIPTION
# What's new

- Animation fully unloaded before app starts.
- Animation is unloaded only if it was loaded before.

# Verification 

- Check that the log line `[I][AnimationManager] Unloading animation 'xxx'` occurs before any application log lines.
- Build fw with `LOADER_AUTOSTART` flag that pointed to some app, check that the firmware does not crash.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
