### PR TITLE
fbt, vscode: tweaks for cdb generation for clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,6 +1,7 @@
 CompileFlags:
     Add: 
         - -Wno-unknown-warning-option
+        - -Wno-format
     Remove: 
         - -mword-relocations
 

--- a/.clangd
+++ b/.clangd
@@ -1,7 +1,8 @@
 CompileFlags:
-  Add: -Wno-unknown-warning-option
-  ## Experimental
-  # Remove: [-m*, -f*]
+    Add: 
+        - -Wno-unknown-warning-option
+    Remove: 
+        - -mword-relocations
 
 Diagnostics:
-  UnusedIncludes: None
+    UnusedIncludes: None

--- a/.clangd
+++ b/.clangd
@@ -5,5 +5,9 @@ CompileFlags:
     Remove: 
         - -mword-relocations
 
+---
+
+If:
+    PathMatch: .*\.h
 Diagnostics:
     UnusedIncludes: None

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,7 @@
+CompileFlags:
+  Add: -Wno-unknown-warning-option
+  ## Experimental
+  # Remove: [-m*, -f*]
+
+Diagnostics:
+  UnusedIncludes: None

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ compile_commands.json
 # JetBrains IDEs
 .idea/
 
+# Sublime Text
+.sublime-project.sublime-workspace
+
 # Python VirtEnvironments
 .env
 .venv

--- a/.sublime-project
+++ b/.sublime-project
@@ -1,0 +1,20 @@
+{
+    "folders":
+    [
+        {
+            "path": ".",
+        }
+    ],
+    "settings": {
+      "LSP": {
+         "clangd": {
+            "initializationOptions": {
+                "clangd.compile-commands-dir": "build/latest",
+                "clangd.header-insertion": null,
+                "clangd.query-driver": "**",
+            },
+                "enabled": true,
+            },
+      },
+   },
+}

--- a/.sublime-project
+++ b/.sublime-project
@@ -12,6 +12,7 @@
                 "clangd.compile-commands-dir": "build/latest",
                 "clangd.header-insertion": null,
                 "clangd.query-driver": "**",
+                "clangd.clang-tidy": true,
             },
                 "enabled": true,
             },

--- a/.vscode/example/settings.json
+++ b/.vscode/example/settings.json
@@ -19,6 +19,7 @@
     "clangd.arguments": [
         // We might be able to tighten this a bit more to only include the correct toolchain.
         "--query-driver=**",
-        "--compile-commands-dir=${workspaceFolder}/build/latest"
+        "--compile-commands-dir=${workspaceFolder}/build/latest",
+        "--header-insertion=never"
     ]
 }

--- a/.vscode/example/settings.json
+++ b/.vscode/example/settings.json
@@ -20,6 +20,7 @@
         // We might be able to tighten this a bit more to only include the correct toolchain.
         "--query-driver=**",
         "--compile-commands-dir=${workspaceFolder}/build/latest",
+        "--clang-tidy",
         "--header-insertion=never"
     ]
 }

--- a/firmware.scons
+++ b/firmware.scons
@@ -20,6 +20,7 @@ env = ENV.Clone(
         "fbt_resources",
     ],
     COMPILATIONDB_USE_ABSPATH=False,
+    COMPILATIONDB_USE_BINARY_ABSPATH=True,
     BUILD_DIR=fw_build_meta["build_dir"],
     IS_BASE_FIRMWARE=fw_build_meta["type"] == "firmware",
     FW_FLAVOR=fw_build_meta["flavor"],

--- a/scripts/fbt_tools/ccache.py
+++ b/scripts/fbt_tools/ccache.py
@@ -12,3 +12,4 @@ def generate(env):
         env["LINK"] = env["CXX"]
         env["CXX_NOCACHE"] = env["CXX"]
         env["CXX"] = "$CCACHE $CXX_NOCACHE"
+        env.AppendUnique(COMPILATIONDB_OMIT_BINARIES=["ccache"])

--- a/scripts/ufbt/SConstruct
+++ b/scripts/ufbt/SConstruct
@@ -102,6 +102,7 @@ env = core_env.Clone(
         core_env.subst("$SDK_DEFINITION"), load_version_only=True
     ).version,
     APPCHECK_COMSTR="\tAPPCHK\t${SOURCE}\n\t\tTarget: ${TARGET_HW}, API: ${UFBT_API_VERSION}",
+    COMPILATIONDB_USE_BINARY_ABSPATH=True,
 )
 
 wrap_tempfile(env, "LINKCOM")


### PR DESCRIPTION
# What's new

- fbt: cdb tool: better commandline handling; omitting ccache
- added initial .clangd config

# Verification 

- try clangd setup 
- don't forget to pass `--query-driver=**` to its options
- `subl --project .sublime-project`

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
