### PR TITLE
LFRFID GProxII Fix Writing and Rendering Conflict

### DIFF
--- a/lib/lfrfid/protocols/protocol_gproxii.c
+++ b/lib/lfrfid/protocols/protocol_gproxii.c
@@ -39,7 +39,7 @@ void protocol_gproxii_free(ProtocolGProxII* protocol) {
 }
 
 uint8_t* protocol_gproxii_get_data(ProtocolGProxII* protocol) {
-    return protocol->decoded_data;
+    return protocol->data;
 }
 
 bool wiegand_check(uint64_t fc_and_card, bool even_parity, bool odd_parity, int card_len) {
@@ -235,6 +235,7 @@ LevelDuration protocol_gproxii_encoder_yield(ProtocolGProxII* protocol) {
 }
 
 void protocol_gproxii_render_data(ProtocolGProxII* protocol, FuriString* result) {
+    protocol_gproxii_can_be_decoded(protocol);
     int xor_code = bit_lib_get_bits(protocol->decoded_data, 0, 8);
     int card_len = bit_lib_get_bits(protocol->decoded_data, 8, 6);
     int crc_code = bit_lib_get_bits(protocol->decoded_data, 14, 2);


### PR DESCRIPTION
# What's new

- This PR aims to resolve the conflict between `protocol_gproxii_get_data`, `protocol_gproxii_render_data` and `protocol_gproxii_write_data`. 
- #3796 : `get_data` gets encoded data `data` into memory when loading. `render_data` uses `decoded_data`, which is not in memory after loading. It's not a problem immediately after reading because `decoded_data` is still in memory. But when loading data from saved files, rendering would fail. `write_data` works just fine because it writes from encoded data `data`.
- #3869 : probably tried to fix the render issue, so `get_data` gets `decoded_data` now. This makes rendering work right after loading a file. But it also means there's nothing in memory for `data`. So writing would fail. It will write all zeroes onto a T5577. 
- This PR resolves the conflict by reverting #3869 's change on `get_data`, and adding one line of `protocol_gproxii_can_be_decoded` in the beginning of `render_data` so that the encoded data `data` is decoded and feed into `decoded_data` before rendering. Writing works correctly as it used to.

# Verification 

1. Use PM3 to write a T5577 with this command: `lf gproxii clone --xor 236 --fmt 36 --fc 8 --cn 22744`. 
2. Use Flipper: Read the tag, save it. Exit the app, enter again. Go to Saved, select the just saved file, check if the data are correctly shown instead of 'Read Error'. Write to a T5577. 
3. Do step 2 before and after this PR. Before this PR, writing will fail. Before #3869 , rendering will fail. After this PR, both works.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
