### PR TITLE
Furi: Fix EventLoop state persisting on same thread after free

### DIFF
--- a/applications/debug/unit_tests/unit_test_api_table_i.h
+++ b/applications/debug/unit_tests/unit_test_api_table_i.h
@@ -3,6 +3,7 @@
 #include <nfc/protocols/iso15693_3/iso15693_3_poller_i.h>
 #include <FreeRTOS.h>
 #include <FreeRTOS-Kernel/include/queue.h>
+#include <task.h>
 
 #include <rpc/rpc_i.h>
 #include <flipper.pb.h>
@@ -18,6 +19,11 @@ static constexpr auto unit_tests_api_table = sort(create_array_t<sym_entry>(
     API_METHOD(iso15693_3_poller_get_data, const Iso15693_3Data*, (Iso15693_3Poller*)),
     API_METHOD(rpc_system_storage_get_error, PB_CommandStatus, (FS_Error)),
     API_METHOD(xQueueSemaphoreTake, BaseType_t, (QueueHandle_t, TickType_t)),
+    API_METHOD(
+        xTaskGenericNotify,
+        BaseType_t,
+        (TaskHandle_t, UBaseType_t, uint32_t, eNotifyAction, uint32_t*)),
+    API_METHOD(xTaskGetCurrentTaskHandle, TaskHandle_t, ()),
     API_METHOD(vQueueDelete, void, (QueueHandle_t)),
     API_METHOD(
         xQueueGenericCreateStatic,

--- a/furi/core/event_loop.c
+++ b/furi/core/event_loop.c
@@ -110,6 +110,9 @@ void furi_event_loop_free(FuriEventLoop* instance) {
     furi_check(instance->thread_id == furi_thread_get_current_id());
 
     FuriEventLoopTree_clear(instance->tree);
+    xTaskNotifyStateClearIndexed(instance->thread_id, FURI_EVENT_LOOP_FLAG_NOTIFY_INDEX);
+    ulTaskNotifyValueClearIndexed(
+        instance->thread_id, FURI_EVENT_LOOP_FLAG_NOTIFY_INDEX, 0xffffffff);
     free(instance);
 }
 

--- a/furi/core/event_loop.c
+++ b/furi/core/event_loop.c
@@ -1,6 +1,7 @@
 #include "event_loop_i.h"
 #include "message_queue_i.h"
 
+#include "log.h"
 #include "check.h"
 #include "thread.h"
 
@@ -9,6 +10,8 @@
 
 #include <FreeRTOS.h>
 #include <task.h>
+
+#define TAG "FuriEventLoop"
 
 struct FuriEventLoopItem {
     // Source
@@ -99,8 +102,14 @@ FuriEventLoop* furi_event_loop_alloc(void) {
     FuriEventLoop* instance = malloc(sizeof(FuriEventLoop));
 
     instance->thread_id = furi_thread_get_current_id();
+
     FuriEventLoopTree_init(instance->tree);
     WaitingList_init(instance->waiting_list);
+
+    // Clear notification state and value
+    xTaskNotifyStateClearIndexed(instance->thread_id, FURI_EVENT_LOOP_FLAG_NOTIFY_INDEX);
+    ulTaskNotifyValueClearIndexed(
+        instance->thread_id, FURI_EVENT_LOOP_FLAG_NOTIFY_INDEX, 0xFFFFFFFF);
 
     return instance;
 }
@@ -110,9 +119,14 @@ void furi_event_loop_free(FuriEventLoop* instance) {
     furi_check(instance->thread_id == furi_thread_get_current_id());
 
     FuriEventLoopTree_clear(instance->tree);
-    xTaskNotifyStateClearIndexed(instance->thread_id, FURI_EVENT_LOOP_FLAG_NOTIFY_INDEX);
-    ulTaskNotifyValueClearIndexed(
-        instance->thread_id, FURI_EVENT_LOOP_FLAG_NOTIFY_INDEX, 0xffffffff);
+
+    uint32_t flags = 0;
+    BaseType_t ret = xTaskNotifyWaitIndexed(
+        FURI_EVENT_LOOP_FLAG_NOTIFY_INDEX, 0, FuriEventLoopFlagAll, &flags, 0);
+    if(ret == pdTRUE) {
+        FURI_LOG_D(TAG, "Some events was not processed: 0x%lx", flags);
+    }
+
     free(instance);
 }
 


### PR DESCRIPTION
# What's new

- Freeing view dispatcher then making new one on same thread would stop it instantly
- This clears event loop notify state on free, so new view dispatcher / event loop is not affected by previous one
- Not sure if this is fine in terms of rtos and safety, but it did resolve the symptoms

# Verification 

- Free view dispatcher and alloc new one on same thread, both will run correctly

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
