### PR TITLE
[FL-3854] Disable logging in mjs +2k free flash

### DIFF
--- a/lib/mjs/common/platforms/platform_flipper.h
+++ b/lib/mjs/common/platforms/platform_flipper.h
@@ -37,9 +37,8 @@
 typedef struct stat cs_stat_t;
 #define DIRSEP '/'
 
-#ifndef CS_ENABLE_STDIO
+#undef CS_ENABLE_STDIO
 #define CS_ENABLE_STDIO 0
-#endif
 
 #ifndef MG_ENABLE_FILESYSTEM
 #define MG_ENABLE_FILESYSTEM 0

--- a/lib/mjs/mjs_internal.h
+++ b/lib/mjs/mjs_internal.h
@@ -48,7 +48,7 @@
 #endif
 
 #ifndef CS_ENABLE_STDIO
-#define CS_ENABLE_STDIO 0
+#define CS_ENABLE_STDIO 1
 #endif
 
 #include "common/cs_dbg.h"

--- a/lib/mjs/mjs_internal.h
+++ b/lib/mjs/mjs_internal.h
@@ -48,7 +48,7 @@
 #endif
 
 #ifndef CS_ENABLE_STDIO
-#define CS_ENABLE_STDIO 1
+#define CS_ENABLE_STDIO 0
 #endif
 
 #include "common/cs_dbg.h"


### PR DESCRIPTION
by @hedger 

# What's new

- [FL-3854]  Disable logging to free up 2k flash space

# Verification 

- Test JS runner

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-3854]: https://flipperzero.atlassian.net/browse/FL-3854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ