### PR TITLE
Furi: wrap message queue in container, prepare it for epoll. Accessor: disable expansion service on start.

### DIFF
--- a/applications/debug/accessor/accessor_app.cpp
+++ b/applications/debug/accessor/accessor_app.cpp
@@ -34,12 +34,16 @@ void AccessorApp::run(void) {
 AccessorApp::AccessorApp()
     : text_store{0} {
     notification = static_cast<NotificationApp*>(furi_record_open(RECORD_NOTIFICATION));
+    expansion = static_cast<Expansion*>(furi_record_open(RECORD_EXPANSION));
     onewire_host = onewire_host_alloc(&gpio_ibutton);
+    expansion_disable(expansion);
     furi_hal_power_enable_otg();
 }
 
 AccessorApp::~AccessorApp() {
     furi_hal_power_disable_otg();
+    expansion_enable(expansion);
+    furi_record_close(RECORD_EXPANSION);
     furi_record_close(RECORD_NOTIFICATION);
     onewire_host_free(onewire_host);
 }

--- a/applications/debug/accessor/accessor_app.h
+++ b/applications/debug/accessor/accessor_app.h
@@ -6,6 +6,7 @@
 #include "helpers/wiegand.h"
 #include <one_wire/one_wire_host.h>
 #include <notification/notification_messages.h>
+#include <expansion/expansion.h>
 
 class AccessorApp {
 public:
@@ -51,4 +52,5 @@ private:
     OneWireHost* onewire_host;
 
     NotificationApp* notification;
+    Expansion* expansion;
 };

--- a/applications/system/snake_game/snake_game.c
+++ b/applications/system/snake_game/snake_game.c
@@ -136,15 +136,17 @@ static void snake_game_render_callback(Canvas* const canvas, void* ctx) {
     furi_mutex_release(snake_state->mutex);
 }
 
-static void snake_game_input_callback(InputEvent* input_event, FuriMessageQueue* event_queue) {
-    furi_assert(event_queue);
+static void snake_game_input_callback(InputEvent* input_event, void* context) {
+    furi_assert(context);
+    FuriMessageQueue* event_queue = context;
 
     SnakeEvent event = {.type = EventTypeKey, .input = *input_event};
     furi_message_queue_put(event_queue, &event, FuriWaitForever);
 }
 
-static void snake_game_update_timer_callback(FuriMessageQueue* event_queue) {
-    furi_assert(event_queue);
+static void snake_game_update_timer_callback(void* context) {
+    furi_assert(context);
+    FuriMessageQueue* event_queue = context;
 
     SnakeEvent event = {.type = EventTypeTick};
     furi_message_queue_put(event_queue, &event, 0);

--- a/furi/core/message_queue.h
+++ b/furi/core/message_queue.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-typedef void FuriMessageQueue;
+typedef struct FuriMessageQueue FuriMessageQueue;
 
 /** Allocate furi message queue
  *


### PR DESCRIPTION
# What's new

- Furi: wrap message queue in container, prepare it for epoll.
- Accessor: disable expansion service on start.

# Verification 

- Check everything
- And accessor app too

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
