### PR TITLE
FuriTimer: Use an event instead of a volatile bool to wait for deletion

### DIFF
--- a/furi/core/timer.c
+++ b/furi/core/timer.c
@@ -3,6 +3,7 @@
 #include "kernel.h"
 
 #include <FreeRTOS.h>
+#include <event_groups.h>
 #include <timers.h>
 
 struct FuriTimer {
@@ -13,6 +14,8 @@ struct FuriTimer {
 
 // IMPORTANT: container MUST be the FIRST struct member
 static_assert(offsetof(FuriTimer, container) == 0);
+
+#define TIMER_DELETED_EVENT (1U << 0)
 
 static void TimerCallback(TimerHandle_t hTimer) {
     FuriTimer* instance = pvTimerGetTimerID(hTimer);
@@ -41,8 +44,8 @@ static void furi_timer_epilogue(void* context, uint32_t arg) {
     furi_assert(context);
     UNUSED(arg);
 
-    volatile bool* can_be_removed = context;
-    *can_be_removed = true;
+    EventGroupHandle_t hEvent = context;
+    xEventGroupSetBits(hEvent, TIMER_DELETED_EVENT);
 }
 
 void furi_timer_free(FuriTimer* instance) {
@@ -52,14 +55,12 @@ void furi_timer_free(FuriTimer* instance) {
     TimerHandle_t hTimer = (TimerHandle_t)instance;
     furi_check(xTimerDelete(hTimer, portMAX_DELAY) == pdPASS);
 
-    volatile bool can_be_removed = false;
-    furi_check(
-        xTimerPendFunctionCall(furi_timer_epilogue, (void*)&can_be_removed, 0, portMAX_DELAY) ==
-        pdPASS);
+    StaticEventGroup_t event_container;
+    EventGroupHandle_t hEvent = xEventGroupCreateStatic(&event_container);
+    furi_check(xTimerPendFunctionCall(furi_timer_epilogue, hEvent, 0, portMAX_DELAY) == pdPASS);
 
-    while(!can_be_removed) {
-        furi_delay_tick(2);
-    }
+    xEventGroupWaitBits(hEvent, TIMER_DELETED_EVENT, 0, pdTRUE, portMAX_DELAY);
+    vEventGroupDelete(hEvent);
 
     free(instance);
 }


### PR DESCRIPTION
# What's new

Further improves over #3865, now `furi_timer_free` uses an event to wait for the timer to be deleted instead of looping on a volatile bool.

`FuriThread` could benefit from something similar too, but the event would have to be made part of the thread structure, so it's not worth it at the moment.

# Verification 

* Verify timers still work (and release) as intended.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
