### PR TITLE
[FL-3775] Archive: fix condition race on exit

### DIFF
--- a/applications/main/archive/archive.c
+++ b/applications/main/archive/archive.c
@@ -16,6 +16,7 @@ ArchiveApp* archive_alloc(void) {
     ArchiveApp* archive = malloc(sizeof(ArchiveApp));
 
     archive->gui = furi_record_open(RECORD_GUI);
+    archive->loader = furi_record_open(RECORD_LOADER);
     archive->text_input = text_input_alloc();
     archive->fav_move_str = furi_string_alloc();
 
@@ -61,6 +62,8 @@ void archive_free(ArchiveApp* archive) {
 
     text_input_free(archive->text_input);
 
+    furi_record_close(RECORD_LOADER);
+    archive->loader = NULL;
     furi_record_close(RECORD_GUI);
     archive->gui = NULL;
 

--- a/applications/main/archive/archive_i.h
+++ b/applications/main/archive/archive_i.h
@@ -22,6 +22,7 @@ typedef enum {
 
 struct ArchiveApp {
     Gui* gui;
+    Loader* loader;
     ViewDispatcher* view_dispatcher;
     SceneManager* scene_manager;
     ArchiveBrowserView* browser;

--- a/applications/main/archive/scenes/archive_scene_browser.c
+++ b/applications/main/archive/scenes/archive_scene_browser.c
@@ -211,7 +211,6 @@ bool archive_scene_browser_on_event(void* context, SceneManagerEvent event) {
             if(!archive_is_home(browser)) {
                 archive_leave_dir(browser);
             } else {
-                FURI_LOG_I(TAG, "ArchiveBrowserEventExit");
                 if(archive->loader_stop_subscription) {
                     furi_pubsub_unsubscribe(
                         loader_get_pubsub(archive->loader), archive->loader_stop_subscription);
@@ -232,9 +231,9 @@ bool archive_scene_browser_on_event(void* context, SceneManagerEvent event) {
 
 void archive_scene_browser_on_exit(void* context) {
     ArchiveApp* archive = (ArchiveApp*)context;
-    FURI_LOG_I(TAG, "archive_scene_browser_on_exit");
     if(archive->loader_stop_subscription) {
-        furi_pubsub_unsubscribe(loader_get_pubsub(archive->loader), archive->loader_stop_subscription);
+        furi_pubsub_unsubscribe(
+            loader_get_pubsub(archive->loader), archive->loader_stop_subscription);
         archive->loader_stop_subscription = NULL;
     }
 }

--- a/applications/main/archive/scenes/archive_scene_browser.c
+++ b/applications/main/archive/scenes/archive_scene_browser.c
@@ -86,10 +86,8 @@ void archive_scene_browser_on_enter(void* context) {
     archive_update_focus(browser, archive->text_store);
     view_dispatcher_switch_to_view(archive->view_dispatcher, ArchiveViewBrowser);
 
-    Loader* loader = furi_record_open(RECORD_LOADER);
-    archive->loader_stop_subscription =
-        furi_pubsub_subscribe(loader_get_pubsub(loader), archive_loader_callback, archive);
-    furi_record_close(RECORD_LOADER);
+    archive->loader_stop_subscription = furi_pubsub_subscribe(
+        loader_get_pubsub(archive->loader), archive_loader_callback, archive);
 
     uint32_t state = scene_manager_get_scene_state(archive->scene_manager, ArchiveAppSceneBrowser);
 
@@ -213,10 +211,12 @@ bool archive_scene_browser_on_event(void* context, SceneManagerEvent event) {
             if(!archive_is_home(browser)) {
                 archive_leave_dir(browser);
             } else {
-                Loader* loader = furi_record_open(RECORD_LOADER);
-                furi_pubsub_unsubscribe(
-                    loader_get_pubsub(loader), archive->loader_stop_subscription);
-                furi_record_close(RECORD_LOADER);
+                FURI_LOG_I(TAG, "ArchiveBrowserEventExit");
+                if(archive->loader_stop_subscription) {
+                    furi_pubsub_unsubscribe(
+                        loader_get_pubsub(archive->loader), archive->loader_stop_subscription);
+                    archive->loader_stop_subscription = NULL;
+                }
 
                 view_dispatcher_stop(archive->view_dispatcher);
             }
@@ -232,8 +232,9 @@ bool archive_scene_browser_on_event(void* context, SceneManagerEvent event) {
 
 void archive_scene_browser_on_exit(void* context) {
     ArchiveApp* archive = (ArchiveApp*)context;
-
-    Loader* loader = furi_record_open(RECORD_LOADER);
-    furi_pubsub_unsubscribe(loader_get_pubsub(loader), archive->loader_stop_subscription);
-    furi_record_close(RECORD_LOADER);
+    FURI_LOG_I(TAG, "archive_scene_browser_on_exit");
+    if(archive->loader_stop_subscription) {
+        furi_pubsub_unsubscribe(loader_get_pubsub(archive->loader), archive->loader_stop_subscription);
+        archive->loader_stop_subscription = NULL;
+    }
 }


### PR DESCRIPTION
# What's new

- [FL-3775] Archive: fix condition race on exit, fix #3458

# Verification 

- Pin at least 6 apps in archive
- Start file upload with qFlipper in background
- Open archive, navigate to the app, start it, repeatedly press back button
- No crash should occurs

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-3775]: https://flipperzero.atlassian.net/browse/FL-3775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ