### PR TITLE
Electra non-initialized encoded epilogue on render fix

### DIFF
--- a/lib/lfrfid/protocols/protocol_electra.c
+++ b/lib/lfrfid/protocols/protocol_electra.c
@@ -411,6 +411,7 @@ bool protocol_electra_write_data(ProtocolElectra* protocol, void* data) {
 };
 
 void protocol_electra_render_data(ProtocolElectra* protocol, FuriString* result) {
+    protocol_electra_encoder_start(protocol);
     furi_string_printf(result, "Epilogue: %016llX", protocol->encoded_epilogue);
 };
 


### PR DESCRIPTION
# What's new

- Fix of https://github.com/flipperdevices/flipperzero-firmware/pull/3640#issuecomment-2125404581

# Verification 

- Open saved Electra dump with non-null epilogue
- Open Info
- Epilogue must be correct

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
