### PR TITLE
SubGhz: Princeton protocol add custom guard time

### DIFF
--- a/applications/main/subghz/helpers/subghz_txrx_create_protocol_key.c
+++ b/applications/main/subghz/helpers/subghz_txrx_create_protocol_key.c
@@ -81,7 +81,8 @@ SubGhzProtocolStatus subghz_txrx_gen_data_protocol_and_te(
         }
     }
     if(ret == SubGhzProtocolStatusOk) {
-        if(!flipper_format_update_uint32(instance->fff_data, "Guard_time", 30, 1)) {
+        uint32_t guard_time = 30;
+        if(!flipper_format_update_uint32(instance->fff_data, "Guard_time", (uint32_t*)&guard_time, 1)) {
             ret = SubGhzProtocolStatusErrorParserOthers;
             FURI_LOG_E(TAG, "Unable to update Guard_time");
         }

--- a/applications/main/subghz/helpers/subghz_txrx_create_protocol_key.c
+++ b/applications/main/subghz/helpers/subghz_txrx_create_protocol_key.c
@@ -82,7 +82,8 @@ SubGhzProtocolStatus subghz_txrx_gen_data_protocol_and_te(
     }
     if(ret == SubGhzProtocolStatusOk) {
         uint32_t guard_time = 30;
-        if(!flipper_format_update_uint32(instance->fff_data, "Guard_time", (uint32_t*)&guard_time, 1)) {
+        if(!flipper_format_update_uint32(
+               instance->fff_data, "Guard_time", (uint32_t*)&guard_time, 1)) {
             ret = SubGhzProtocolStatusErrorParserOthers;
             FURI_LOG_E(TAG, "Unable to update Guard_time");
         }

--- a/applications/main/subghz/helpers/subghz_txrx_create_protocol_key.c
+++ b/applications/main/subghz/helpers/subghz_txrx_create_protocol_key.c
@@ -80,6 +80,12 @@ SubGhzProtocolStatus subghz_txrx_gen_data_protocol_and_te(
             FURI_LOG_E(TAG, "Unable to update Te");
         }
     }
+    if(ret == SubGhzProtocolStatusOk) {
+        if(!flipper_format_update_uint32(instance->fff_data, "Guard_time", 30, 1)) {
+            ret = SubGhzProtocolStatusErrorParserOthers;
+            FURI_LOG_E(TAG, "Unable to update Guard_time");
+        }
+    }
     return ret;
 }
 

--- a/lib/subghz/protocols/princeton.c
+++ b/lib/subghz/protocols/princeton.c
@@ -13,6 +13,7 @@
  */
 
 #define TAG "SubGhzProtocolPrinceton"
+#define PRINCETON_GUARD_TIME_DEFALUT 30 //GUARD_TIME = PRINCETON_GUARD_TIME_DEFALUT * 30
 
 static const SubGhzBlockConst subghz_protocol_princeton_const = {
     .te_short = 390,
@@ -170,7 +171,7 @@ SubGhzProtocolStatus
         //optional parameter parameter
         if(!flipper_format_read_uint32(
                flipper_format, "Guard_time", (uint32_t*)&instance->guard_time, 1)) {
-            instance->guard_time = 30;
+            instance->guard_time = PRINCETON_GUARD_TIME_DEFALUT;
         }
 
         flipper_format_read_uint32(
@@ -243,7 +244,7 @@ void subghz_protocol_decoder_princeton_feed(void* context, bool level, uint32_t 
             instance->decoder.decode_data = 0;
             instance->decoder.decode_count_bit = 0;
             instance->te = 0;
-            instance->guard_time = 30;
+            instance->guard_time = PRINCETON_GUARD_TIME_DEFALUT;
         }
         break;
     case PrincetonDecoderStepSaveDuration:
@@ -367,7 +368,7 @@ SubGhzProtocolStatus
         }
         if(!flipper_format_read_uint32(
                flipper_format, "Guard_time", (uint32_t*)&instance->guard_time, 1)) {
-            instance->guard_time = 30;
+            instance->guard_time = PRINCETON_GUARD_TIME_DEFALUT;
         }
     } while(false);
 

--- a/lib/subghz/protocols/princeton.c
+++ b/lib/subghz/protocols/princeton.c
@@ -29,6 +29,7 @@ struct SubGhzProtocolDecoderPrinceton {
 
     uint32_t te;
     uint32_t last_data;
+    uint32_t guard_time;
 };
 
 struct SubGhzProtocolEncoderPrinceton {
@@ -38,6 +39,7 @@ struct SubGhzProtocolEncoderPrinceton {
     SubGhzBlockGeneric generic;
 
     uint32_t te;
+    uint32_t guard_time;
 };
 
 typedef enum {
@@ -135,8 +137,9 @@ static bool
 
     //Send Stop bit
     instance->encoder.upload[index++] = level_duration_make(true, (uint32_t)instance->te);
-    //Send PT_GUARD
-    instance->encoder.upload[index++] = level_duration_make(false, (uint32_t)instance->te * 30);
+    //Send PT_GUARD_TIME
+    instance->encoder.upload[index++] =
+        level_duration_make(false, (uint32_t)instance->te * instance->guard_time);
 
     return true;
 }
@@ -165,6 +168,11 @@ SubGhzProtocolStatus
             break;
         }
         //optional parameter parameter
+        if(!flipper_format_read_uint32(
+               flipper_format, "Guard_time", (uint32_t*)&instance->guard_time, 1)) {
+            instance->guard_time = 30;
+        }
+
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
 
@@ -235,6 +243,7 @@ void subghz_protocol_decoder_princeton_feed(void* context, bool level, uint32_t 
             instance->decoder.decode_data = 0;
             instance->decoder.decode_count_bit = 0;
             instance->te = 0;
+            instance->guard_time = 30;
         }
         break;
     case PrincetonDecoderStepSaveDuration:
@@ -257,6 +266,7 @@ void subghz_protocol_decoder_princeton_feed(void* context, bool level, uint32_t 
 
                         instance->generic.data = instance->decoder.decode_data;
                         instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                        instance->guard_time = round((float)duration / instance->te);
 
                         if(instance->base.callback)
                             instance->base.callback(&instance->base, instance->base.context);
@@ -323,6 +333,12 @@ SubGhzProtocolStatus subghz_protocol_decoder_princeton_serialize(
         FURI_LOG_E(TAG, "Unable to add TE");
         ret = SubGhzProtocolStatusErrorParserTe;
     }
+    if((ret == SubGhzProtocolStatusOk) &&
+       !flipper_format_write_uint32(flipper_format, "Guard_time", &instance->guard_time, 1)) {
+        FURI_LOG_E(TAG, "Unable to add Guard_time");
+        ret = SubGhzProtocolStatusErrorParserOthers;
+    }
+
     return ret;
 }
 
@@ -348,6 +364,10 @@ SubGhzProtocolStatus
             FURI_LOG_E(TAG, "Missing TE");
             ret = SubGhzProtocolStatusErrorParserTe;
             break;
+        }
+        if(!flipper_format_read_uint32(
+               flipper_format, "Guard_time", (uint32_t*)&instance->guard_time, 1)) {
+            instance->guard_time = 30;
         }
     } while(false);
 

--- a/lib/subghz/protocols/princeton.c
+++ b/lib/subghz/protocols/princeton.c
@@ -13,7 +13,7 @@
  */
 
 #define TAG "SubGhzProtocolPrinceton"
-#define PRINCETON_GUARD_TIME_DEFALUT 30 //GUARD_TIME = PRINCETON_GUARD_TIME_DEFALUT * 30
+#define PRINCETON_GUARD_TIME_DEFALUT 30 //GUARD_TIME = PRINCETON_GUARD_TIME_DEFALUT * TE
 
 static const SubGhzBlockConst subghz_protocol_princeton_const = {
     .te_short = 390,


### PR DESCRIPTION
# What's new

- SubGhz: Princeton protocol add custom guard time

# Verification 

- Accept and reproduce different remote controls with the Princeton protocol with recording of the message via SDR and compare the guard time between the messages

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
