### PR TITLE
[FL-3704] Updater: reset various debug flags on production build flash

### DIFF
--- a/applications/system/updater/util/update_task_worker_flasher.c
+++ b/applications/system/updater/util/update_task_worker_flasher.c
@@ -348,6 +348,8 @@ int32_t update_task_worker_flash_writer(void* context) {
         // Production
         furi_hal_rtc_set_log_level(FuriLogLevelDefault);
         furi_hal_rtc_reset_flag(FuriHalRtcFlagDebug);
+        furi_hal_rtc_reset_flag(FuriHalRtcFlagLegacySleep);
+        furi_hal_rtc_set_heap_track_mode(FuriHalRtcHeapTrackModeNone);
 #endif
         update_task_set_progress(update_task, UpdateTaskStageCompleted, 100);
         success = true;


### PR DESCRIPTION
# What's new

- Updater: reset various debug flags on production build flash

# Verification 

- Set debug, logging, heap trace system settings
- `./fbt flash_usb_full`
- Check settings: there should be no changes in settings
- `./fbt flash_usb_full COMPACT=1 DEBUG=0`
- Check system settings: debug options should return to default values

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
