### PR TITLE
[FL-3829] NFC App: fix changing UID

### DIFF
--- a/applications/main/nfc/scenes/nfc_scene_set_uid.c
+++ b/applications/main/nfc/scenes/nfc_scene_set_uid.c
@@ -7,10 +7,7 @@ void nfc_scene_set_uid_on_enter(void* context) {
 
     size_t uid_len;
     const uint8_t* uid = nfc_device_get_uid(instance->nfc_device, &uid_len);
-
     memcpy(instance->byte_input_store, uid, uid_len);
-    // Save UID length for use in callback
-    scene_manager_set_scene_state(instance->scene_manager, NfcSceneSetUid, uid_len);
 
     // Setup view
     ByteInput* byte_input = instance->byte_input;

--- a/applications/main/nfc/scenes/nfc_scene_set_uid.c
+++ b/applications/main/nfc/scenes/nfc_scene_set_uid.c
@@ -2,13 +2,6 @@
 
 #include "../helpers/protocol_support/nfc_protocol_support_gui_common.h"
 
-static void nfc_scene_set_uid_byte_input_changed_callback(void* context) {
-    NfcApp* instance = context;
-    // Retrieve previously saved UID length
-    const size_t uid_len = scene_manager_get_scene_state(instance->scene_manager, NfcSceneSetUid);
-    nfc_device_set_uid(instance->nfc_device, instance->byte_input_store, uid_len);
-}
-
 void nfc_scene_set_uid_on_enter(void* context) {
     NfcApp* instance = context;
 
@@ -25,7 +18,7 @@ void nfc_scene_set_uid_on_enter(void* context) {
     byte_input_set_result_callback(
         byte_input,
         nfc_protocol_support_common_byte_input_done_callback,
-        nfc_scene_set_uid_byte_input_changed_callback,
+        NULL,
         instance,
         instance->byte_input_store,
         uid_len);
@@ -39,6 +32,9 @@ bool nfc_scene_set_uid_on_event(void* context, SceneManagerEvent event) {
 
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == NfcCustomEventByteInputDone) {
+            size_t uid_len = 0;
+            nfc_device_get_uid(instance->nfc_device, &uid_len);
+            nfc_device_set_uid(instance->nfc_device, instance->byte_input_store, uid_len);
             if(scene_manager_has_previous_scene(instance->scene_manager, NfcSceneSavedMenu)) {
                 if(nfc_save(instance)) {
                     scene_manager_next_scene(instance->scene_manager, NfcSceneSaveSuccess);


### PR DESCRIPTION
# What's new

- Fix setting UID on each byte change. Now UID changes only after "Save" pressed.

# Verification 

- UID is not changed until "Saved" pressed.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
