### PR TITLE
Furi: Add "out of memory" and "malloc(0)" crash messages

### DIFF
--- a/furi/core/memmgr_heap.c
+++ b/furi/core/memmgr_heap.c
@@ -486,7 +486,7 @@ void* pvPortMalloc(size_t xWantedSize) {
 
     configASSERT((((size_t)pvReturn) & (size_t)portBYTE_ALIGNMENT_MASK) == 0);
 
-    furi_check(pvReturn);
+    furi_check(pvReturn, xWantedSize ? "out of memory" : "malloc(0)");
     pvReturn = memset(pvReturn, 0, to_wipe);
     return pvReturn;
 }


### PR DESCRIPTION
# What's new

- Clear crash messages for "out of memory" and "malloc(0)"
- Allows for easier debugging of what went wrong

# Verification 

- Crash by out of memory or malloc(0), see new messages

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
