### PR TITLE
Fix typo in "charge me" screen.

### DIFF
--- a/applications/services/power/power_service/views/power_off.c
+++ b/applications/services/power/power_service/views/power_off.c
@@ -33,7 +33,7 @@ static void power_off_draw_callback(Canvas* canvas, void* _model) {
         elements_button_center(canvas, "OK");
         elements_button_right(canvas, "Hide");
     } else {
-        snprintf(buff, sizeof(buff), "Charge me!\nDont't forget!");
+        snprintf(buff, sizeof(buff), "Charge me!\nDon't forget!");
         elements_multiline_text_aligned(canvas, 70, 23, AlignLeft, AlignTop, buff);
 
         canvas_draw_str_aligned(canvas, 64, 60, AlignCenter, AlignBottom, "Hold a second...");


### PR DESCRIPTION
# What's new

- The low power screen says `Charge me! Dont't forget!`. This change fixes the typo so the text says `Don't forget!`.

# Verification 

- Discharge the Flipper fully then turn it on and see the new message.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
