### PR TITLE
[NFC] Change the plantain last number display from "?" to "X"

### DIFF
--- a/applications/main/nfc/plugins/supported_cards/plantain.c
+++ b/applications/main/nfc/plugins/supported_cards/plantain.c
@@ -230,7 +230,7 @@ static bool plantain_parse(const NfcDevice* device, FuriString* parsed_data) {
         }
 
         furi_string_printf(
-            parsed_data, "\e#Plantain\nNo.: %llu\nBalance: %lu\n", card_number, balance);
+            parsed_data, "\e#Plantain\nNo.: %lluX\nBalance: %lu\n", card_number, balance);
         parsed = true;
     } while(false);
 

--- a/applications/main/nfc/plugins/supported_cards/two_cities.c
+++ b/applications/main/nfc/plugins/supported_cards/two_cities.c
@@ -158,7 +158,7 @@ static bool two_cities_parse(const NfcDevice* device, FuriString* parsed_data) {
 
         furi_string_printf(
             parsed_data,
-            "\e#Troika+Plantain\nPN: %llu?\nPB: %lu rur.\nTN: %lu\nTB: %u rur.\n",
+            "\e#Troika+Plantain\nPN: %lluX\nPB: %lu rur.\nTN: %lu\nTB: %u rur.\n",
             card_number,
             balance,
             troika_number,


### PR DESCRIPTION
# What's new

- The meaning of the last symbol is now more obvious

# Verification 

- Read a plantain card, check that the number matches the card, with the last digit being replaced with X
- Do the same for a "Two Cities" card

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
