### PR TITLE
RPC: Add TarExtract command, some small fixes

### DIFF
--- a/applications/services/rpc/rpc_storage.c
+++ b/applications/services/rpc/rpc_storage.c
@@ -220,6 +220,8 @@ static void rpc_system_storage_list_root(const PB_Main* request, void* context) 
     RpcSession* session = rpc_storage->session;
     furi_assert(session);
 
+    rpc_system_storage_reset_state(rpc_storage, session, true);
+
     const char* hard_coded_dirs[] = {"any", "int", "ext"};
 
     PB_Main response = {
@@ -679,6 +681,8 @@ static void rpc_system_storage_backup_create_process(const PB_Main* request, voi
     RpcSession* session = rpc_storage->session;
     furi_assert(session);
 
+    rpc_system_storage_reset_state(rpc_storage, session, true);
+
     Storage* fs_api = furi_record_open(RECORD_STORAGE);
 
     bool backup_ok =
@@ -700,6 +704,8 @@ static void rpc_system_storage_backup_restore_process(const PB_Main* request, vo
     RpcStorageSystem* rpc_storage = context;
     RpcSession* session = rpc_storage->session;
     furi_assert(session);
+
+    rpc_system_storage_reset_state(rpc_storage, session, true);
 
     Storage* fs_api = furi_record_open(RECORD_STORAGE);
 

--- a/applications/services/rpc/rpc_storage.c
+++ b/applications/services/rpc/rpc_storage.c
@@ -220,8 +220,6 @@ static void rpc_system_storage_list_root(const PB_Main* request, void* context) 
     RpcSession* session = rpc_storage->session;
     furi_assert(session);
 
-    rpc_system_storage_reset_state(rpc_storage, session, true);
-
     const char* hard_coded_dirs[] = {"any", "int", "ext"};
 
     PB_Main response = {

--- a/applications/services/rpc/rpc_storage.c
+++ b/applications/services/rpc/rpc_storage.c
@@ -51,7 +51,6 @@ static void rpc_system_storage_reset_state(
         if(rpc_storage->state == RpcStorageStateWriting) {
             storage_file_close(rpc_storage->file);
             storage_file_free(rpc_storage->file);
-            furi_record_close(RECORD_STORAGE);
         }
 
         rpc_storage->state = RpcStorageStateIdle;
@@ -119,10 +118,8 @@ static void rpc_system_storage_info_process(const PB_Main* request, void* contex
     PB_Main* response = malloc(sizeof(PB_Main));
     response->command_id = request->command_id;
 
-    Storage* fs_api = furi_record_open(RECORD_STORAGE);
-
     FS_Error error = storage_common_fs_info(
-        fs_api,
+        rpc_storage->api,
         request->content.storage_info_request.path,
         &response->content.storage_info_response.total_space,
         &response->content.storage_info_response.free_space);
@@ -136,7 +133,6 @@ static void rpc_system_storage_info_process(const PB_Main* request, void* contex
 
     rpc_send_and_release(session, response);
     free(response);
-    furi_record_close(RECORD_STORAGE);
 }
 
 static void rpc_system_storage_timestamp_process(const PB_Main* request, void* context) {
@@ -155,11 +151,9 @@ static void rpc_system_storage_timestamp_process(const PB_Main* request, void* c
     PB_Main* response = malloc(sizeof(PB_Main));
     response->command_id = request->command_id;
 
-    Storage* fs_api = furi_record_open(RECORD_STORAGE);
-
     const char* path = request->content.storage_timestamp_request.path;
     uint32_t timestamp = 0;
-    FS_Error error = storage_common_timestamp(fs_api, path, &timestamp);
+    FS_Error error = storage_common_timestamp(rpc_storage->api, path, &timestamp);
 
     response->command_status = rpc_system_storage_get_error(error);
     response->which_content = PB_Main_empty_tag;
@@ -171,7 +165,6 @@ static void rpc_system_storage_timestamp_process(const PB_Main* request, void* c
 
     rpc_send_and_release(session, response);
     free(response);
-    furi_record_close(RECORD_STORAGE);
 }
 
 static void rpc_system_storage_stat_process(const PB_Main* request, void* context) {
@@ -190,11 +183,9 @@ static void rpc_system_storage_stat_process(const PB_Main* request, void* contex
     PB_Main* response = malloc(sizeof(PB_Main));
     response->command_id = request->command_id;
 
-    Storage* fs_api = furi_record_open(RECORD_STORAGE);
-
     const char* path = request->content.storage_stat_request.path;
     FileInfo fileinfo;
-    FS_Error error = storage_common_stat(fs_api, path, &fileinfo);
+    FS_Error error = storage_common_stat(rpc_storage->api, path, &fileinfo);
 
     response->command_status = rpc_system_storage_get_error(error);
     response->which_content = PB_Main_empty_tag;
@@ -210,12 +201,12 @@ static void rpc_system_storage_stat_process(const PB_Main* request, void* contex
 
     rpc_send_and_release(session, response);
     free(response);
-    furi_record_close(RECORD_STORAGE);
 }
 
 static void rpc_system_storage_list_root(const PB_Main* request, void* context) {
     furi_assert(request);
     furi_assert(context);
+
     RpcStorageSystem* rpc_storage = context;
     RpcSession* session = rpc_storage->session;
     furi_assert(session);
@@ -280,8 +271,7 @@ static void rpc_system_storage_list_process(const PB_Main* request, void* contex
         return;
     }
 
-    Storage* fs_api = furi_record_open(RECORD_STORAGE);
-    File* dir = storage_file_alloc(fs_api);
+    File* dir = storage_file_alloc(rpc_storage->api);
 
     PB_Main response = {
         .command_id = request->command_id,
@@ -294,7 +284,7 @@ static void rpc_system_storage_list_process(const PB_Main* request, void* contex
     bool include_md5 = list_request->include_md5;
     FuriString* md5 = furi_string_alloc();
     FuriString* md5_path = furi_string_alloc();
-    File* file = storage_file_alloc(fs_api);
+    File* file = storage_file_alloc(rpc_storage->api);
 
     bool finish = false;
     int i = 0;
@@ -351,8 +341,6 @@ static void rpc_system_storage_list_process(const PB_Main* request, void* contex
     storage_dir_close(dir);
     storage_file_free(dir);
     storage_file_free(file);
-
-    furi_record_close(RECORD_STORAGE);
 }
 
 static void rpc_system_storage_read_process(const PB_Main* request, void* context) {
@@ -371,8 +359,7 @@ static void rpc_system_storage_read_process(const PB_Main* request, void* contex
     /* use same message memory to send response */
     PB_Main* response = malloc(sizeof(PB_Main));
     const char* path = request->content.storage_read_request.path;
-    Storage* fs_api = furi_record_open(RECORD_STORAGE);
-    File* file = storage_file_alloc(fs_api);
+    File* file = storage_file_alloc(rpc_storage->api);
     bool fs_operation_success = storage_file_open(file, path, FSAM_READ, FSOM_OPEN_EXISTING);
 
     if(fs_operation_success) {
@@ -421,8 +408,6 @@ static void rpc_system_storage_read_process(const PB_Main* request, void* contex
     free(response);
     storage_file_close(file);
     storage_file_free(file);
-
-    furi_record_close(RECORD_STORAGE);
 }
 
 static void rpc_system_storage_write_process(const PB_Main* request, void* context) {
@@ -452,7 +437,6 @@ static void rpc_system_storage_write_process(const PB_Main* request, void* conte
     }
 
     if(rpc_storage->state != RpcStorageStateWriting) {
-        rpc_storage->api = furi_record_open(RECORD_STORAGE);
         rpc_storage->file = storage_file_alloc(rpc_storage->api);
         rpc_storage->current_command_id = request->command_id;
         rpc_storage->state = RpcStorageStateWriting;
@@ -493,14 +477,15 @@ static void rpc_system_storage_write_process(const PB_Main* request, void* conte
     }
 }
 
-static bool rpc_system_storage_is_dir_is_empty(Storage* fs_api, const char* path) {
-    furi_assert(fs_api);
+static bool rpc_system_storage_is_dir_is_empty(Storage* storage, const char* path) {
+    furi_assert(storage);
     furi_assert(path);
+
     FileInfo fileinfo;
     bool is_dir_is_empty = true;
-    FS_Error error = storage_common_stat(fs_api, path, &fileinfo);
+    FS_Error error = storage_common_stat(storage, path, &fileinfo);
     if((error == FSE_OK) && file_info_is_dir(&fileinfo)) {
-        File* dir = storage_file_alloc(fs_api);
+        File* dir = storage_file_alloc(storage);
         if(storage_dir_open(dir, path)) {
             char* name = malloc(MAX_NAME_LENGTH);
             while(storage_dir_read(dir, &fileinfo, name, MAX_NAME_LENGTH)) {
@@ -532,18 +517,17 @@ static void rpc_system_storage_delete_process(const PB_Main* request, void* cont
     PB_CommandStatus status = PB_CommandStatus_ERROR;
     rpc_system_storage_reset_state(rpc_storage, session, true);
 
-    Storage* fs_api = furi_record_open(RECORD_STORAGE);
-
     char* path = request->content.storage_delete_request.path;
     if(!path) {
         status = PB_CommandStatus_ERROR_INVALID_PARAMETERS;
     } else {
-        FS_Error error_remove = storage_common_remove(fs_api, path);
+        FS_Error error_remove = storage_common_remove(rpc_storage->api, path);
         // FSE_DENIED is for empty directory, but not only for this
         // that's why we have to check it
-        if((error_remove == FSE_DENIED) && !rpc_system_storage_is_dir_is_empty(fs_api, path)) {
+        if((error_remove == FSE_DENIED) &&
+           !rpc_system_storage_is_dir_is_empty(rpc_storage->api, path)) {
             if(request->content.storage_delete_request.recursive) {
-                bool deleted = storage_simply_remove_recursive(fs_api, path);
+                bool deleted = storage_simply_remove_recursive(rpc_storage->api, path);
                 status = deleted ? PB_CommandStatus_OK : PB_CommandStatus_ERROR;
             } else {
                 status = PB_CommandStatus_ERROR_STORAGE_DIR_NOT_EMPTY;
@@ -555,7 +539,6 @@ static void rpc_system_storage_delete_process(const PB_Main* request, void* cont
         }
     }
 
-    furi_record_close(RECORD_STORAGE);
     rpc_send_and_release_empty(session, request->command_id, status);
 }
 
@@ -573,11 +556,10 @@ static void rpc_system_storage_mkdir_process(const PB_Main* request, void* conte
     PB_CommandStatus status;
     rpc_system_storage_reset_state(rpc_storage, session, true);
 
-    Storage* fs_api = furi_record_open(RECORD_STORAGE);
     char* path = request->content.storage_mkdir_request.path;
     if(path) {
         if(path_contains_only_ascii(path)) {
-            FS_Error error = storage_common_mkdir(fs_api, path);
+            FS_Error error = storage_common_mkdir(rpc_storage->api, path);
             status = rpc_system_storage_get_error(error);
         } else {
             status = PB_CommandStatus_ERROR_STORAGE_INVALID_NAME;
@@ -585,7 +567,6 @@ static void rpc_system_storage_mkdir_process(const PB_Main* request, void* conte
     } else {
         status = PB_CommandStatus_ERROR_INVALID_PARAMETERS;
     }
-    furi_record_close(RECORD_STORAGE);
     rpc_send_and_release_empty(session, request->command_id, status);
 }
 
@@ -609,8 +590,7 @@ static void rpc_system_storage_md5sum_process(const PB_Main* request, void* cont
         return;
     }
 
-    Storage* fs_api = furi_record_open(RECORD_STORAGE);
-    File* file = storage_file_alloc(fs_api);
+    File* file = storage_file_alloc(rpc_storage->api);
     FuriString* md5 = furi_string_alloc();
     FS_Error file_error;
 
@@ -634,8 +614,6 @@ static void rpc_system_storage_md5sum_process(const PB_Main* request, void* cont
 
     furi_string_free(md5);
     storage_file_free(file);
-
-    furi_record_close(RECORD_STORAGE);
 }
 
 static void rpc_system_storage_rename_process(const PB_Main* request, void* context) {
@@ -652,11 +630,9 @@ static void rpc_system_storage_rename_process(const PB_Main* request, void* cont
     PB_CommandStatus status;
     rpc_system_storage_reset_state(rpc_storage, session, true);
 
-    Storage* fs_api = furi_record_open(RECORD_STORAGE);
-
     if(path_contains_only_ascii(request->content.storage_rename_request.new_path)) {
         FS_Error error = storage_common_rename(
-            fs_api,
+            rpc_storage->api,
             request->content.storage_rename_request.old_path,
             request->content.storage_rename_request.new_path);
         status = rpc_system_storage_get_error(error);
@@ -664,7 +640,6 @@ static void rpc_system_storage_rename_process(const PB_Main* request, void* cont
         status = PB_CommandStatus_ERROR_STORAGE_INVALID_NAME;
     }
 
-    furi_record_close(RECORD_STORAGE);
     rpc_send_and_release_empty(session, request->command_id, status);
 }
 
@@ -681,12 +656,8 @@ static void rpc_system_storage_backup_create_process(const PB_Main* request, voi
 
     rpc_system_storage_reset_state(rpc_storage, session, true);
 
-    Storage* fs_api = furi_record_open(RECORD_STORAGE);
-
-    bool backup_ok =
-        lfs_backup_create(fs_api, request->content.storage_backup_create_request.archive_path);
-
-    furi_record_close(RECORD_STORAGE);
+    bool backup_ok = lfs_backup_create(
+        rpc_storage->api, request->content.storage_backup_create_request.archive_path);
 
     rpc_send_and_release_empty(
         session, request->command_id, backup_ok ? PB_CommandStatus_OK : PB_CommandStatus_ERROR);
@@ -705,12 +676,8 @@ static void rpc_system_storage_backup_restore_process(const PB_Main* request, vo
 
     rpc_system_storage_reset_state(rpc_storage, session, true);
 
-    Storage* fs_api = furi_record_open(RECORD_STORAGE);
-
-    bool backup_ok =
-        lfs_backup_unpack(fs_api, request->content.storage_backup_restore_request.archive_path);
-
-    furi_record_close(RECORD_STORAGE);
+    bool backup_ok = lfs_backup_unpack(
+        rpc_storage->api, request->content.storage_backup_restore_request.archive_path);
 
     rpc_send_and_release_empty(
         session, request->command_id, backup_ok ? PB_CommandStatus_OK : PB_CommandStatus_ERROR);
@@ -730,8 +697,7 @@ static void rpc_system_storage_tar_extract_process(const PB_Main* request, void*
     PB_CommandStatus status;
     rpc_system_storage_reset_state(rpc_storage, session, true);
 
-    Storage* fs_api = furi_record_open(RECORD_STORAGE);
-    TarArchive* archive = tar_archive_alloc(fs_api);
+    TarArchive* archive = tar_archive_alloc(rpc_storage->api);
 
     do {
         if(!path_contains_only_ascii(request->content.storage_tar_extract_request.out_path)) {
@@ -757,7 +723,6 @@ static void rpc_system_storage_tar_extract_process(const PB_Main* request, void*
     } while(0);
 
     tar_archive_free(archive);
-    furi_record_close(RECORD_STORAGE);
     rpc_send_and_release_empty(session, request->command_id, status);
 }
 
@@ -824,5 +789,8 @@ void rpc_system_storage_free(void* context) {
     furi_assert(session);
 
     rpc_system_storage_reset_state(rpc_storage, session, false);
+
+    furi_record_close(RECORD_STORAGE);
+    rpc_storage->api = NULL;
     free(rpc_storage);
 }

--- a/lib/toolbox/tar/tar_archive.c
+++ b/lib/toolbox/tar/tar_archive.c
@@ -224,6 +224,11 @@ static int archive_extract_foreach_cb(mtar_t* tar, const mtar_header_t* header, 
 
     FuriString* full_extracted_fname;
     if(header->type == MTAR_TDIR) {
+        // Skip "/" entry since concat would leave it dangling, also want caller to mkdir destination
+        if(strcmp(header->name, "/") == 0) {
+            return 0;
+        }
+
         full_extracted_fname = furi_string_alloc();
         path_concat(op_params->work_dir, header->name, full_extracted_fname);
 


### PR DESCRIPTION
# What's new

- RPC storage command to extract tar file to destination (needs flipperdevices/flipperzero-protobuf#50, probably need to update submodule if/when it is merged)
- Fixed extract failing if not extracting at `/ext` or `/int`, this is because first directory entry in tar is `/` and `path_concat()` would result in `/path/to/dest/` with trailing slash. This is a basic fix but might be worth changing the behavior of the path library in such edge cases?
- Added some missing storage state resets, all other functions had them so it seemed like they should be there, revert if i misunderstood :D

# Verification 

- Storage operations, backup and restore, work fine over RPC
- Tar files (like resources.tar, so USTAR format) can be extracted to chosen destination (not sure on easiest way to make one-off RPC calls to test)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
