### PR TITLE
[FL-3853] SubGhz: fix Missed the "Deleted" screen when deleting RAW Subghz

### DIFF
--- a/applications/main/subghz/scenes/subghz_scene_delete_raw.c
+++ b/applications/main/subghz/scenes/subghz_scene_delete_raw.c
@@ -58,13 +58,7 @@ bool subghz_scene_delete_raw_on_event(void* context, SceneManagerEvent event) {
         if(event.event == SubGhzCustomEventSceneDeleteRAW) {
             furi_string_set(subghz->file_path_tmp, subghz->file_path);
             if(subghz_delete_file(subghz)) {
-                if(subghz_rx_key_state_get(subghz) != SubGhzRxKeyStateRAWLoad) {
-                    subghz_rx_key_state_set(subghz, SubGhzRxKeyStateIDLE);
-                    scene_manager_next_scene(subghz->scene_manager, SubGhzSceneDeleteSuccess);
-                } else {
-                    scene_manager_next_scene(subghz->scene_manager, SubGhzSceneSaved);
-                }
-
+                scene_manager_next_scene(subghz->scene_manager, SubGhzSceneDeleteSuccess);
             } else {
                 scene_manager_search_and_switch_to_previous_scene(
                     subghz->scene_manager, SubGhzSceneStart);

--- a/applications/main/subghz/scenes/subghz_scene_delete_success.c
+++ b/applications/main/subghz/scenes/subghz_scene_delete_success.c
@@ -26,14 +26,24 @@ bool subghz_scene_delete_success_on_event(void* context, SceneManagerEvent event
 
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == SubGhzCustomEventSceneDeleteSuccess) {
-            if(scene_manager_search_and_switch_to_previous_scene(
-                   subghz->scene_manager, SubGhzSceneReadRAW)) {
-            } else if(scene_manager_search_and_switch_to_previous_scene(
-                          subghz->scene_manager, SubGhzSceneSaved)) {
+            if(subghz_rx_key_state_get(subghz) == SubGhzRxKeyStateRAWLoad) {
+                if(scene_manager_search_and_switch_to_previous_scene(
+                       subghz->scene_manager, SubGhzSceneSaved)) {
+                } else {
+                    scene_manager_search_and_switch_to_previous_scene(
+                        subghz->scene_manager, SubGhzSceneStart);
+                }
             } else {
-                scene_manager_search_and_switch_to_previous_scene(
-                    subghz->scene_manager, SubGhzSceneStart);
+                subghz_rx_key_state_set(subghz, SubGhzRxKeyStateIDLE);
+
+                if(scene_manager_search_and_switch_to_previous_scene(
+                       subghz->scene_manager, SubGhzSceneReadRAW)) {
+                } else {
+                    scene_manager_search_and_switch_to_previous_scene(
+                        subghz->scene_manager, SubGhzSceneStart);
+                }
             }
+
             return true;
         }
     }

--- a/applications/main/subghz/scenes/subghz_scene_saved.c
+++ b/applications/main/subghz/scenes/subghz_scene_saved.c
@@ -8,6 +8,7 @@ void subghz_scene_saved_on_enter(void* context) {
             subghz_rx_key_state_set(subghz, SubGhzRxKeyStateRAWLoad);
             scene_manager_next_scene(subghz->scene_manager, SubGhzSceneReadRAW);
         } else {
+            subghz_rx_key_state_set(subghz, SubGhzRxKeyStateRAWLoad);
             scene_manager_next_scene(subghz->scene_manager, SubGhzSceneSavedMenu);
         }
     } else {


### PR DESCRIPTION
# What's new

- [FL-3853] SubGhz: fix Missed the "Deleted" screen when deleting RAW Subghz

# Verification 

- Сheck file deletion flow

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-3853]: https://flipperzero.atlassian.net/browse/FL-3853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ