### PR TITLE
[FL-3856] Don't crash on reading weird cards

### DIFF
--- a/applications/main/nfc/helpers/protocol_support/mf_plus/mf_plus.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_plus/mf_plus.c
@@ -41,8 +41,7 @@ static NfcCommand nfc_scene_read_poller_callback_mf_plus(NfcGenericEvent event, 
         view_dispatcher_send_custom_event(instance->view_dispatcher, NfcCustomEventPollerSuccess);
         command = NfcCommandStop;
     } else if(mf_plus_event->type == MfPlusPollerEventTypeReadFailed) {
-        view_dispatcher_send_custom_event(instance->view_dispatcher, NfcCustomEventPollerFailure);
-        command = NfcCommandStop;
+        command = NfcCommandReset;
     }
 
     return command;

--- a/lib/nfc/protocols/mf_plus/mf_plus_i.c
+++ b/lib/nfc/protocols/mf_plus/mf_plus_i.c
@@ -4,13 +4,15 @@
     MF_PLUS_FFF_PICC_PREFIX " " \
                             "Version"
 
+#define MF_PLUS_T1_TK_VALUE_LEN 7
+
 #define MF_PLUS_FFF_SECURITY_LEVEL_KEY "Security Level"
 #define MF_PLUS_FFF_CARD_TYPE_KEY "Card Type"
 #define MF_PLUS_FFF_MEMORY_SIZE_KEY "Memory Size"
 
 #define TAG "MfPlus"
 
-const uint8_t mf_plus_ats_t1_tk_values[][7] = {
+const uint8_t mf_plus_ats_t1_tk_values[][MF_PLUS_T1_TK_VALUE_LEN] = {
     {0xC1, 0x05, 0x2F, 0x2F, 0x00, 0x35, 0xC7}, // Mifare Plus S
     {0xC1, 0x05, 0x2F, 0x2F, 0x01, 0xBC, 0xD6}, // Mifare Plus X
     {0xC1, 0x05, 0x2F, 0x2F, 0x00, 0xF6, 0xD1}, // Mifare Plus SE
@@ -96,6 +98,10 @@ MfPlusError
     furi_assert(mf_plus_data);
 
     MfPlusError error = MfPlusErrorProtocol;
+
+    if(simple_array_get_count(iso4_data->ats_data.t1_tk) != MF_PLUS_T1_TK_VALUE_LEN) {
+        return MfPlusErrorProtocol;
+    }
 
     switch(iso4_data->iso14443_3a_data->sak) {
     case 0x08:


### PR DESCRIPTION
# What's new

- Reading emulated FeliCa cards on iOS devices no longer triggers a crash
- Fix crash on exit from read Mf Plus

# Verification 

- Check that Mifare Plus cards still get read
- Check that reading cards that have previously crashed Flipper doesn't crash it now
- Flipper doesn't crash on exit from read Mf Plus

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
