### PR TITLE
[FL-3817] iButton: fix crash when deleting some keys

### DIFF
--- a/lib/ibutton/protocols/dallas/protocol_ds1971.c
+++ b/lib/ibutton/protocols/dallas/protocol_ds1971.c
@@ -218,19 +218,15 @@ void dallas_ds1971_render_uid(FuriString* result, const iButtonProtocolData* pro
 
 void dallas_ds1971_render_data(FuriString* result, const iButtonProtocolData* protocol_data) {
     const DS1971ProtocolData* data = protocol_data;
-    FuriString* data_string = furi_string_alloc();
+
+    furi_string_cat_printf(result, "\e#Memory Data\n--------------------\n");
 
     pretty_format_bytes_hex_canonical(
-        data_string,
+        result,
         DS1971_DATA_BYTE_COUNT,
         PRETTY_FORMAT_FONT_MONOSPACE,
         data->eeprom_data,
         DS1971_EEPROM_DATA_SIZE);
-
-    furi_string_cat_printf(result, "\e#Memory Data\n--------------------\n");
-    furi_string_cat_printf(result, "%s", furi_string_get_cstr(data_string));
-
-    furi_string_free(data_string);
 }
 
 void dallas_ds1971_render_brief_data(FuriString* result, const iButtonProtocolData* protocol_data) {

--- a/lib/ibutton/protocols/dallas/protocol_ds1992.c
+++ b/lib/ibutton/protocols/dallas/protocol_ds1992.c
@@ -191,19 +191,15 @@ void dallas_ds1992_render_uid(FuriString* result, const iButtonProtocolData* pro
 
 void dallas_ds1992_render_data(FuriString* result, const iButtonProtocolData* protocol_data) {
     const DS1992ProtocolData* data = protocol_data;
-    FuriString* data_string = furi_string_alloc();
+
+    furi_string_cat_printf(result, "\e#Memory Data\n--------------------\n");
 
     pretty_format_bytes_hex_canonical(
-        data_string,
+        result,
         DS1992_DATA_BYTE_COUNT,
         PRETTY_FORMAT_FONT_MONOSPACE,
         data->sram_data,
         DS1992_SRAM_DATA_SIZE);
-
-    furi_string_cat_printf(result, "\e#Memory Data\n--------------------\n");
-    furi_string_cat_printf(result, "%s", furi_string_get_cstr(data_string));
-
-    furi_string_free(data_string);
 }
 
 void dallas_ds1992_render_brief_data(FuriString* result, const iButtonProtocolData* protocol_data) {

--- a/lib/ibutton/protocols/dallas/protocol_ds1996.c
+++ b/lib/ibutton/protocols/dallas/protocol_ds1996.c
@@ -217,19 +217,14 @@ void dallas_ds1996_render_uid(FuriString* result, const iButtonProtocolData* pro
 void dallas_ds1996_render_data(FuriString* result, const iButtonProtocolData* protocol_data) {
     const DS1996ProtocolData* data = protocol_data;
 
-    FuriString* data_string = furi_string_alloc();
+    furi_string_cat_printf(result, "\e#Memory Data\n--------------------\n");
 
     pretty_format_bytes_hex_canonical(
-        data_string,
+        result,
         DS1996_DATA_BYTE_COUNT,
         PRETTY_FORMAT_FONT_MONOSPACE,
         data->sram_data,
         DS1996_SRAM_DATA_SIZE);
-
-    furi_string_cat_printf(result, "\e#Memory Data\n--------------------\n");
-    furi_string_cat_printf(result, "%s", furi_string_get_cstr(data_string));
-
-    furi_string_free(data_string);
 }
 
 void dallas_ds1996_render_brief_data(FuriString* result, const iButtonProtocolData* protocol_data) {

--- a/lib/ibutton/protocols/misc/protocol_cyfral.c
+++ b/lib/ibutton/protocols/misc/protocol_cyfral.c
@@ -325,7 +325,7 @@ static LevelDuration protocol_cyfral_encoder_yield(ProtocolCyfral* proto) {
     return result;
 }
 
-static void protocol_cyfral_render_uid(FuriString* result, ProtocolCyfral* proto) {
+static void protocol_cyfral_render_uid(ProtocolCyfral* proto, FuriString* result) {
     furi_string_cat_printf(result, "ID: ");
     for(size_t i = 0; i < CYFRAL_DATA_SIZE; ++i) {
         furi_string_cat_printf(result, "%02X ", ((uint8_t*)&proto->data)[i]);
@@ -333,10 +333,7 @@ static void protocol_cyfral_render_uid(FuriString* result, ProtocolCyfral* proto
 }
 
 static void protocol_cyfral_render_brief_data(ProtocolCyfral* proto, FuriString* result) {
-    furi_string_cat_printf(result, "ID: ");
-    for(size_t i = 0; i < CYFRAL_DATA_SIZE; ++i) {
-        furi_string_cat_printf(result, "%02X ", ((uint8_t*)&proto->data)[i]);
-    }
+    protocol_cyfral_render_uid(proto, result);
 }
 
 const ProtocolBase ibutton_protocol_misc_cyfral = {

--- a/lib/ibutton/protocols/misc/protocol_group_misc.c
+++ b/lib/ibutton/protocols/misc/protocol_group_misc.c
@@ -200,6 +200,16 @@ static bool ibutton_protocol_group_misc_load(
     }
 }
 
+static void ibutton_protocol_group_misc_render_uid(
+    iButtonProtocolGroupMisc* group,
+    const iButtonProtocolData* data,
+    iButtonProtocolLocalId id,
+    FuriString* result) {
+    const size_t data_size = protocol_dict_get_data_size(group->dict, id);
+    protocol_dict_set_data(group->dict, id, data, data_size);
+    protocol_dict_render_uid(group->dict, result, id);
+}
+
 static void ibutton_protocol_group_misc_render_data(
     iButtonProtocolGroupMisc* group,
     const iButtonProtocolData* data,
@@ -283,6 +293,7 @@ const iButtonProtocolGroupBase ibutton_protocol_group_misc = {
     .save = (iButtonProtocolGroupSaveFunc)ibutton_protocol_group_misc_save,
     .load = (iButtonProtocolGroupLoadFunc)ibutton_protocol_group_misc_load,
 
+    .render_uid = (iButtonProtocolGroupRenderFunc)ibutton_protocol_group_misc_render_uid,
     .render_data = (iButtonProtocolGroupRenderFunc)ibutton_protocol_group_misc_render_data,
     .render_brief_data =
         (iButtonProtocolGroupRenderFunc)ibutton_protocol_group_misc_render_brief_data,

--- a/lib/toolbox/pretty_format.c
+++ b/lib/toolbox/pretty_format.c
@@ -28,8 +28,7 @@ void pretty_format_bytes_hex_canonical(
     const size_t line_length = (line_prefix ? strlen(line_prefix) : 0) + 4 * num_places + 2;
 
     /* Reserve memory in adance in order to avoid unnecessary reallocs */
-    furi_string_reset(result);
-    furi_string_reserve(result, line_count * line_length);
+    furi_string_reserve(result, furi_string_size(result) + line_count * line_length);
 
     for(size_t i = 0; i < data_size; i += num_places) {
         if(line_prefix) {

--- a/lib/toolbox/protocols/protocol_dict.c
+++ b/lib/toolbox/protocols/protocol_dict.c
@@ -198,6 +198,15 @@ LevelDuration protocol_dict_encoder_yield(ProtocolDict* dict, size_t protocol_in
     }
 }
 
+void protocol_dict_render_uid(ProtocolDict* dict, FuriString* result, size_t protocol_index) {
+    furi_check(protocol_index < dict->count);
+    ProtocolRenderData fn = dict->base[protocol_index]->render_uid;
+
+    if(fn) {
+        return fn(dict->data[protocol_index], result);
+    }
+}
+
 void protocol_dict_render_data(ProtocolDict* dict, FuriString* result, size_t protocol_index) {
     furi_check(protocol_index < dict->count);
     ProtocolRenderData fn = dict->base[protocol_index]->render_data;

--- a/lib/toolbox/protocols/protocol_dict.c
+++ b/lib/toolbox/protocols/protocol_dict.c
@@ -203,7 +203,7 @@ void protocol_dict_render_uid(ProtocolDict* dict, FuriString* result, size_t pro
     ProtocolRenderData fn = dict->base[protocol_index]->render_uid;
 
     if(fn) {
-        return fn(dict->data[protocol_index], result);
+        fn(dict->data[protocol_index], result);
     }
 }
 
@@ -212,7 +212,7 @@ void protocol_dict_render_data(ProtocolDict* dict, FuriString* result, size_t pr
     ProtocolRenderData fn = dict->base[protocol_index]->render_data;
 
     if(fn) {
-        return fn(dict->data[protocol_index], result);
+        fn(dict->data[protocol_index], result);
     }
 }
 
@@ -221,7 +221,7 @@ void protocol_dict_render_brief_data(ProtocolDict* dict, FuriString* result, siz
     ProtocolRenderData fn = dict->base[protocol_index]->render_brief_data;
 
     if(fn) {
-        return fn(dict->data[protocol_index], result);
+        fn(dict->data[protocol_index], result);
     }
 }
 

--- a/lib/toolbox/protocols/protocol_dict.h
+++ b/lib/toolbox/protocols/protocol_dict.h
@@ -58,6 +58,8 @@ bool protocol_dict_encoder_start(ProtocolDict* dict, size_t protocol_index);
 
 LevelDuration protocol_dict_encoder_yield(ProtocolDict* dict, size_t protocol_index);
 
+void protocol_dict_render_uid(ProtocolDict* dict, FuriString* result, size_t protocol_index);
+
 void protocol_dict_render_data(ProtocolDict* dict, FuriString* result, size_t protocol_index);
 
 void protocol_dict_render_brief_data(ProtocolDict* dict, FuriString* result, size_t protocol_index);

--- a/targets/f18/api_symbols.csv
+++ b/targets/f18/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,61.1,,
+Version,+,61.2,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,
@@ -2251,6 +2251,7 @@ Function,+,protocol_dict_get_validate_count,uint32_t,"ProtocolDict*, size_t"
 Function,+,protocol_dict_get_write_data,_Bool,"ProtocolDict*, size_t, void*"
 Function,+,protocol_dict_render_brief_data,void,"ProtocolDict*, FuriString*, size_t"
 Function,+,protocol_dict_render_data,void,"ProtocolDict*, FuriString*, size_t"
+Function,+,protocol_dict_render_uid,void,"ProtocolDict*, FuriString*, size_t"
 Function,+,protocol_dict_set_data,void,"ProtocolDict*, size_t, const uint8_t*, size_t"
 Function,-,pulse_reader_alloc,PulseReader*,"const GpioPin*, uint32_t"
 Function,-,pulse_reader_free,void,PulseReader*

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,61.1,,
+Version,+,61.2,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
@@ -2849,6 +2849,7 @@ Function,+,protocol_dict_get_validate_count,uint32_t,"ProtocolDict*, size_t"
 Function,+,protocol_dict_get_write_data,_Bool,"ProtocolDict*, size_t, void*"
 Function,+,protocol_dict_render_brief_data,void,"ProtocolDict*, FuriString*, size_t"
 Function,+,protocol_dict_render_data,void,"ProtocolDict*, FuriString*, size_t"
+Function,+,protocol_dict_render_uid,void,"ProtocolDict*, FuriString*, size_t"
 Function,+,protocol_dict_set_data,void,"ProtocolDict*, size_t, const uint8_t*, size_t"
 Function,-,pulse_reader_alloc,PulseReader*,"const GpioPin*, uint32_t"
 Function,-,pulse_reader_free,void,PulseReader*


### PR DESCRIPTION
# What's new

- iButton no longer crashes when deleting Metakom or Cyfral keys

# Verification 

- Delete keys of the types mentioned above, check that it works as expected

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
