### PR TITLE
GUI: Fix array out of bounds in menu exit

### DIFF
--- a/applications/services/gui/modules/menu.c
+++ b/applications/services/gui/modules/menu.c
@@ -121,9 +121,11 @@ static void menu_exit(void* context) {
         menu->view,
         MenuModel * model,
         {
-            MenuItem* item = MenuItemArray_get(model->items, model->position);
-            if(item && item->icon) {
-                icon_animation_stop(item->icon);
+            if(model->position < MenuItemArray_size(model->items)) {
+                MenuItem* item = MenuItemArray_get(model->items, model->position);
+                if(item->icon) {
+                    icon_animation_stop(item->icon);
+                }
             }
         },
         false);

--- a/applications/services/gui/modules/menu.c
+++ b/applications/services/gui/modules/menu.c
@@ -44,25 +44,19 @@ static void menu_draw_callback(Canvas* canvas, void* _model) {
         canvas_set_font(canvas, FontSecondary);
         shift_position = (0 + position + items_count - 1) % items_count;
         item = MenuItemArray_get(model->items, shift_position);
-        if(item->icon) {
-            canvas_draw_icon_animation(canvas, 4, 3, item->icon);
-        }
+        canvas_draw_icon_animation(canvas, 4, 3, item->icon);
         canvas_draw_str(canvas, 22, 14, item->label);
         // Second line main
         canvas_set_font(canvas, FontPrimary);
         shift_position = (1 + position + items_count - 1) % items_count;
         item = MenuItemArray_get(model->items, shift_position);
-        if(item->icon) {
-            canvas_draw_icon_animation(canvas, 4, 25, item->icon);
-        }
+        canvas_draw_icon_animation(canvas, 4, 25, item->icon);
         canvas_draw_str(canvas, 22, 36, item->label);
         // Third line
         canvas_set_font(canvas, FontSecondary);
         shift_position = (2 + position + items_count - 1) % items_count;
         item = MenuItemArray_get(model->items, shift_position);
-        if(item->icon) {
-            canvas_draw_icon_animation(canvas, 4, 47, item->icon);
-        }
+        canvas_draw_icon_animation(canvas, 4, 47, item->icon);
         canvas_draw_str(canvas, 22, 58, item->label);
         // Frame and scrollbar
         elements_frame(canvas, 0, 21, 128 - 5, 21);
@@ -109,9 +103,7 @@ static void menu_enter(void* context) {
         {
             if(MenuItemArray_size(model->items)) {
                 MenuItem* item = MenuItemArray_get(model->items, model->position);
-                if(item->icon) {
-                    icon_animation_start(item->icon);
-                }
+                icon_animation_start(item->icon);
             }
         },
         false);
@@ -125,9 +117,7 @@ static void menu_exit(void* context) {
         {
             if(MenuItemArray_size(model->items)) {
                 MenuItem* item = MenuItemArray_get(model->items, model->position);
-                if(item->icon) {
-                    icon_animation_stop(item->icon);
-                }
+                icon_animation_stop(item->icon);
             }
         },
         false);
@@ -236,9 +226,7 @@ static void menu_process_up(Menu* menu) {
         {
             if(MenuItemArray_size(model->items)) {
                 MenuItem* item = MenuItemArray_get(model->items, model->position);
-                if(item->icon) {
-                    icon_animation_stop(item->icon);
-                }
+                icon_animation_stop(item->icon);
 
                 if(model->position > 0) {
                     model->position--;
@@ -247,9 +235,7 @@ static void menu_process_up(Menu* menu) {
                 }
 
                 item = MenuItemArray_get(model->items, model->position);
-                if(item->icon) {
-                    icon_animation_start(item->icon);
-                }
+                icon_animation_start(item->icon);
             }
         },
         true);
@@ -262,9 +248,7 @@ static void menu_process_down(Menu* menu) {
         {
             if(MenuItemArray_size(model->items)) {
                 MenuItem* item = MenuItemArray_get(model->items, model->position);
-                if(item->icon) {
-                    icon_animation_stop(item->icon);
-                }
+                icon_animation_stop(item->icon);
 
                 if(model->position < MenuItemArray_size(model->items) - 1) {
                     model->position++;
@@ -273,9 +257,7 @@ static void menu_process_down(Menu* menu) {
                 }
 
                 item = MenuItemArray_get(model->items, model->position);
-                if(item->icon) {
-                    icon_animation_start(item->icon);
-                }
+                icon_animation_start(item->icon);
             }
         },
         true);

--- a/applications/services/gui/modules/menu.c
+++ b/applications/services/gui/modules/menu.c
@@ -107,9 +107,11 @@ static void menu_enter(void* context) {
         menu->view,
         MenuModel * model,
         {
-            MenuItem* item = MenuItemArray_get(model->items, model->position);
-            if(item && item->icon) {
-                icon_animation_start(item->icon);
+            if(MenuItemArray_size(model->items)) {
+                MenuItem* item = MenuItemArray_get(model->items, model->position);
+                if(item->icon) {
+                    icon_animation_start(item->icon);
+                }
             }
         },
         false);
@@ -121,7 +123,7 @@ static void menu_exit(void* context) {
         menu->view,
         MenuModel * model,
         {
-            if(model->position < MenuItemArray_size(model->items)) {
+            if(MenuItemArray_size(model->items)) {
                 MenuItem* item = MenuItemArray_get(model->items, model->position);
                 if(item->icon) {
                     icon_animation_stop(item->icon);
@@ -232,20 +234,22 @@ static void menu_process_up(Menu* menu) {
         menu->view,
         MenuModel * model,
         {
-            MenuItem* item = MenuItemArray_get(model->items, model->position);
-            if(item && item->icon) {
-                icon_animation_stop(item->icon);
-            }
+            if(MenuItemArray_size(model->items)) {
+                MenuItem* item = MenuItemArray_get(model->items, model->position);
+                if(item->icon) {
+                    icon_animation_stop(item->icon);
+                }
 
-            if(model->position > 0) {
-                model->position--;
-            } else {
-                model->position = MenuItemArray_size(model->items) - 1;
-            }
+                if(model->position > 0) {
+                    model->position--;
+                } else {
+                    model->position = MenuItemArray_size(model->items) - 1;
+                }
 
-            item = MenuItemArray_get(model->items, model->position);
-            if(item && item->icon) {
-                icon_animation_start(item->icon);
+                item = MenuItemArray_get(model->items, model->position);
+                if(item->icon) {
+                    icon_animation_start(item->icon);
+                }
             }
         },
         true);
@@ -256,20 +260,22 @@ static void menu_process_down(Menu* menu) {
         menu->view,
         MenuModel * model,
         {
-            MenuItem* item = MenuItemArray_get(model->items, model->position);
-            if(item && item->icon) {
-                icon_animation_stop(item->icon);
-            }
+            if(MenuItemArray_size(model->items)) {
+                MenuItem* item = MenuItemArray_get(model->items, model->position);
+                if(item->icon) {
+                    icon_animation_stop(item->icon);
+                }
 
-            if(model->position < MenuItemArray_size(model->items) - 1) {
-                model->position++;
-            } else {
-                model->position = 0;
-            }
+                if(model->position < MenuItemArray_size(model->items) - 1) {
+                    model->position++;
+                } else {
+                    model->position = 0;
+                }
 
-            item = MenuItemArray_get(model->items, model->position);
-            if(item && item->icon) {
-                icon_animation_start(item->icon);
+                item = MenuItemArray_get(model->items, model->position);
+                if(item->icon) {
+                    icon_animation_start(item->icon);
+                }
             }
         },
         true);
@@ -281,12 +287,12 @@ static void menu_process_ok(Menu* menu) {
         menu->view,
         MenuModel * model,
         {
-            if(model->position < MenuItemArray_size(model->items)) {
+            if(MenuItemArray_size(model->items)) {
                 item = MenuItemArray_get(model->items, model->position);
             }
         },
         true);
-    if(item && item->callback) {
+    if(item->callback) {
         item->callback(item->callback_context, item->index);
     }
 }

--- a/applications/services/gui/modules/menu.c
+++ b/applications/services/gui/modules/menu.c
@@ -292,7 +292,7 @@ static void menu_process_ok(Menu* menu) {
             }
         },
         true);
-    if(item->callback) {
+    if(item && item->callback) {
         item->callback(item->callback_context, item->index);
     }
 }


### PR DESCRIPTION
# What's new

- Fix edge case crash with menu view exit
- CC @skotopes 

# Verification 

- menu_reset() before exiting menu view will not crash

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
