### PR TITLE
Debug: backup openocd work area, fix crash after fresh debugger connect and continue

### DIFF
--- a/scripts/debug/stm32wbx.cfg
+++ b/scripts/debug/stm32wbx.cfg
@@ -44,7 +44,7 @@ if {[using_jtag]} {
 set _TARGETNAME $_CHIPNAME.cpu
 target create $_TARGETNAME cortex_m -endian $_ENDIAN -dap $_CHIPNAME.dap
 
-$_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size $_WORKAREASIZE -work-area-backup 0
+$_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size $_WORKAREASIZE -work-area-backup 1
 
 set _FLASHNAME $_CHIPNAME.flash
 flash bank $_FLASHNAME stm32l4x 0 0 0 0 $_TARGETNAME


### PR DESCRIPTION
# What's new

- Debug: backup openocd work area, fix crash after fresh debugger connect and continue

# Verification 

- Flash firmware
- `./fbt debug` and then disconnect
- Reconnect USB - no crash should happen

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
