### PR TITLE
[FL-3844] Loader: fix crash on "locked via cli loader"

### DIFF
--- a/applications/services/loader/loader.c
+++ b/applications/services/loader/loader.c
@@ -428,13 +428,19 @@ static LoaderStatus loader_do_start_by_name(
     do {
         // check lock
         if(loader_do_is_locked(loader)) {
-            const char* current_thread_name =
-                furi_thread_get_name(furi_thread_get_id(loader->app.thread));
-            status = loader_make_status_error(
-                LoaderStatusErrorAppStarted,
-                error_message,
-                "Loader is locked, please close the \"%s\" first",
-                current_thread_name);
+            if(loader->app.thread == (FuriThread*)LOADER_MAGIC_THREAD_VALUE) {
+                status = loader_make_status_error(
+                    LoaderStatusErrorAppStarted, error_message, "Loader is locked");
+            } else {
+                const char* current_thread_name =
+                    furi_thread_get_name(furi_thread_get_id(loader->app.thread));
+
+                status = loader_make_status_error(
+                    LoaderStatusErrorAppStarted,
+                    error_message,
+                    "Loader is locked, please close the \"%s\" first",
+                    current_thread_name);
+            }
             break;
         }
 


### PR DESCRIPTION
# What's new

- No more crashes if loader was locked via CLI

# Verification 

- Launch CLI, select any app in flipper menu, do not open, launch rfid read and click ok on flipper same time

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
