### PR TITLE
Threading, Timers improvements

### DIFF
--- a/applications/services/loader/loader.c
+++ b/applications/services/loader/loader.c
@@ -717,7 +717,7 @@ static bool loader_do_signal(Loader* loader, uint32_t signal, void* arg) {
 
 static bool loader_do_get_application_name(Loader* loader, FuriString* name) {
     if(loader_is_application_running(loader)) {
-        furi_string_set(name, furi_thread_get_name(loader->app.thread));
+        furi_string_set(name, furi_thread_get_name(furi_thread_get_id(loader->app.thread)));
         return true;
     }
 

--- a/furi/core/event_loop_timer.c
+++ b/furi/core/event_loop_timer.c
@@ -65,7 +65,10 @@ static void furi_event_loop_timer_enqueue_request(
     TimerQueue_push_back(instance->timer_queue, timer);
 
     xTaskNotifyIndexed(
-        instance->thread_id, FURI_EVENT_LOOP_FLAG_NOTIFY_INDEX, FuriEventLoopFlagTimer, eSetBits);
+        (TaskHandle_t)instance->thread_id,
+        FURI_EVENT_LOOP_FLAG_NOTIFY_INDEX,
+        FuriEventLoopFlagTimer,
+        eSetBits);
 }
 
 /*


### PR DESCRIPTION
# What's new

This PR introduces several changes to timers and threads:
1. `FuriTimer::can_be_removed` has been replaced with a local variable to reduce the size of the structure. Passing a pointer to a local variable to a pending callback is safe in `furi_timer_free`, because we are waiting for that pending call to finish before returning from the caller. This change reduces the memory usage of `FuriTimer` while keeping the blocking behaviour of `furi_timer_free`.
2. Numerous changes have been made to `FuriThread`.
    * ~~Since currently `FuriThread*`, `FuriThreadId` and `TaskHandle_t` are aliases, the use of TLS to store a pointer to `FuriThread` is not required anymore. I replaced all the instances of this and changed FreeRTOS config not to allocate that TLS slot.~~ **DROPPED AS IT'S UNSAFE**
    * **MOVED TO #3881** To simplify join logic, a new `FuriThreadStateStopping` has been introduced, while `StateStopped` is now raised from the TCB cleanup. This means `furi_thread_join` can just wait for the state to change to `Stopped`.
    * **MOVED TO #3881** The above change comes with a bonus - thread state callbacks may now assume that upon receiving a `Stopped` call, it is safe to release `FuriThread`. Multiple call sites in the firmware have been updated to make use of this new assumption, instead of deferring their release to a pending timer call.
    * **MOVED TO #3881** State change callback received a new `FuriThread* thread` parameter - previously, callbacks assumed that they are always invoked from the thread that is changing its state, but this wasn't true for `StateStarting`, and with this PR, it's not true for `StateStopped` either.
3. Several call sites mixed up `FuriThread*` and `FuriThreadId`. While this is fine in the internal thread routines, IMO shouldn't be done by other modules.

Thanks to the removal of a struct member in `FuriTimer` ~~and a now-useless TLS slot~~, this change saves a bit of heap and pool space. I suspect the code should be a bit smaller too, but I haven't compared the sizes.

Before:
```
>: free
Free heap size: 146328
Total heap size: 186064
Minimum heap size: 137768
Maximum heap block: 146240
Pool free: 1368
Maximum pool block: 1340

>: free_blocks
A 2000B470 S 32
A 2000B4B8 S 146240
```

After:
```
>: free
Free heap size: 146392
Total heap size: 186064
Minimum heap size: 137872
Maximum heap block: 146344
Pool free: 1416
Maximum pool block: 1344

>: free_blocks
A 2000B410 S 24
A 2000B470 S 146312
```

# Verification 

* Run a full suite of tests.
* Verify that apps start and stop.
* Verify that RPC via qFlipper still works.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
