### PR TITLE
NFC ISO14443a-4 I-Block Chaining support

### DIFF
--- a/lib/nfc/helpers/iso14443_4_layer.c
+++ b/lib/nfc/helpers/iso14443_4_layer.c
@@ -2,8 +2,12 @@
 
 #include <furi.h>
 
+#define TAG "iso14443_4_layer"
+
 #define ISO14443_4_BLOCK_PCB (1U << 1)
 #define ISO14443_4_BLOCK_PCB_I (0U)
+#define ISO14443_4_BLOCK_PCB_I_MASK (0x0FU)
+#define ISO14443_4_BLOCK_PCB_I_CHAINING (1U << 4)
 #define ISO14443_4_BLOCK_PCB_R (5U << 5)
 #define ISO14443_4_BLOCK_PCB_S (3U << 6)
 
@@ -12,7 +16,8 @@ struct Iso14443_4Layer {
     uint8_t pcb_prev;
 };
 
-static inline void iso14443_4_layer_update_pcb(Iso14443_4Layer* instance) {
+void iso14443_4_layer_update_pcb(Iso14443_4Layer* instance) {
+    instance->pcb &= ISO14443_4_BLOCK_PCB_I_MASK;
     instance->pcb_prev = instance->pcb;
     instance->pcb ^= (uint8_t)0x01;
 }
@@ -32,6 +37,12 @@ void iso14443_4_layer_free(Iso14443_4Layer* instance) {
 void iso14443_4_layer_reset(Iso14443_4Layer* instance) {
     furi_assert(instance);
     instance->pcb = ISO14443_4_BLOCK_PCB_I | ISO14443_4_BLOCK_PCB;
+}
+
+void iso14443_4_layer_r_ack(Iso14443_4Layer* instance, BitBuffer* block_data) {
+    furi_assert(instance);
+    instance->pcb = ISO14443_4_BLOCK_PCB_R | (instance->pcb & ~ISO14443_4_BLOCK_PCB_I_CHAINING);
+    bit_buffer_append_byte(block_data, instance->pcb);
 }
 
 void iso14443_4_layer_encode_block(
@@ -54,11 +65,39 @@ bool iso14443_4_layer_decode_block(
 
     bool ret = false;
 
-    do {
-        if(!bit_buffer_starts_with_byte(block_data, instance->pcb_prev)) break;
-        bit_buffer_copy_right(output_data, block_data, 1);
-        ret = true;
-    } while(false);
+    if(iso14443_4_layer_is_block_chaining(instance, block_data)) {
+        do {
+            bit_buffer_copy_right(output_data, block_data, 1);
+            ret = true;
+        } while(false);
+    } else {
+        do {
+            if(!bit_buffer_starts_with_byte(block_data, instance->pcb_prev)) break;
+            size_t used = bit_buffer_get_size_bytes(output_data);
+            size_t capacity = bit_buffer_get_capacity_bytes(output_data);
+            size_t available = capacity - used;
+            size_t needed = bit_buffer_get_size_bytes(block_data);
+            if(needed > available) break;
+            FURI_LOG_D(
+                TAG,
+                "used=%zu, capacity=%zu, available=%zu, needed=%zu",
+                used,
+                capacity,
+                available,
+                needed);
+
+            bit_buffer_append_right(output_data, block_data, 1);
+            ret = true;
+        } while(false);
+    }
 
     return ret;
+}
+
+bool iso14443_4_layer_is_block_chaining(
+    const Iso14443_4Layer* instance,
+    const BitBuffer* block_data) {
+    furi_assert(instance);
+    return (bit_buffer_starts_with_byte(
+        block_data, instance->pcb_prev | ISO14443_4_BLOCK_PCB_I_CHAINING));
 }

--- a/lib/nfc/helpers/iso14443_4_layer.h
+++ b/lib/nfc/helpers/iso14443_4_layer.h
@@ -24,6 +24,12 @@ bool iso14443_4_layer_decode_block(
     BitBuffer* output_data,
     const BitBuffer* block_data);
 
+void iso14443_4_layer_update_pcb(Iso14443_4Layer* instance);
+void iso14443_4_layer_r_ack(Iso14443_4Layer* instance, BitBuffer* block_data);
+bool iso14443_4_layer_is_block_chaining(
+    const Iso14443_4Layer* instance,
+    const BitBuffer* block_data);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
# What's new

- Support I-Block Chaining (#3701)


Doesn't actually work `bit_buffer_append_right` fails when the destination is non-empty.  No crash according to the UART logs or the UI, but the flipper freezes in whatever state it was in.  

- Works: `30758 [D][iso14443_4_layer] used=0, capacity=384, available=384, needed=175`
- Fails: `30947 [D][iso14443_4_layer] used=252, capacity=384, available=132, needed=7` (And this is the last line of the UART logs until reboot using Left+Back)

# Verification 

- Read something ISO14443a-4 that does use I-block chaining

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
