### PR TITLE
[FL-3870] Desktop: allow to close blocking bad sd animation

### DIFF
--- a/applications/services/desktop/animations/animation_manager.c
+++ b/applications/services/desktop/animations/animation_manager.c
@@ -47,13 +47,13 @@ struct AnimationManager {
     int32_t freezed_animation_time_left;
     ViewStack* view_stack;
 
-    bool dummy_mode;
-    bool blocking_shown_url;
-    bool blocking_shown_sd_bad;
-    bool blocking_shown_no_db;
-    bool blocking_shown_sd_ok;
-    bool levelup_pending;
-    bool levelup_active;
+    bool dummy_mode : 1;
+    bool blocking_shown_url : 1;
+    bool blocking_shown_sd_bad : 1;
+    bool blocking_shown_no_db : 1;
+    bool blocking_shown_sd_ok : 1;
+    bool levelup_pending : 1;
+    bool levelup_active : 1;
 };
 
 static StorageAnimation*

--- a/applications/services/desktop/animations/animation_manager.c
+++ b/applications/services/desktop/animations/animation_manager.c
@@ -32,11 +32,6 @@ typedef enum {
 } AnimationManagerState;
 
 struct AnimationManager {
-    bool sd_show_url;
-    bool sd_shown_no_db;
-    bool sd_shown_sd_ok;
-    bool levelup_pending;
-    bool levelup_active;
     AnimationManagerState state;
     FuriPubSubSubscription* pubsub_subscription_storage;
     FuriPubSubSubscription* pubsub_subscription_dolphin;
@@ -51,7 +46,14 @@ struct AnimationManager {
     FuriString* freezed_animation_name;
     int32_t freezed_animation_time_left;
     ViewStack* view_stack;
+
     bool dummy_mode;
+    bool blocking_shown_url;
+    bool blocking_shown_sd_bad;
+    bool blocking_shown_no_db;
+    bool blocking_shown_sd_ok;
+    bool levelup_pending;
+    bool levelup_active;
 };
 
 static StorageAnimation*
@@ -214,27 +216,31 @@ static bool animation_manager_check_blocking(AnimationManager* animation_manager
     FS_Error sd_status = storage_sd_status(storage);
 
     if(sd_status == FSE_INTERNAL) {
-        blocking_animation = animation_storage_find_animation(BAD_SD_ANIMATION_NAME);
-        furi_assert(blocking_animation);
+        if(!animation_manager->blocking_shown_sd_bad) {
+            blocking_animation = animation_storage_find_animation(BAD_SD_ANIMATION_NAME);
+            furi_assert(blocking_animation);
+            animation_manager->blocking_shown_sd_bad = true;
+        }
     } else if(sd_status == FSE_NOT_READY) {
-        animation_manager->sd_shown_sd_ok = false;
-        animation_manager->sd_shown_no_db = false;
+        animation_manager->blocking_shown_sd_bad = false;
+        animation_manager->blocking_shown_sd_ok = false;
+        animation_manager->blocking_shown_no_db = false;
     } else if(sd_status == FSE_OK) {
-        if(!animation_manager->sd_shown_sd_ok) {
+        if(!animation_manager->blocking_shown_sd_ok) {
             blocking_animation = animation_storage_find_animation(SD_OK_ANIMATION_NAME);
             furi_assert(blocking_animation);
-            animation_manager->sd_shown_sd_ok = true;
-        } else if(!animation_manager->sd_shown_no_db) {
+            animation_manager->blocking_shown_sd_ok = true;
+        } else if(!animation_manager->blocking_shown_no_db) {
             if(!storage_file_exists(storage, EXT_PATH("Manifest"))) {
                 blocking_animation = animation_storage_find_animation(NO_DB_ANIMATION_NAME);
                 furi_assert(blocking_animation);
-                animation_manager->sd_shown_no_db = true;
-                animation_manager->sd_show_url = true;
+                animation_manager->blocking_shown_no_db = true;
+                animation_manager->blocking_shown_url = true;
             }
-        } else if(animation_manager->sd_show_url) {
+        } else if(animation_manager->blocking_shown_url) {
             blocking_animation = animation_storage_find_animation(URL_ANIMATION_NAME);
             furi_assert(blocking_animation);
-            animation_manager->sd_show_url = false;
+            animation_manager->blocking_shown_url = false;
         }
     }
 
@@ -299,7 +305,7 @@ AnimationManager* animation_manager_alloc(void) {
         dolphin_get_pubsub(dolphin), animation_manager_check_blocking_callback, animation_manager);
     furi_record_close(RECORD_DOLPHIN);
 
-    animation_manager->sd_shown_sd_ok = true;
+    animation_manager->blocking_shown_sd_ok = true;
     if(!animation_manager_check_blocking(animation_manager)) {
         animation_manager_start_new_idle(animation_manager);
     }


### PR DESCRIPTION
# What's new

- Desktop: allow to close blocking bad sd animation

# Verification 

- Insert bad sd(fully erased or damaged)
- press right to close animation

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
