### PR TITLE
CCID: Add CCIDWorker

### DIFF
--- a/applications/debug/ccid_test/ccid_test_app.c
+++ b/applications/debug/ccid_test/ccid_test_app.c
@@ -133,8 +133,8 @@ void handle_instruction_01(ISO7816_Response_APDU* responseAPDU) {
 void handle_instruction_02(
     uint8_t p1,
     uint8_t p2,
-    uint8_t lc,
-    uint8_t le,
+    uint16_t lc,
+    uint16_t le,
     ISO7816_Response_APDU* responseAPDU) {
     if(p1 == 0 && p2 == 0 && lc == 0 && le >= 2) {
         responseAPDU->Data[0] = 0x62;
@@ -153,7 +153,11 @@ void handle_instruction_02(
 //Instruction 3: sends a command with a body with two bytes, receives a response with no bytes
 //APDU example: 0x01:0x03:0x00:0x00:0x02:CA:FE
 //response SW1=0x90, SW2=0x00
-void handle_instruction_03(uint8_t p1, uint8_t p2, uint8_t lc, ISO7816_Response_APDU* responseAPDU) {
+void handle_instruction_03(
+    uint8_t p1,
+    uint8_t p2,
+    uint16_t lc,
+    ISO7816_Response_APDU* responseAPDU) {
     if(p1 == 0 && p2 == 0 && lc == 2) {
         responseAPDU->DataLen = 0;
         iso7816_set_response(responseAPDU, ISO7816_RESPONSE_OK);
@@ -170,8 +174,8 @@ void handle_instruction_03(uint8_t p1, uint8_t p2, uint8_t lc, ISO7816_Response_
 void handle_instruction_04(
     uint8_t p1,
     uint8_t p2,
-    uint8_t lc,
-    uint8_t le,
+    uint16_t lc,
+    uint16_t le,
     const uint8_t* commandApduDataBuffer,
     ISO7816_Response_APDU* responseAPDU) {
     if(p1 == 0 && p2 == 0 && lc > 0 && le > 0 && le >= lc) {

--- a/applications/debug/ccid_test/ccid_test_app.c
+++ b/applications/debug/ccid_test/ccid_test_app.c
@@ -255,8 +255,8 @@ int32_t ccid_test_app(void* p) {
     furi_hal_usb_unlock();
 
     furi_check(furi_hal_usb_set_config(&usb_ccid, &app->ccid_cfg) == true);
-    furi_hal_ccid_set_callbacks((CcidCallbacks*)&ccid_cb, NULL);
-    furi_hal_ccid_ccid_insert_smartcard();
+    furi_hal_usb_ccid_set_callbacks((CcidCallbacks*)&ccid_cb, NULL);
+    furi_hal_usb_ccid_insert_smartcard();
 
     iso7816_set_callbacks((Iso7816Callbacks*)&iso87816_cb);
 
@@ -278,7 +278,7 @@ int32_t ccid_test_app(void* p) {
 
     //tear down USB
     furi_hal_usb_set_config(usb_mode_prev, NULL);
-    furi_hal_ccid_set_callbacks(NULL, NULL);
+    furi_hal_usb_ccid_set_callbacks(NULL, NULL);
 
     iso7816_set_callbacks(NULL);
 

--- a/applications/debug/ccid_test/ccid_test_app.c
+++ b/applications/debug/ccid_test/ccid_test_app.c
@@ -253,8 +253,10 @@ int32_t ccid_test_app(void* p) {
 
     FuriHalUsbInterface* usb_mode_prev = furi_hal_usb_get_config();
     furi_hal_usb_unlock();
-    furi_hal_ccid_set_callbacks((CcidCallbacks*)&ccid_cb, NULL);
+
     furi_check(furi_hal_usb_set_config(&usb_ccid, &app->ccid_cfg) == true);
+    furi_hal_ccid_set_callbacks((CcidCallbacks*)&ccid_cb, NULL);
+    furi_hal_ccid_ccid_insert_smartcard();
 
     iso7816_set_callbacks((Iso7816Callbacks*)&iso87816_cb);
 

--- a/applications/debug/ccid_test/ccid_test_app.c
+++ b/applications/debug/ccid_test/ccid_test_app.c
@@ -279,7 +279,6 @@ int32_t ccid_test_app(void* p) {
     //tear down USB
     furi_hal_usb_ccid_set_callbacks(NULL, NULL);
     furi_hal_usb_set_config(usb_mode_prev, NULL);
-    
 
     iso7816_set_callbacks(NULL);
 

--- a/applications/debug/ccid_test/ccid_test_app.c
+++ b/applications/debug/ccid_test/ccid_test_app.c
@@ -277,8 +277,9 @@ int32_t ccid_test_app(void* p) {
     }
 
     //tear down USB
-    furi_hal_usb_set_config(usb_mode_prev, NULL);
     furi_hal_usb_ccid_set_callbacks(NULL, NULL);
+    furi_hal_usb_set_config(usb_mode_prev, NULL);
+    
 
     iso7816_set_callbacks(NULL);
 

--- a/applications/debug/ccid_test/client/ccid_client.py
+++ b/applications/debug/ccid_test/client/ccid_client.py
@@ -100,12 +100,13 @@ def main():
             small_apdu,
         )
 
-        max_apdu = list(range(0, 0x30))
+        upper_bound = 0xF0
+        max_apdu = list(range(0, upper_bound))
 
         test_apdu(
             connection,
-            "INS 0x04: Lc=0x30, data=max_apdu, Le=0x30. Expect 0x30 bytes data in return",
-            [0x01, 0x04, 0x00, 0x00, 0x30] + max_apdu + [0x30],
+            "INS 0x04: Lc=0x%x, data=max_apdu, Le=0x%x. Expect 0x%x bytes data in return" % (upper_bound, upper_bound, upper_bound),
+            [0x01, 0x04, 0x00, 0x00, upper_bound] + max_apdu + [upper_bound],
             0x90,
             0x00,
             max_apdu,

--- a/applications/debug/ccid_test/client/ccid_client.py
+++ b/applications/debug/ccid_test/client/ccid_client.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # pylint: disable=missing-module-docstring, too-many-arguments, consider-using-f-string, missing-function-docstring
 from smartcard.System import readers
 
@@ -105,7 +106,8 @@ def main():
 
         test_apdu(
             connection,
-            "INS 0x04: Lc=0x%x, data=max_apdu, Le=0x%x. Expect 0x%x bytes data in return" % (upper_bound, upper_bound, upper_bound),
+            "INS 0x04: Lc=0x%x, data=max_apdu, Le=0x%x. Expect 0x%x bytes data in return"
+            % (upper_bound, upper_bound, upper_bound),
             [0x01, 0x04, 0x00, 0x00, upper_bound] + max_apdu + [upper_bound],
             0x90,
             0x00,

--- a/targets/f18/api_symbols.csv
+++ b/targets/f18/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,68.1,,
+Version,+,69.0,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
 Header,+,applications/services/cli/cli.h,,

--- a/targets/f18/api_symbols.csv
+++ b/targets/f18/api_symbols.csv
@@ -1178,9 +1178,6 @@ Function,+,furi_hal_bus_enable,void,FuriHalBus
 Function,+,furi_hal_bus_init_early,void,
 Function,+,furi_hal_bus_is_enabled,_Bool,FuriHalBus
 Function,+,furi_hal_bus_reset,void,FuriHalBus
-Function,+,furi_hal_ccid_ccid_insert_smartcard,void,
-Function,+,furi_hal_ccid_ccid_remove_smartcard,void,
-Function,+,furi_hal_ccid_set_callbacks,void,"CcidCallbacks*, void*"
 Function,+,furi_hal_cdc_get_ctrl_line_state,uint8_t,uint8_t
 Function,+,furi_hal_cdc_get_port_settings,usb_cdc_line_coding*,uint8_t
 Function,+,furi_hal_cdc_receive,int32_t,"uint8_t, uint8_t*, uint16_t"
@@ -1454,6 +1451,9 @@ Function,-,furi_hal_spi_config_init_early,void,
 Function,-,furi_hal_spi_dma_init,void,
 Function,+,furi_hal_spi_release,void,FuriHalSpiBusHandle*
 Function,+,furi_hal_switch,void,void*
+Function,+,furi_hal_usb_ccid_insert_smartcard,void,
+Function,+,furi_hal_usb_ccid_remove_smartcard,void,
+Function,+,furi_hal_usb_ccid_set_callbacks,void,"CcidCallbacks*, void*"
 Function,+,furi_hal_usb_disable,void,
 Function,+,furi_hal_usb_enable,void,
 Function,+,furi_hal_usb_get_config,FuriHalUsbInterface*,

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,68.1,,
+Version,+,69.0,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
@@ -1283,9 +1283,6 @@ Function,+,furi_hal_bus_enable,void,FuriHalBus
 Function,+,furi_hal_bus_init_early,void,
 Function,+,furi_hal_bus_is_enabled,_Bool,FuriHalBus
 Function,+,furi_hal_bus_reset,void,FuriHalBus
-Function,+,furi_hal_ccid_ccid_insert_smartcard,void,
-Function,+,furi_hal_ccid_ccid_remove_smartcard,void,
-Function,+,furi_hal_ccid_set_callbacks,void,"CcidCallbacks*, void*"
 Function,+,furi_hal_cdc_get_ctrl_line_state,uint8_t,uint8_t
 Function,+,furi_hal_cdc_get_port_settings,usb_cdc_line_coding*,uint8_t
 Function,+,furi_hal_cdc_receive,int32_t,"uint8_t, uint8_t*, uint16_t"
@@ -1668,6 +1665,9 @@ Function,+,furi_hal_subghz_stop_async_tx,void,
 Function,+,furi_hal_subghz_tx,_Bool,
 Function,+,furi_hal_subghz_write_packet,void,"const uint8_t*, uint8_t"
 Function,+,furi_hal_switch,void,void*
+Function,+,furi_hal_usb_ccid_insert_smartcard,void,
+Function,+,furi_hal_usb_ccid_remove_smartcard,void,
+Function,+,furi_hal_usb_ccid_set_callbacks,void,"CcidCallbacks*, void*"
 Function,+,furi_hal_usb_disable,void,
 Function,+,furi_hal_usb_enable,void,
 Function,+,furi_hal_usb_get_config,FuriHalUsbInterface*,

--- a/targets/f7/furi_hal/furi_hal_usb_ccid.c
+++ b/targets/f7/furi_hal/furi_hal_usb_ccid.c
@@ -435,15 +435,15 @@ void furi_hal_ccid_send_packet(uint8_t* data, uint8_t len) {
 }
 
 void furi_hal_ccid_send_response(uint8_t* data, uint32_t len) {
-    uint32_t dataToSendLen = len;
-    uint32_t dataIndex = 0;
-    while(dataToSendLen >= CCID_EPSIZE) {
-        furi_hal_ccid_send_packet(&data[dataIndex], CCID_EPSIZE);
-        dataToSendLen = dataToSendLen - CCID_EPSIZE;
-        dataIndex = dataIndex + CCID_EPSIZE;
+    uint32_t data_to_send = len;
+    uint32_t data_index = 0;
+    while(data_to_send >= CCID_EPSIZE) {
+        furi_hal_ccid_send_packet(&data[data_index], CCID_EPSIZE);
+        data_to_send = data_to_send - CCID_EPSIZE;
+        data_index = data_index + CCID_EPSIZE;
     }
 
-    furi_hal_ccid_send_packet(&data[dataIndex], dataToSendLen);
+    furi_hal_ccid_send_packet(&data[data_index], data_to_send);
 }
 
 static void ccid_rx_ep_callback(usbd_device* dev, uint8_t event, uint8_t ep) {

--- a/targets/f7/furi_hal/furi_hal_usb_ccid.c
+++ b/targets/f7/furi_hal/furi_hal_usb_ccid.c
@@ -425,9 +425,9 @@ void furi_hal_ccid_send_packet(uint8_t* data, uint8_t len) {
     }
 }
 
-void furi_hal_ccid_send_response(uint8_t* data, uint8_t len) {
-    int dataToSendLen = len;
-    int dataIndex = 0;
+void furi_hal_ccid_send_response(uint8_t* data, uint32_t len) {
+    uint32_t dataToSendLen = len;
+    uint32_t dataIndex = 0;
     while(dataToSendLen >= CCID_EPSIZE) {
         furi_hal_ccid_send_packet(&data[dataIndex], CCID_EPSIZE);
         dataToSendLen = dataToSendLen - CCID_EPSIZE;

--- a/targets/furi_hal_include/furi_hal_usb_ccid.h
+++ b/targets/furi_hal_include/furi_hal_usb_ccid.h
@@ -1,9 +1,11 @@
 #pragma once
+
 #include "hid_usage_desktop.h"
 #include "hid_usage_button.h"
 #include "hid_usage_keyboard.h"
 #include "hid_usage_consumer.h"
 #include "hid_usage_led.h"
+#include <stdint.h>
 
 #define CCID_SHORT_APDU_SIZE (0xFF)
 
@@ -28,9 +30,17 @@ typedef struct {
         void* context);
 } CcidCallbacks;
 
+/** Set CCID callbacks
+ *
+ * @param      cb       CcidCallbacks instance
+ * @param      context  The context for callbacks
+ */
 void furi_hal_usb_ccid_set_callbacks(CcidCallbacks* cb, void* context);
 
+/** Insert Smart Card */
 void furi_hal_usb_ccid_insert_smartcard(void);
+
+/** Remove Smart Card */
 void furi_hal_usb_ccid_remove_smartcard(void);
 
 #ifdef __cplusplus

--- a/targets/furi_hal_include/furi_hal_usb_ccid.h
+++ b/targets/furi_hal_include/furi_hal_usb_ccid.h
@@ -28,10 +28,10 @@ typedef struct {
         void* context);
 } CcidCallbacks;
 
-void furi_hal_ccid_set_callbacks(CcidCallbacks* cb, void* context);
+void furi_hal_usb_ccid_set_callbacks(CcidCallbacks* cb, void* context);
 
-void furi_hal_ccid_ccid_insert_smartcard(void);
-void furi_hal_ccid_ccid_remove_smartcard(void);
+void furi_hal_usb_ccid_insert_smartcard(void);
+void furi_hal_usb_ccid_remove_smartcard(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This new thread allows for Flipper to receive CCID messages bigger than CCID_EPSIZE by receiving multiple packaged in a row and adding them to the buffer

# What's new

- A new thread was added (CcidWorker)
- CCID now works as a producer-consumer: ccid_tx_ep_callback acts as a producer, adding items into the buffer, while the worker thread removed them once complete
- Allows for CCID data payloads up to 0xF3 to be sent

# Verification 

 - Start CCID Test application
 - Run the ccid_client.py script under applications/debug/ccid_test/client
 - Select the 'Generic USB Smart Card Reader'
 - All tests should pass

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
