### PR TITLE
[FL-3797] Favorite apps navigation fix and text fixes

### DIFF
--- a/applications/settings/desktop_settings/scenes/desktop_settings_scene_favorite.c
+++ b/applications/settings/desktop_settings/scenes/desktop_settings_scene_favorite.c
@@ -80,6 +80,7 @@ void desktop_settings_scene_favorite_on_enter(void* context) {
         furi_assert(favorite_id < DummyAppNumber);
         curr_favorite_app = &app->settings.dummy_apps[favorite_id];
         default_passport = true;
+        favorite_id |= SCENE_STATE_SET_DUMMY_APP;
     }
 
     // Special case: Application browser
@@ -141,28 +142,28 @@ void desktop_settings_scene_favorite_on_enter(void* context) {
 
     switch(favorite_id) {
     case SCENE_STATE_SET_FAVORITE_APP | FavoriteAppLeftShort:
-        submenu_set_header(submenu, "Left - Short");
+        submenu_set_header(submenu, "Left - Press");
         break;
     case SCENE_STATE_SET_FAVORITE_APP | FavoriteAppLeftLong:
-        submenu_set_header(submenu, "Left - Long");
+        submenu_set_header(submenu, "Left - Hold");
         break;
     case SCENE_STATE_SET_FAVORITE_APP | FavoriteAppRightShort:
-        submenu_set_header(submenu, "Right - Short");
+        submenu_set_header(submenu, "Right - Press");
         break;
     case SCENE_STATE_SET_FAVORITE_APP | FavoriteAppRightLong:
-        submenu_set_header(submenu, "Right - Long");
+        submenu_set_header(submenu, "Right - Hold");
         break;
     case SCENE_STATE_SET_DUMMY_APP | DummyAppLeft:
-        submenu_set_header(submenu, "Left");
+        submenu_set_header(submenu, "Left - Press");
         break;
     case SCENE_STATE_SET_DUMMY_APP | DummyAppRight:
-        submenu_set_header(submenu, "Right");
+        submenu_set_header(submenu, "Right - Press");
         break;
     case SCENE_STATE_SET_DUMMY_APP | DummyAppDown:
-        submenu_set_header(submenu, "Down");
+        submenu_set_header(submenu, "Down - Press");
         break;
     case SCENE_STATE_SET_DUMMY_APP | DummyAppOk:
-        submenu_set_header(submenu, "Middle");
+        submenu_set_header(submenu, "Middle - Press");
         break;
     default:
         break;

--- a/applications/settings/desktop_settings/scenes/desktop_settings_scene_favorite.c
+++ b/applications/settings/desktop_settings/scenes/desktop_settings_scene_favorite.c
@@ -142,22 +142,18 @@ void desktop_settings_scene_favorite_on_enter(void* context) {
 
     switch(favorite_id) {
     case SCENE_STATE_SET_FAVORITE_APP | FavoriteAppLeftShort:
+    case SCENE_STATE_SET_DUMMY_APP | DummyAppLeft:
         submenu_set_header(submenu, "Left - Press");
         break;
     case SCENE_STATE_SET_FAVORITE_APP | FavoriteAppLeftLong:
         submenu_set_header(submenu, "Left - Hold");
         break;
     case SCENE_STATE_SET_FAVORITE_APP | FavoriteAppRightShort:
+    case SCENE_STATE_SET_DUMMY_APP | DummyAppRight:
         submenu_set_header(submenu, "Right - Press");
         break;
     case SCENE_STATE_SET_FAVORITE_APP | FavoriteAppRightLong:
         submenu_set_header(submenu, "Right - Hold");
-        break;
-    case SCENE_STATE_SET_DUMMY_APP | DummyAppLeft:
-        submenu_set_header(submenu, "Left - Press");
-        break;
-    case SCENE_STATE_SET_DUMMY_APP | DummyAppRight:
-        submenu_set_header(submenu, "Right - Press");
         break;
     case SCENE_STATE_SET_DUMMY_APP | DummyAppDown:
         submenu_set_header(submenu, "Down - Press");

--- a/applications/settings/desktop_settings/scenes/desktop_settings_scene_quick_apps_direction_menu.c
+++ b/applications/settings/desktop_settings/scenes/desktop_settings_scene_quick_apps_direction_menu.c
@@ -34,14 +34,14 @@ void desktop_settings_scene_quick_apps_direction_menu_on_enter(void* context) {
     if(favorite_id == SCENE_STATE_SET_FAVORITE_APP) {
         submenu_add_item(
             submenu,
-            "Left - Click",
+            "Left - Press",
             QuickAppsSubmenuIndexFavoriteLeftClick,
             desktop_settings_scene_quick_apps_direction_menu_submenu_callback,
             app);
 
         submenu_add_item(
             submenu,
-            "Right - Click",
+            "Right - Press",
             QuickAppsSubmenuIndexFavoriteRightClick,
             desktop_settings_scene_quick_apps_direction_menu_submenu_callback,
             app);
@@ -64,28 +64,28 @@ void desktop_settings_scene_quick_apps_direction_menu_on_enter(void* context) {
     } else {
         submenu_add_item(
             submenu,
-            "Left - Click",
+            "Left - Press",
             QuickAppsSubmenuIndexDummyLeftClick,
             desktop_settings_scene_quick_apps_direction_menu_submenu_callback,
             app);
 
         submenu_add_item(
             submenu,
-            "Right - Click",
+            "Right - Press",
             QuickAppsSubmenuIndexDummyRightClick,
             desktop_settings_scene_quick_apps_direction_menu_submenu_callback,
             app);
 
         submenu_add_item(
             submenu,
-            "Down - Click",
+            "Down - Press",
             QuickAppsSubmenuIndexDummyDownClick,
             desktop_settings_scene_quick_apps_direction_menu_submenu_callback,
             app);
 
         submenu_add_item(
             submenu,
-            "Middle - Click",
+            "Middle - Press",
             QuickAppsSubmenuIndexDummyMiddleClick,
             desktop_settings_scene_quick_apps_direction_menu_submenu_callback,
             app);


### PR DESCRIPTION
# What's new

Fixed navigation in dummy mode, fixed wording for button presses and menus

# Verification 

Settings -> Desktop -> Set Quick Access Apps -> Dummy mode all menu items should lead to correct corresponding menus
Button Long press is renamed into Button Hold
Button Click is renamed into Button Press

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
