### PR TITLE
[FL-3871] Infrared: check for negative timings

### DIFF
--- a/lib/flipper_format/flipper_format_stream.c
+++ b/lib/flipper_format/flipper_format_stream.c
@@ -400,7 +400,11 @@ bool flipper_format_stream_read_value_line(
                     }; break;
                     case FlipperStreamValueUint32: {
                         uint32_t* data = _data;
-                        scan_values = sscanf(furi_string_get_cstr(value), "%" PRIu32, &data[i]);
+                        // Minus sign is allowed in scanf() for unsigned numbers, resulting in unintentionally huge values with no error reported
+                        if(!furi_string_start_with(value, "-")) {
+                            scan_values =
+                                sscanf(furi_string_get_cstr(value), "%" PRIu32, &data[i]);
+                        }
                     }; break;
                     case FlipperStreamValueHexUint64: {
                         uint64_t* data = _data;


### PR DESCRIPTION
# What's new

- Rogue negative timings now result in error.

# Verification 

1. Compile and flash the firmware (external apps are unaffected).
2. Unzip the file [Test.zip](https://github.com/user-attachments/files/16237619/Test.zip) and copy `Test.ir` to `/ext/infrared` on the Flipper.
3. Go to `Infrared -> Saved Remotes` and load `Test`.
4. Press `Button Error`. An error should be displayed, no hangups should occur.
5. Test other operations (Adding buttons, moving, renaming etc). Adding new buttons should work (because they are appended to the end of the file), but everything else should fail.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
