### PR TITLE
Fix: Add missing fclose and va_end calls

### DIFF
--- a/lib/mjs/common/cs_file.c
+++ b/lib/mjs/common/cs_file.c
@@ -41,6 +41,7 @@ char* cs_read_file(const char* path, size_t* size) {
             fseek(fp, 0, SEEK_SET); /* Some platforms might not have rewind(), Oo */
             if(fread(data, 1, *size, fp) != *size) {
                 free(data);
+                fclose(fp);
                 return NULL;
             }
             data[*size] = '\0';

--- a/lib/mjs/mjs_array.c
+++ b/lib/mjs/mjs_array.c
@@ -19,8 +19,11 @@
 static int v_sprintf_s(char* buf, size_t size, const char* fmt, ...) {
     size_t n;
     va_list ap;
+
     va_start(ap, fmt);
     n = c_vsnprintf(buf, size, fmt, ap);
+    va_end(ap);
+
     if(n > size) {
         return size;
     }


### PR DESCRIPTION
# What's new

- Fixed a potential file descriptor leak in `cs_file.c` by adding a missing `fclose` call after a failed `fread`. 
- In `mjs_array.c`, added a missing `va_end` before exit to correctly cleanup the variable argument list.

# Verification 

- In `cs_file.c` code right now is disable. AFAIK
- In `mjs_array.c` by heap

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
