### PR TITLE
CCID: Updated types to match Short APDU size

### DIFF
--- a/applications/debug/ccid_test/ccid_test_app.c
+++ b/applications/debug/ccid_test/ccid_test_app.c
@@ -96,7 +96,7 @@ void ccid_test_app_free(CcidTestApp* app) {
     free(app);
 }
 
-void ccid_icc_power_on_callback(uint8_t* atrBuffer, uint32_t* atrlen, void* context) {
+void ccid_icc_power_on_callback(uint8_t* atrBuffer, uint8_t* atrlen, void* context) {
     UNUSED(context);
 
     iso7816_icc_power_on_callback(atrBuffer, atrlen);
@@ -104,9 +104,9 @@ void ccid_icc_power_on_callback(uint8_t* atrBuffer, uint32_t* atrlen, void* cont
 
 void ccid_xfr_datablock_callback(
     const uint8_t* pcToReaderDataBlock,
-    uint32_t pcToReaderDataBlockLen,
+    uint8_t pcToReaderDataBlockLen,
     uint8_t* readerToPcDataBlock,
-    uint32_t* readerToPcDataBlockLen,
+    uint8_t* readerToPcDataBlockLen,
     void* context) {
     UNUSED(context);
 

--- a/applications/debug/ccid_test/iso7816_callbacks.c
+++ b/applications/debug/ccid_test/iso7816_callbacks.c
@@ -16,7 +16,7 @@ void iso7816_set_callbacks(Iso7816Callbacks* cb) {
     callbacks = cb;
 }
 
-void iso7816_icc_power_on_callback(uint8_t* atrBuffer, uint32_t* atrlen) {
+void iso7816_icc_power_on_callback(uint8_t* atrBuffer, uint8_t* atrlen) {
     Iso7816Atr atr;
     callbacks->iso7816_answer_to_reset(&atr);
 
@@ -33,9 +33,9 @@ void iso7816_icc_power_on_callback(uint8_t* atrBuffer, uint32_t* atrlen) {
 //dataBlockLen tells reader how nany bytes should be read
 void iso7816_xfr_datablock_callback(
     const uint8_t* pcToReaderDataBlock,
-    uint32_t pcToReaderDataBlockLen,
+    uint8_t pcToReaderDataBlockLen,
     uint8_t* readerToPcDataBlock,
-    uint32_t* readerToPcDataBlockLen) {
+    uint8_t* readerToPcDataBlockLen) {
     struct ISO7816_Response_APDU responseAPDU;
     uint8_t responseApduDataBuffer[ISO7816_RESPONSE_BUFFER_SIZE];
     uint8_t responseApduDataBufferLen = 0;

--- a/applications/debug/ccid_test/iso7816_callbacks.h
+++ b/applications/debug/ccid_test/iso7816_callbacks.h
@@ -18,11 +18,11 @@ typedef struct {
 
 void iso7816_set_callbacks(Iso7816Callbacks* cb);
 
-void iso7816_icc_power_on_callback(uint8_t* atrBuffer, uint32_t* atrlen);
+void iso7816_icc_power_on_callback(uint8_t* atrBuffer, uint8_t* atrlen);
 void iso7816_xfr_datablock_callback(
     const uint8_t* dataBlock,
-    uint32_t dataBlockLen,
+    uint8_t dataBlockLen,
     uint8_t* responseDataBlock,
-    uint32_t* responseDataBlockLen);
+    uint8_t* responseDataBlockLen);
 
 #endif //_ISO7816_CALLBACKS_H_

--- a/applications/debug/ccid_test/iso7816_t0_apdu.c
+++ b/applications/debug/ccid_test/iso7816_t0_apdu.c
@@ -9,7 +9,7 @@
 void iso7816_read_command_apdu(
     struct ISO7816_Command_APDU* command,
     const uint8_t* dataBuffer,
-    uint32_t dataLen) {
+    uint8_t dataLen) {
     UNUSED(dataLen);
 
     command->CLA = dataBuffer[0];
@@ -23,10 +23,10 @@ void iso7816_read_command_apdu(
 void iso7816_write_response_apdu(
     const struct ISO7816_Response_APDU* response,
     uint8_t* readerToPcDataBlock,
-    uint32_t* readerToPcDataBlockLen,
+    uint8_t* readerToPcDataBlockLen,
     uint8_t* responseDataBuffer,
-    uint32_t responseDataLen) {
-    uint32_t responseDataBufferIndex = 0;
+    uint8_t responseDataLen) {
+    uint8_t responseDataBufferIndex = 0;
 
     //response body
     if(responseDataLen > 0) {

--- a/applications/debug/ccid_test/iso7816_t0_apdu.h
+++ b/applications/debug/ccid_test/iso7816_t0_apdu.h
@@ -26,11 +26,11 @@ void iso7816_answer_to_reset(Iso7816Atr* atr);
 void iso7816_read_command_apdu(
     struct ISO7816_Command_APDU* command,
     const uint8_t* dataBuffer,
-    uint32_t dataLen);
+    uint8_t dataLen);
 void iso7816_write_response_apdu(
     const struct ISO7816_Response_APDU* response,
     uint8_t* readerToPcDataBlock,
-    uint32_t* readerToPcDataBlockLen,
+    uint8_t* readerToPcDataBlockLen,
     uint8_t* responseDataBuffer,
-    uint32_t responseDataLen);
+    uint8_t responseDataLen);
 #endif //_ISO7816_T0_APDU_H_

--- a/targets/f7/furi_hal/furi_hal_usb_ccid.c
+++ b/targets/f7/furi_hal/furi_hal_usb_ccid.c
@@ -332,7 +332,7 @@ void CALLBACK_CCID_IccPowerOn(
             if(callbacks[CCID_SLOT_INDEX] != NULL) {
                 callbacks[CCID_SLOT_INDEX]->icc_power_on_callback(
                     responseDataBlock->abData,
-                    &responseDataBlock->dwLength,
+                    (uint8_t*)&responseDataBlock->dwLength,
                     cb_ctx[CCID_SLOT_INDEX]);
                 responseDataBlock->bStatus = CCID_COMMANDSTATUS_PROCESSEDWITHOUTERROR |
                                              CCID_ICCSTATUS_PRESENTANDACTIVE;
@@ -364,10 +364,11 @@ void CALLBACK_CCID_XfrBlock(
             if(callbacks[CCID_SLOT_INDEX] != NULL) {
                 callbacks[CCID_SLOT_INDEX]->xfr_datablock_callback(
                     (const uint8_t*)receivedXfrBlock->abData,
-                    receivedXfrBlock->dwLength,
+                    (uint8_t)receivedXfrBlock->dwLength,
                     responseDataBlock->abData,
-                    &responseDataBlock->dwLength,
+                    (uint8_t*)&responseDataBlock->dwLength,
                     cb_ctx[CCID_SLOT_INDEX]);
+
                 responseDataBlock->bStatus = CCID_COMMANDSTATUS_PROCESSEDWITHOUTERROR |
                                              CCID_ICCSTATUS_PRESENTANDACTIVE;
             } else {

--- a/targets/furi_hal_include/furi_hal_usb_ccid.h
+++ b/targets/furi_hal_include/furi_hal_usb_ccid.h
@@ -17,12 +17,12 @@ typedef struct {
 } FuriHalUsbCcidConfig;
 
 typedef struct {
-    void (*icc_power_on_callback)(uint8_t* dataBlock, uint32_t* dataBlockLen, void* context);
+    void (*icc_power_on_callback)(uint8_t* dataBlock, uint8_t* dataBlockLen, void* context);
     void (*xfr_datablock_callback)(
         const uint8_t* pcToReaderDataBlock,
-        uint32_t pcToReaderDataBlockLen,
+        uint8_t pcToReaderDataBlockLen,
         uint8_t* readerToPcDataBlock,
-        uint32_t* readerToPcDataBlockLen,
+        uint8_t* readerToPcDataBlockLen,
         void* context);
 } CcidCallbacks;
 


### PR DESCRIPTION
# What's new

The CCID stack  currently implemented in Flipper operates in short APDU mode, which supports only 256 bytes for the data length. The buffer on furi_hal_usb_ccid.c already supports this size - however the data types on the callback functions are still using uint32_t instead of uint8_t. This PR updates the callbacks so they use uint8_t as the proper type for the data length

# Verification 

 - Start the CCID app and verify that the device was successfully detected as a CCID device with the command:

> opensc-tool --atr

The command above shoud return `3b:00`
- Check that example 1 works with:

> opensc-tool --send-apdu 01:01:00:00

The command above should return

```
Received (SW1=0x90, SW2=0x00)`
```

- Check that example 2 works with:

> opensc-tool --send-apdu 01:02:00:00

The command above should return:

```
Received (SW1=0x90, SW2=0x01):
62 63 bc
```

- Check that example 3 works with:

> opensc-tool --send-apdu 01:03:00:00:02:CA:FE

The command above should return:

```
Received (SW1=0x90, SW2=0x02):
CA FE ..
```

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
