### PR TITLE
VSCode fixes: .gitignore & clangd

### DIFF
--- a/.sublime-project
+++ b/.sublime-project
@@ -6,16 +6,20 @@
         }
     ],
     "settings": {
-      "LSP": {
-         "clangd": {
-            "initializationOptions": {
-                "clangd.compile-commands-dir": "build/latest",
-                "clangd.header-insertion": "never",
-                "clangd.query-driver": "**",
-                "clangd.clang-tidy": true,
-            },
+        "LSP": {
+            "clangd": {
                 "enabled": true,
+                "initializationOptions": {
+                    // Use with toolchain version 39+
+                    // Set `"binary": "custom",` option in LSP-clangd config to use toolchain clangd
+                    // "custom_command": ["toolchain/current/bin/clangd"],
+
+                    "clangd.compile-commands-dir": "build/latest",
+                    "clangd.header-insertion": "never",
+                    "clangd.query-driver": "**/arm-none-eabi-*",
+                    "clangd.clang-tidy": true,
+                },
             },
-      },
+        },
    },
 }

--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -1,5 +1,3 @@
-/c_cpp_properties.json
-/extensions.json
-/launch.json
-/settings.json
-/tasks.json
+*
+!example/
+!ReadMe.md

--- a/.vscode/example/settings.json.tmpl
+++ b/.vscode/example/settings.json.tmpl
@@ -12,7 +12,7 @@
         "SConstruct": "python",
         "*.fam": "python"
     },
-    "clangd.path": "${workspaceFolder}/toolchain/current/bin/clangd@FBT_PLATFORM_EXECUTABLE_EXT@",
+    // "clangd.path": "${workspaceFolder}/toolchain/current/bin/clangd@FBT_PLATFORM_EXECUTABLE_EXT@",
     "clangd.arguments": [
         "--query-driver=**/arm-none-eabi-*",
         "--compile-commands-dir=${workspaceFolder}/build/latest",

--- a/scripts/ufbt/project_template/.vscode/settings.json
+++ b/scripts/ufbt/project_template/.vscode/settings.json
@@ -19,7 +19,7 @@
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter"
     },
-    "clangd.path": "@UFBT_TOOLCHAIN_CLANGD@",
+    // "clangd.path": "@UFBT_TOOLCHAIN_CLANGD@",
     "clangd.arguments": [
         "--query-driver=**/arm-none-eabi-*",
         "--compile-commands-dir=${workspaceFolder}/.vscode",


### PR DESCRIPTION
# What's new

- vscode: temporary disabled toolchain-provided clangd 
- vscode: fine-tuned .gitignore to allow extra untracked files in .vscode folder
- sublime project: updates for clangd support

# Verification 

- deploy .vscode config and check there are no errors for  `furi/core/base.h`

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
