### PR TITLE
Publishing T5577 page 1 block count macro

### DIFF
--- a/lib/lfrfid/tools/t5577.c
+++ b/lib/lfrfid/tools/t5577.c
@@ -13,9 +13,6 @@
 #define T5577_OPCODE_PAGE_1 0b11
 #define T5577_OPCODE_RESET  0b00
 
-#define T5577_BLOCKS_IN_PAGE_0 8
-#define T5577_BLOCKS_IN_PAGE_1 4
-
 static void t5577_start(void) {
     furi_hal_rfid_tim_read_start(125000, 0.5);
 

--- a/lib/lfrfid/tools/t5577.h
+++ b/lib/lfrfid/tools/t5577.h
@@ -7,8 +7,8 @@ extern "C" {
 #endif
 
 #define LFRFID_T5577_BLOCK_COUNT 8
-#define T5577_BLOCKS_IN_PAGE_0 8
-#define T5577_BLOCKS_IN_PAGE_1 4
+#define T5577_BLOCKS_IN_PAGE_0   8
+#define T5577_BLOCKS_IN_PAGE_1   4
 
 // T5577 block 0 definitions, thanks proxmark3!
 #define LFRFID_T5577_POR_DELAY             0x00000001

--- a/lib/lfrfid/tools/t5577.h
+++ b/lib/lfrfid/tools/t5577.h
@@ -7,6 +7,8 @@ extern "C" {
 #endif
 
 #define LFRFID_T5577_BLOCK_COUNT 8
+#define T5577_BLOCKS_IN_PAGE_0 8
+#define T5577_BLOCKS_IN_PAGE_1 4
 
 // T5577 block 0 definitions, thanks proxmark3!
 #define LFRFID_T5577_POR_DELAY             0x00000001


### PR DESCRIPTION
# What's new

- The header file used to only include page 0 count as a macro. I wish to make both page 0 and 1 block count out of the .c and available for external use. And perhaps we could gradually phase out the old macro `LFRFID_T5577_BLOCK_COUNT` created 2 years ago. 

# Verification 

- Nothing much. Just publishing a macro for external app usage.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
