### PR TITLE
USB: Fix file writing hang regression for big files

### DIFF
--- a/targets/f7/furi_hal/furi_hal_usb_cdc.c
+++ b/targets/f7/furi_hal/furi_hal_usb_cdc.c
@@ -7,13 +7,13 @@
 #include "usb.h"
 #include "usb_cdc.h"
 
-#define CDC0_RXD_EP 0x02
+#define CDC0_RXD_EP 0x01
 #define CDC0_TXD_EP 0x82
-#define CDC0_NTF_EP 0x81
+#define CDC0_NTF_EP 0x83
 
 #define CDC1_RXD_EP 0x04
-#define CDC1_TXD_EP 0x84
-#define CDC1_NTF_EP 0x83
+#define CDC1_TXD_EP 0x85
+#define CDC1_NTF_EP 0x86
 
 #define CDC_NTF_SZ 0x08
 


### PR DESCRIPTION
# What's new

- Fixes #3452 as it is still an issue
- TLDR:
  - #3358 fixed crashes when using `cat` on flipper serial
  - it also included some unrelated USB CDC parameter changes
  - from what I've tested, the crash for `cat` on serial is fixed even when not including the USB CDC changes
  - this additional unrelated change was only denoted as `USB CDC: switch from 2x unidirectional data endpoints to 1x bidirectional`
  - from what I can see there are no additional details, no bugs this is attempting to fix, and no improvements this brings
  - there are however some very real issues with this tiny USB CDC changes
  - during USB file writing (like qFlipper or Web update) there is a random chance of USB lockup
  - when this happens, Flipper USB will be fully unresponsive until rebooted
  - qFlipper will say timeout after some seconds, Web will just remain stuck forever
  - the bigger the file being written over USB, the higher chance of lockup
  - it is most prominent when installing some big CFW (6MB+ resources.tar), but I have seen multiple users struggling to update OFW due to this bug
  - in other cases I told people to downgrade to older OFW to avoid this bug, and they could not even downgrade due to having newer OFW currently installed with this bug
  - CFWs have reverted this changes in same way as this PR and have had no issues since. going from CFW to new CFW, or from CFW to OFW
  - but since OFW after 0.99 has this bug, if user has OFW installed they can have issues updating to newer OFW or installing CFW

# Verification 

- Install firmware with big resources.tar multiple times and no issues

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
