### PR TITLE
LFRFID: add DEZ 10 format to EM4100 info screen

### DIFF
--- a/lib/lfrfid/protocols/protocol_em4100.c
+++ b/lib/lfrfid/protocols/protocol_em4100.c
@@ -347,11 +347,13 @@ void protocol_em4100_render_data(ProtocolEM4100* protocol, FuriString* result) {
     uint8_t* data = protocol->data;
     furi_string_printf(
         result,
-        "FC: %03u\n"
-        "Card: %05hu (RF/%hhu)",
+        "FC: %03u Card: %05hu CL:%hhu\n"
+        "DEZ 10: %010lu",
         data[2],
         (uint16_t)((data[3] << 8) | (data[4])),
-        protocol->clock_per_bit);
+        protocol->clock_per_bit,
+        (uint32_t)((data[2] << 16) | (data[3] << 8) | (data[4]))
+    );
 };
 
 const ProtocolBase protocol_em4100 = {


### PR DESCRIPTION
# What's new

- DEZ 10 is a popular representation of EM4100' ID and usually printed/embossed on original keyfobs.

# Verification 

- Reading or opening saved EM4100 card should now show DEZ 10 representation in addition to existing FC+Card.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
