### PR TITLE
Fix .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,3 @@ charset = utf-8
 [*.{cpp,h,c,py,sh}]
 indent_style = space
 indent_size = 4
-
-[{Makefile,*.mk}]
-indent_size = tab


### PR DESCRIPTION
I was ~copying best practices to my project~ exploring firmware, and spotted a typo

# What's new

- Fixed editor config for Makefiles

# Verification 

- IDEs won't alert on this

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
