### PR TITLE
Fix calling both `view_free_model()` and `view_free()`

### DIFF
--- a/applications/services/gui/view.c
+++ b/applications/services/gui/view.c
@@ -97,10 +97,11 @@ void view_free_model(View* view) {
         furi_mutex_free(model->mutex);
         free(model->data);
         free(model);
-        view->model = NULL;
     } else {
         furi_crash();
     }
+    view->model = NULL;
+    view->model_type = ViewModelTypeNone;
 }
 
 void* view_get_model(View* view) {


### PR DESCRIPTION
# What's new

- `view_free_model()` will free the model but not remember that it was freed
- so, `view_free()` will call `view_free_model()` again and (on TLSF) crash

# Verification 

- Call both `view_free_model()` and `view_free()` on same view object

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
