### PR TITLE
Text Box: fix displaying text with end text focus

### DIFF
--- a/applications/debug/text_box_view_test/text_box_view_test.c
+++ b/applications/debug/text_box_view_test/text_box_view_test.c
@@ -20,6 +20,33 @@ static const TextBoxViewTestContent text_box_view_test_content_arr[] = {
     },
     {
         .font = TextBoxFontText,
+        .focus = TextBoxFocusEnd,
+        .text = "First test to add dynamically lines with EndFocus set\nLine 0",
+    },
+    {
+        .font = TextBoxFontText,
+        .focus = TextBoxFocusEnd,
+        .text = "First test to add dynamically lines with EndFocus set\nLine 0\nLine 1",
+    },
+    {
+        .font = TextBoxFontText,
+        .focus = TextBoxFocusEnd,
+        .text = "First test to add dynamically lines with EndFocus set\nLine 0\nLine 1\nLine 2",
+    },
+    {
+        .font = TextBoxFontText,
+        .focus = TextBoxFocusEnd,
+        .text =
+            "First test to add dynamically lines with EndFocus set\nLine 0\nLine 1\nLine 2\nLine 3",
+    },
+    {
+        .font = TextBoxFontText,
+        .focus = TextBoxFocusEnd,
+        .text =
+            "First test to add dynamically lines with EndFocus set\nLine 0\nLine 1\nLine 2\nLine 3\nLine 4",
+    },
+    {
+        .font = TextBoxFontText,
         .focus = TextBoxFocusStart,
         .text =
             "Verify that symbols don't overlap borders: llllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllend",
@@ -57,7 +84,8 @@ typedef struct {
 } TextBoxViewTest;
 
 static void text_box_update_view(TextBoxViewTest* instance) {
-    text_box_reset(instance->text_box);
+    // Intentional incorrect way to reset text box to verify that state resets if text changes
+    text_box_set_text(instance->text_box, "");
 
     const TextBoxViewTestContent* content =
         &text_box_view_test_content_arr[instance->current_content_i];

--- a/applications/services/gui/modules/text_box.c
+++ b/applications/services/gui/modules/text_box.c
@@ -227,14 +227,13 @@ static void text_box_prepare_model(Canvas* canvas, TextBoxModel* model) {
         text_box_seek_next_line(canvas, model);
         lines_num++;
     } while(!text_box_end_of_text_reached(model));
+    model->text_offset = 0;
     lines_num++;
 
     if(model->focus == TextBoxFocusEnd) {
         if(lines_num > model->lines_on_screen) {
             model->text_offset = window_offset[(lines_num - 1) % model->lines_on_screen];
         }
-    } else {
-        model->text_offset = 0;
     }
 
     if(lines_num > model->lines_on_screen) {

--- a/targets/f7/furi_hal/furi_hal_flash.c
+++ b/targets/f7/furi_hal/furi_hal_flash.c
@@ -19,7 +19,6 @@
 #ifdef FLASH_OP_DEBUG
 #undef FURI_LOG_T
 #define FURI_LOG_T(...)
-#else
 #endif
 
 #define FURI_HAL_CRITICAL_MSG "Critical flash operation fail"


### PR DESCRIPTION
# What's new

- When set text fits the screen and TextFocus set to TextFocusEnd, the internal text offset is calculated incorrectly on initial text iteration. Fixed that issue
- Add test cases in TextBoxViewTest debug app

# Verification 

- Run TextBoxViewTest debug app. Verify all screens are displayed correctly

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
