### PR TITLE
Desktop: fix crash on autolock after restart in locked state

### DIFF
--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -61,11 +61,11 @@ static void desktop_clock_update(Desktop* desktop) {
     furi_hal_rtc_get_datetime(&curr_dt);
     bool time_format_12 = locale_get_time_format() == LocaleTimeFormat12h;
 
-    if(desktop->time_hour != curr_dt.hour || desktop->time_minute != curr_dt.minute ||
-       desktop->time_format_12 != time_format_12) {
-        desktop->time_format_12 = time_format_12;
-        desktop->time_hour = curr_dt.hour;
-        desktop->time_minute = curr_dt.minute;
+    if(desktop->clock.hour != curr_dt.hour || desktop->clock.minute != curr_dt.minute ||
+       desktop->clock.format_12 != time_format_12) {
+        desktop->clock.format_12 = time_format_12;
+        desktop->clock.hour = curr_dt.hour;
+        desktop->clock.minute = curr_dt.minute;
         view_port_update(desktop->clock_viewport);
     }
 }
@@ -92,8 +92,8 @@ static void desktop_clock_draw_callback(Canvas* canvas, void* context) {
 
     canvas_set_font(canvas, FontPrimary);
 
-    uint8_t hour = desktop->time_hour;
-    if(desktop->time_format_12) {
+    uint8_t hour = desktop->clock.hour;
+    if(desktop->clock.format_12) {
         if(hour > 12) {
             hour -= 12;
         }
@@ -103,11 +103,11 @@ static void desktop_clock_draw_callback(Canvas* canvas, void* context) {
     }
 
     char buffer[20];
-    snprintf(buffer, sizeof(buffer), "%02u:%02u", hour, desktop->time_minute);
+    snprintf(buffer, sizeof(buffer), "%02u:%02u", hour, desktop->clock.minute);
 
     view_port_set_width(
         desktop->clock_viewport,
-        canvas_string_width(canvas, buffer) - 1 + (desktop->time_minute % 10 == 1));
+        canvas_string_width(canvas, buffer) - 1 + (desktop->clock.minute % 10 == 1));
 
     canvas_draw_str_aligned(canvas, 0, 8, AlignLeft, AlignBottom, buffer);
 }

--- a/applications/services/desktop/desktop_i.h
+++ b/applications/services/desktop/desktop_i.h
@@ -35,6 +35,12 @@ typedef enum {
     DesktopViewIdTotal,
 } DesktopViewId;
 
+typedef struct {
+    uint8_t hour;
+    uint8_t minute;
+    bool format_12; // 1 - 12 hour, 0 - 24H
+} DesktopClock;
+
 struct Desktop {
     // Scene
     FuriThread* scene_thread;
@@ -75,9 +81,7 @@ struct Desktop {
 
     FuriPubSub* status_pubsub;
 
-    uint8_t time_hour;
-    uint8_t time_minute;
-    bool time_format_12 : 1; // 1 - 12 hour, 0 - 24H
+    DesktopClock clock;
 
     bool in_transition : 1;
     bool locked : 1;

--- a/applications/services/desktop/desktop_i.h
+++ b/applications/services/desktop/desktop_i.h
@@ -80,6 +80,7 @@ struct Desktop {
     bool time_format_12 : 1; // 1 - 12 hour, 0 - 24H
 
     bool in_transition : 1;
+    bool locked : 1;
 
     FuriSemaphore* animation_semaphore;
 };


### PR DESCRIPTION
# What's new

- Desktop: fix crash on autolock after restart in locked state. Fix #3620

# Verification 

- Flash firmware with lib debug enabled
- Enable autolock in desktop settings 
- Go to desktop and lock flipper
- Reset flipper
- Ensure flipper locked itself on start
- Wait for autolock timeout, no crash should happen

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
