### PR TITLE
[FL-3888] Make file extensions case-insensitive

### DIFF
--- a/applications/main/archive/helpers/archive_files.c
+++ b/applications/main/archive/helpers/archive_files.c
@@ -15,7 +15,7 @@ void archive_set_file_type(ArchiveFile_t* file, const char* path, bool is_folder
     } else {
         for(size_t i = 0; i < COUNT_OF(known_ext); i++) {
             if((known_ext[i][0] == '?') || (known_ext[i][0] == '*')) continue;
-            if(furi_string_end_with(file->path, known_ext[i])) {
+            if(furi_string_end_withi(file->path, known_ext[i])) {
                 if(i == ArchiveFileTypeBadUsb) {
                     if(furi_string_search(
                            file->path, archive_get_default_path(ArchiveTabBadUsb)) == 0) {

--- a/applications/services/gui/modules/file_browser_worker.c
+++ b/applications/services/gui/modules/file_browser_worker.c
@@ -134,7 +134,7 @@ static bool browser_filter_by_name(BrowserWorker* browser, FuriString* name, boo
             if((furi_string_empty(ext)) || (furi_string_cmp_str(ext, "*") == 0)) {
                 return true;
             }
-            if(furi_string_end_with(name, ext)) {
+            if(furi_string_end_withi(name, ext)) {
                 return true;
             }
         }

--- a/furi/core/string.c
+++ b/furi/core/string.c
@@ -17,6 +17,7 @@ struct FuriString {
 #undef furi_string_replace_all
 #undef furi_string_start_with
 #undef furi_string_end_with
+#undef furi_string_end_withi
 #undef furi_string_search_char
 #undef furi_string_search_rchar
 #undef furi_string_trim
@@ -218,8 +219,26 @@ bool furi_string_end_with(const FuriString* v, const FuriString* v2) {
     return string_end_with_string_p(v->string, v2->string);
 }
 
+bool furi_string_end_withi(const FuriString* v, const FuriString* v2) {
+    return furi_string_end_withi_str(v, string_get_cstr(v2->string));
+}
+
 bool furi_string_end_with_str(const FuriString* v, const char str[]) {
     return string_end_with_str_p(v->string, str);
+}
+
+bool furi_string_end_withi_str(const FuriString* v, const char str[]) {
+    M_STR1NG_CONTRACT(v);
+    M_ASSERT(str != NULL);
+
+    const size_t str_len = strlen(str);
+    const size_t v_len = string_size(v->string);
+
+    if(v_len < str_len) {
+        return false;
+    }
+
+    return strcasecmp(&string_get_cstr(v->string)[v_len - str_len], str) == 0;
 }
 
 size_t furi_string_search_char(const FuriString* v, char c, size_t start) {

--- a/furi/core/string.h
+++ b/furi/core/string.h
@@ -510,6 +510,15 @@ bool furi_string_start_with_str(const FuriString* string, const char start[]);
  */
 bool furi_string_end_with(const FuriString* string, const FuriString* end);
 
+/** Test if the string ends with the given string (case insensitive according to the current locale).
+ *
+ * @param      string  The FuriString instance
+ * @param      end     The end
+ *
+ * @return     true if string ends with
+ */
+bool furi_string_end_withi(const FuriString* string, const FuriString* end);
+
 /** Test if the string ends with the given C string.
  *
  * @param      string  The FuriString instance
@@ -518,6 +527,15 @@ bool furi_string_end_with(const FuriString* string, const FuriString* end);
  * @return     true if string ends with
  */
 bool furi_string_end_with_str(const FuriString* string, const char end[]);
+
+/** Test if the string ends with the given C string (case insensitive according to the current locale).
+ *
+ * @param      string  The FuriString instance
+ * @param      end     The end
+ *
+ * @return     true if string ends with
+ */
+bool furi_string_end_withi_str(const FuriString* string, const char end[]);
 
 //---------------------------------------------------------------------------
 //                                Trim
@@ -698,6 +716,13 @@ void furi_string_utf8_decode(char c, FuriStringUTF8State* state, FuriStringUnico
  */
 #define furi_string_end_with(a, b) \
     FURI_STRING_SELECT2(furi_string_end_with, furi_string_end_with_str, a, b)
+
+/** Test if the string ends with the given string (or C string) (case insensitive according to the current locale).
+ *
+ * (string, [c]string)
+ */
+#define furi_string_end_withi(a, b) \
+    FURI_STRING_SELECT2(furi_string_end_withi, furi_string_end_withi_str, a, b)
 
 /** Append a string (or C string) to the string.
  *

--- a/targets/f18/api_symbols.csv
+++ b/targets/f18/api_symbols.csv
@@ -1582,6 +1582,8 @@ Function,+,furi_string_cmpi_str,int,"const FuriString*, const char[]"
 Function,+,furi_string_empty,_Bool,const FuriString*
 Function,+,furi_string_end_with,_Bool,"const FuriString*, const FuriString*"
 Function,+,furi_string_end_with_str,_Bool,"const FuriString*, const char[]"
+Function,+,furi_string_end_withi,_Bool,"const FuriString*, const FuriString*"
+Function,+,furi_string_end_withi_str,_Bool,"const FuriString*, const char[]"
 Function,+,furi_string_equal,_Bool,"const FuriString*, const FuriString*"
 Function,+,furi_string_equal_str,_Bool,"const FuriString*, const char[]"
 Function,+,furi_string_free,void,FuriString*

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1791,6 +1791,8 @@ Function,+,furi_string_cmpi_str,int,"const FuriString*, const char[]"
 Function,+,furi_string_empty,_Bool,const FuriString*
 Function,+,furi_string_end_with,_Bool,"const FuriString*, const FuriString*"
 Function,+,furi_string_end_with_str,_Bool,"const FuriString*, const char[]"
+Function,+,furi_string_end_withi,_Bool,"const FuriString*, const FuriString*"
+Function,+,furi_string_end_withi_str,_Bool,"const FuriString*, const char[]"
 Function,+,furi_string_equal,_Bool,"const FuriString*, const FuriString*"
 Function,+,furi_string_equal_str,_Bool,"const FuriString*, const char[]"
 Function,+,furi_string_free,void,FuriString*
@@ -1959,8 +1961,8 @@ Function,+,ibutton_protocols_render_data,void,"iButtonProtocols*, const iButtonK
 Function,+,ibutton_protocols_render_error,void,"iButtonProtocols*, const iButtonKey*, FuriString*"
 Function,+,ibutton_protocols_render_uid,void,"iButtonProtocols*, const iButtonKey*, FuriString*"
 Function,+,ibutton_protocols_save,_Bool,"iButtonProtocols*, const iButtonKey*, const char*"
-Function,+,ibutton_protocols_write_id,_Bool,"iButtonProtocols*, iButtonKey*"
 Function,+,ibutton_protocols_write_copy,_Bool,"iButtonProtocols*, iButtonKey*"
+Function,+,ibutton_protocols_write_id,_Bool,"iButtonProtocols*, iButtonKey*"
 Function,+,ibutton_worker_alloc,iButtonWorker*,iButtonProtocols*
 Function,+,ibutton_worker_emulate_set_callback,void,"iButtonWorker*, iButtonWorkerEmulateCallback, void*"
 Function,+,ibutton_worker_emulate_start,void,"iButtonWorker*, iButtonKey*"
@@ -1970,8 +1972,8 @@ Function,+,ibutton_worker_read_start,void,"iButtonWorker*, iButtonKey*"
 Function,+,ibutton_worker_start_thread,void,iButtonWorker*
 Function,+,ibutton_worker_stop,void,iButtonWorker*
 Function,+,ibutton_worker_stop_thread,void,iButtonWorker*
-Function,+,ibutton_worker_write_id_start,void,"iButtonWorker*, iButtonKey*"
 Function,+,ibutton_worker_write_copy_start,void,"iButtonWorker*, iButtonKey*"
+Function,+,ibutton_worker_write_id_start,void,"iButtonWorker*, iButtonKey*"
 Function,+,ibutton_worker_write_set_callback,void,"iButtonWorker*, iButtonWorkerWriteCallback, void*"
 Function,+,icon_animation_alloc,IconAnimation*,const Icon*
 Function,+,icon_animation_free,void,IconAnimation*


### PR DESCRIPTION
# What's new

- Treat file extensions as case-insensitive in Archive and Browser
- Add `furi_string_ends_withi()` function family for case-insensitive checks
- Fixes #3492 

# Verification 

1. Create several supported files with varying extension case, e.g. `Remote1.ir`, `Remote2.IR`, etc.
2. Ensure that all of these files are shown with correct icons both in Archive app and when opening files, e.g. from the Infrared app.
3. Ensure that there is no false positives (files with incorrect extensions must not be shown or shown as unknown files depending on the use case).

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
