### PR TITLE
[FL-3808] Fix renaming directories with dots in archive

### DIFF
--- a/applications/main/archive/scenes/archive_scene_rename.c
+++ b/applications/main/archive/scenes/archive_scene_rename.c
@@ -18,13 +18,18 @@ void archive_scene_rename_on_enter(void* context) {
 
     TextInput* text_input = archive->text_input;
     ArchiveFile_t* current = archive_get_current_file(archive->browser);
+    const bool is_file = current->type != ArchiveFileTypeFolder;
 
     FuriString* filename;
     filename = furi_string_alloc();
-    path_extract_filename(current->path, filename, true);
+    path_extract_filename(current->path, filename, is_file);
     strlcpy(archive->text_store, furi_string_get_cstr(filename), MAX_NAME_LEN);
 
-    path_extract_extension(current->path, archive->file_extension, MAX_EXT_LEN);
+    if(is_file) {
+        path_extract_extension(current->path, archive->file_extension, MAX_EXT_LEN);
+    } else {
+        memset(archive->file_extension, 0, sizeof(archive->file_extension));
+    }
 
     text_input_set_header_text(text_input, "Rename:");
 


### PR DESCRIPTION
# What's new

-  Fix renaming directories with dots in archive

# Verification 

1. Create a directory on Flipper's SD card with a name containing one or more dots (e.g. `/ext/my.awesome.dir`)
2. Go to archive (press `down` then `left`) and rename this directory. The result should be as expected (`.dir` should NOT be treated as file extension).
3. Rename any regular file and observe the change in behaviour (characters after the last dot MUST be treated as an extension).

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
