### PR TITLE
Desktop: Sanity check PIN length for good measure

### DIFF
--- a/applications/services/desktop/helpers/pin_code.c
+++ b/applications/services/desktop/helpers/pin_code.c
@@ -58,7 +58,8 @@ static uint32_t desktop_pin_code_pack(const DesktopPinCode* pin_code) {
 }
 
 bool desktop_pin_code_is_set(void) {
-    return furi_hal_rtc_get_pin_value() >> DESKTOP_PIN_CODE_LENGTH_OFFSET;
+    uint8_t length = furi_hal_rtc_get_pin_value() >> DESKTOP_PIN_CODE_LENGTH_OFFSET;
+    return length >= DESKTOP_PIN_CODE_MIN_LEN && length <= DESKTOP_PIN_CODE_MAX_LEN;
 }
 
 void desktop_pin_code_set(const DesktopPinCode* pin_code) {

--- a/applications/services/desktop/helpers/pin_code.h
+++ b/applications/services/desktop/helpers/pin_code.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#define DESKTOP_PIN_CODE_MIN_LEN (4)
 #define DESKTOP_PIN_CODE_MAX_LEN (10)
 
 typedef struct {

--- a/applications/services/desktop/views/desktop_view_pin_input.c
+++ b/applications/services/desktop/views/desktop_view_pin_input.c
@@ -103,7 +103,7 @@ static void desktop_view_pin_input_draw_cells(Canvas* canvas, DesktopViewPinInpu
     furi_assert(canvas);
     furi_assert(model);
 
-    uint8_t draw_pin_size = MAX(4, model->pin.length + 1);
+    uint8_t draw_pin_size = MAX(MIN_PIN_LENGTH, model->pin.length + 1);
     if(model->locked_input || (model->pin.length == MAX_PIN_LENGTH)) {
         draw_pin_size = model->pin.length;
     }

--- a/applications/services/desktop/views/desktop_view_pin_input.c
+++ b/applications/services/desktop/views/desktop_view_pin_input.c
@@ -13,7 +13,7 @@
 #define DEFAULT_PIN_X  64
 #define DEFAULT_PIN_Y  32
 
-#define MIN_PIN_LENGTH 4
+#define MIN_PIN_LENGTH DESKTOP_PIN_CODE_MIN_LEN
 #define MAX_PIN_LENGTH DESKTOP_PIN_CODE_MAX_LEN
 
 struct DesktopViewPinInput {


### PR DESCRIPTION
# What's new

- Title
- I forgot to PR this from few days ago, issues we had in CFW were unrelated to this but extra safety never hurts

# Verification 

- PIN still works as intended
- Setting PIN to unsupported length will leave desktop unlocked (previously, desktop would be impossible to unlock in this state)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
