### PR TITLE
FuriHal: static platform ID used in BLE MAC address

### DIFF
--- a/targets/f7/furi_hal/furi_hal_version.c
+++ b/targets/f7/furi_hal/furi_hal_version.c
@@ -12,8 +12,7 @@
 
 #define FURI_HAL_VERSION_OTP_HEADER_MAGIC (0xBABE)
 #define FURI_HAL_VERSION_OTP_ADDRESS (OTP_AREA_BASE)
-
-#define FURI_HAL_VERSION_DEVICE_ID (0x26u)
+#define FURI_HAL_VERSION_PLATFORM_ID (0x0080e126)
 
 /** OTP V0 Structure: prototypes and early EVT */
 typedef struct {
@@ -108,13 +107,13 @@ static void furi_hal_version_set_name(const char* name) {
 
     // BLE Mac address
     uint32_t udn = LL_FLASH_GetUDN();
-    uint32_t company_id = LL_FLASH_GetSTCompanyID();
-    furi_hal_version.ble_mac[0] = (uint8_t)(udn & 0x000000FF);
-    furi_hal_version.ble_mac[1] = (uint8_t)((udn & 0x0000FF00) >> 8);
-    furi_hal_version.ble_mac[2] = (uint8_t)((udn & 0x00FF0000) >> 16);
-    furi_hal_version.ble_mac[3] = FURI_HAL_VERSION_DEVICE_ID;
-    furi_hal_version.ble_mac[4] = (uint8_t)(company_id & 0x000000FF);
-    furi_hal_version.ble_mac[5] = (uint8_t)((company_id & 0x0000FF00) >> 8);
+    uint32_t platform_id = FURI_HAL_VERSION_PLATFORM_ID;
+    furi_hal_version.ble_mac[0] = (uint8_t)((udn >> 0) & 0xFF);
+    furi_hal_version.ble_mac[1] = (uint8_t)((udn >> 8) & 0xFF);
+    furi_hal_version.ble_mac[2] = (uint8_t)((udn >> 16) & 0xFF);
+    furi_hal_version.ble_mac[3] = (uint8_t)((platform_id >> 0) & 0xFF);
+    furi_hal_version.ble_mac[4] = (uint8_t)((platform_id >> 8) & 0xFF);
+    furi_hal_version.ble_mac[5] = (uint8_t)((platform_id >> 16) & 0xFF);
 }
 
 static void furi_hal_version_load_otp_default(void) {

--- a/targets/f7/furi_hal/furi_hal_version.c
+++ b/targets/f7/furi_hal/furi_hal_version.c
@@ -10,8 +10,10 @@
 
 #define TAG "FuriHalVersion"
 
-#define FURI_HAL_VERSION_OTP_HEADER_MAGIC 0xBABE
-#define FURI_HAL_VERSION_OTP_ADDRESS OTP_AREA_BASE
+#define FURI_HAL_VERSION_OTP_HEADER_MAGIC (0xBABE)
+#define FURI_HAL_VERSION_OTP_ADDRESS (OTP_AREA_BASE)
+
+#define FURI_HAL_VERSION_DEVICE_ID (0x26u)
 
 /** OTP V0 Structure: prototypes and early EVT */
 typedef struct {
@@ -107,11 +109,10 @@ static void furi_hal_version_set_name(const char* name) {
     // BLE Mac address
     uint32_t udn = LL_FLASH_GetUDN();
     uint32_t company_id = LL_FLASH_GetSTCompanyID();
-    uint32_t device_id = LL_FLASH_GetDeviceID();
     furi_hal_version.ble_mac[0] = (uint8_t)(udn & 0x000000FF);
     furi_hal_version.ble_mac[1] = (uint8_t)((udn & 0x0000FF00) >> 8);
     furi_hal_version.ble_mac[2] = (uint8_t)((udn & 0x00FF0000) >> 16);
-    furi_hal_version.ble_mac[3] = (uint8_t)device_id;
+    furi_hal_version.ble_mac[3] = FURI_HAL_VERSION_DEVICE_ID;
     furi_hal_version.ble_mac[4] = (uint8_t)(company_id & 0x000000FF);
     furi_hal_version.ble_mac[5] = (uint8_t)((company_id & 0x0000FF00) >> 8);
 }


### PR DESCRIPTION
# What's new

- FuriHal: fixed platform ID used in BLE MAC address

# Verification 

- Last 3 octets of BLE address are always fixed
- 4th octet of `p/x furi_hal_version.ble_mac` will be 0x26 on flippers manufactured in 2023+

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
