### PR TITLE
Updater: Fix double dir cleanup

### DIFF
--- a/applications/system/updater/util/update_task_worker_backup.c
+++ b/applications/system/updater/util/update_task_worker_backup.c
@@ -96,8 +96,6 @@ static void update_task_cleanup_resources(UpdateTask* update_task) {
                         storage_error_get_desc(result));
                 }
                 furi_string_free(file_path);
-            } else if(entry_ptr->type == ResourceManifestEntryTypeDirectory) {
-                n_dir_entries++;
             }
         }
 


### PR DESCRIPTION
# What's new

- `n_dir_entries` already counted in code block above

# Verification 

- dir cleanup goes to 100%, not 50%

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
