### PR TITLE
FeliCa anti-collision fix

### DIFF
--- a/furi/core/event_flag.c
+++ b/furi/core/event_flag.c
@@ -48,7 +48,9 @@ uint32_t furi_event_flag_set(FuriEventFlag* instance, uint32_t flags) {
             portYIELD_FROM_ISR(yield);
         }
     } else {
+        vTaskSuspendAll();
         rflags = xEventGroupSetBits(hEventGroup, (EventBits_t)flags);
+        (void)xTaskResumeAll();
     }
 
     /* Return event flags after setting */

--- a/furi/core/event_flag.h
+++ b/furi/core/event_flag.h
@@ -26,10 +26,15 @@ void furi_event_flag_free(FuriEventFlag* instance);
 
 /** Set flags
  *
- * @param      instance  pointer to FuriEventFlag
- * @param[in]  flags     The flags
+ * @warning    result of this function can be flags that you've just asked to
+ *             set or not if someone was waiting for them and asked to clear it.
+ *             It is highly recommended to read this function and
+ *             xEventGroupSetBits source code.
  *
- * @return     Resulting flags or error (FuriStatus)
+ * @param      instance  pointer to FuriEventFlag
+ * @param[in]  flags     The flags to set
+ *
+ * @return     Resulting flags(see warning) or error (FuriStatus)
  */
 uint32_t furi_event_flag_set(FuriEventFlag* instance, uint32_t flags);
 

--- a/lib/nfc/nfc.c
+++ b/lib/nfc/nfc.c
@@ -651,11 +651,12 @@ NfcError nfc_felica_listener_set_sensf_res_data(
     const uint8_t* idm,
     const uint8_t idm_len,
     const uint8_t* pmm,
-    const uint8_t pmm_len) {
+    const uint8_t pmm_len,
+    const uint16_t sys_code) {
     furi_check(instance);
 
     FuriHalNfcError error =
-        furi_hal_nfc_felica_listener_set_sensf_res_data(idm, idm_len, pmm, pmm_len);
+        furi_hal_nfc_felica_listener_set_sensf_res_data(idm, idm_len, pmm, pmm_len, sys_code);
     instance->comm_state = NfcCommStateIdle;
     return nfc_process_hal_error(error);
 }

--- a/lib/nfc/nfc.h
+++ b/lib/nfc/nfc.h
@@ -361,6 +361,7 @@ NfcError nfc_iso14443a_listener_set_col_res_data(
  * @param[in] idm_len IDm length in bytes.
  * @param[in] pmm pointer to a byte array containing the PMm.
  * @param[in] pmm_len PMm length in bytes.
+ * @param[in] sys_code System code from SYS_C block
  * @returns NfcErrorNone on success, any other error code on failure.
 */
 NfcError nfc_felica_listener_set_sensf_res_data(
@@ -368,7 +369,8 @@ NfcError nfc_felica_listener_set_sensf_res_data(
     const uint8_t* idm,
     const uint8_t idm_len,
     const uint8_t* pmm,
-    const uint8_t pmm_len);
+    const uint8_t pmm_len,
+    const uint16_t sys_code);
 
 /**
  * @brief Send ISO15693 Start of Frame pattern in listener mode

--- a/lib/nfc/nfc_mock.c
+++ b/lib/nfc/nfc_mock.c
@@ -270,7 +270,8 @@ static void nfc_worker_listener_pass_col_res(Nfc* instance, uint8_t* rx_data, ui
         }
     } else if(rx_bits == 8 * 8) {
         FelicaPollingRequest* request = (FelicaPollingRequest*)rx_data;
-        if(request->system_code == instance->pt_memory.system_code) {
+        if(request->system_code == 0xFFFF ||
+           request->system_code == instance->pt_memory.system_code) {
             uint8_t response_size = sizeof(FelicaSensfResData) + 1;
             bit_buffer_reset(tx_buffer);
             bit_buffer_append_byte(tx_buffer, response_size);
@@ -501,19 +502,19 @@ NfcError nfc_felica_listener_set_sensf_res_data(
     const uint8_t* idm,
     const uint8_t idm_len,
     const uint8_t* pmm,
-    const uint8_t pmm_len) {
+    const uint8_t pmm_len,
+    const uint16_t sys_code) {
     furi_assert(instance);
     furi_assert(idm);
     furi_assert(pmm);
     furi_assert(idm_len == 8);
     furi_assert(pmm_len == 8);
 
-    instance->pt_memory.system_code = 0xFFFF;
+    instance->pt_memory.system_code = sys_code;
     instance->pt_memory.sens_res.code = 0x01;
     instance->software_col_res_required = true;
     memcpy(instance->pt_memory.sens_res.idm.data, idm, idm_len);
     memcpy(instance->pt_memory.sens_res.pmm.data, pmm, pmm_len);
-
     return NfcErrorNone;
 }
 

--- a/lib/nfc/protocols/felica/felica_listener.c
+++ b/lib/nfc/protocols/felica/felica_listener.c
@@ -26,8 +26,9 @@ FelicaListener* felica_listener_alloc(Nfc* nfc, FelicaData* data) {
     memcpy(instance->mc_shadow.data, instance->data->data.fs.mc.data, FELICA_DATA_BLOCK_SIZE);
     instance->data->data.fs.state.data[0] = 0;
     nfc_config(instance->nfc, NfcModeListener, NfcTechFelica);
+    const uint16_t system_code = *(uint16_t*)data->data.fs.sys_c.data;
     nfc_felica_listener_set_sensf_res_data(
-        nfc, data->idm.data, sizeof(data->idm), data->pmm.data, sizeof(data->pmm));
+        nfc, data->idm.data, sizeof(data->idm), data->pmm.data, sizeof(data->pmm), system_code);
 
     return instance;
 }

--- a/targets/f18/api_symbols.csv
+++ b/targets/f18/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,74.0,,
+Version,+,73.0,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
 Header,+,applications/services/cli/cli.h,,

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,74.0,,
+Version,+,73.0,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,72.2,,
+Version,+,74.0,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
@@ -1442,7 +1442,7 @@ Function,+,furi_hal_nfc_abort,FuriHalNfcError,
 Function,+,furi_hal_nfc_acquire,FuriHalNfcError,
 Function,+,furi_hal_nfc_event_start,FuriHalNfcError,
 Function,+,furi_hal_nfc_event_stop,FuriHalNfcError,
-Function,+,furi_hal_nfc_felica_listener_set_sensf_res_data,FuriHalNfcError,"const uint8_t*, const uint8_t, const uint8_t*, const uint8_t"
+Function,+,furi_hal_nfc_felica_listener_set_sensf_res_data,FuriHalNfcError,"const uint8_t*, const uint8_t, const uint8_t*, const uint8_t, const uint16_t"
 Function,+,furi_hal_nfc_field_detect_start,FuriHalNfcError,
 Function,+,furi_hal_nfc_field_detect_stop,FuriHalNfcError,
 Function,+,furi_hal_nfc_field_is_present,_Bool,
@@ -2776,7 +2776,7 @@ Function,+,nfc_device_save,_Bool,"NfcDevice*, const char*"
 Function,+,nfc_device_set_data,void,"NfcDevice*, NfcProtocol, const NfcDeviceData*"
 Function,+,nfc_device_set_loading_callback,void,"NfcDevice*, NfcLoadingCallback, void*"
 Function,+,nfc_device_set_uid,_Bool,"NfcDevice*, const uint8_t*, size_t"
-Function,+,nfc_felica_listener_set_sensf_res_data,NfcError,"Nfc*, const uint8_t*, const uint8_t, const uint8_t*, const uint8_t"
+Function,+,nfc_felica_listener_set_sensf_res_data,NfcError,"Nfc*, const uint8_t*, const uint8_t, const uint8_t*, const uint8_t, const uint16_t"
 Function,+,nfc_free,void,Nfc*
 Function,+,nfc_iso14443a_listener_set_col_res_data,NfcError,"Nfc*, uint8_t*, uint8_t, uint8_t*, uint8_t"
 Function,+,nfc_iso14443a_listener_tx_custom_parity,NfcError,"Nfc*, const BitBuffer*"

--- a/targets/f7/furi_hal/furi_hal_nfc_felica.c
+++ b/targets/f7/furi_hal/furi_hal_nfc_felica.c
@@ -161,7 +161,8 @@ FuriHalNfcError furi_hal_nfc_felica_listener_set_sensf_res_data(
     const uint8_t* idm,
     const uint8_t idm_len,
     const uint8_t* pmm,
-    const uint8_t pmm_len) {
+    const uint8_t pmm_len,
+    const uint16_t sys_code) {
     furi_check(idm);
     furi_check(pmm);
 

--- a/targets/f7/furi_hal/furi_hal_nfc_felica.c
+++ b/targets/f7/furi_hal/furi_hal_nfc_felica.c
@@ -4,6 +4,20 @@
 // Prevent FDT timer from starting
 #define FURI_HAL_NFC_FELICA_LISTENER_FDT_COMP_FC (INT32_MAX)
 
+#define FURI_HAL_FELICA_COMMUNICATION_PERFORMANCE (0x0083U)
+#define FURI_HAL_FELICA_RESPONSE_CODE             (0x01)
+#define FURI_HAL_FELICA_IDM_PMM_LENGTH            (8)
+
+#pragma pack(push, 1)
+typedef struct {
+    uint16_t system_code;
+    uint8_t response_code;
+    uint8_t Idm[FURI_HAL_FELICA_IDM_PMM_LENGTH];
+    uint8_t Pmm[FURI_HAL_FELICA_IDM_PMM_LENGTH];
+    uint16_t communication_performance;
+} FuriHalFelicaPtMemory;
+#pragma pack(pop)
+
 static FuriHalNfcError furi_hal_nfc_felica_poller_init(FuriHalSpiBusHandle* handle) {
     // Enable Felica mode, AM modulation
     st25r3916_change_reg_bits(
@@ -165,14 +179,19 @@ FuriHalNfcError furi_hal_nfc_felica_listener_set_sensf_res_data(
     const uint16_t sys_code) {
     furi_check(idm);
     furi_check(pmm);
+    furi_check(idm_len == FURI_HAL_FELICA_IDM_PMM_LENGTH);
+    furi_check(pmm_len == FURI_HAL_FELICA_IDM_PMM_LENGTH);
 
     FuriHalSpiBusHandle* handle = &furi_hal_spi_bus_handle_nfc;
     // Write PT Memory
-    uint8_t pt_memory[19] = {};
-    pt_memory[2] = 0x01;
-    memcpy(pt_memory + 3, idm, idm_len);
-    memcpy(pt_memory + 3 + idm_len, pmm, pmm_len);
-    st25r3916_write_ptf_mem(handle, pt_memory, sizeof(pt_memory));
+    FuriHalFelicaPtMemory pt;
+    pt.system_code = sys_code;
+    pt.response_code = FURI_HAL_FELICA_RESPONSE_CODE;
+    pt.communication_performance = __builtin_bswap16(FURI_HAL_FELICA_COMMUNICATION_PERFORMANCE);
+    memcpy(pt.Idm, idm, idm_len);
+    memcpy(pt.Pmm, pmm, pmm_len);
+
+    st25r3916_write_ptf_mem(handle, (uint8_t*)&pt, sizeof(FuriHalFelicaPtMemory));
     return FuriHalNfcErrorNone;
 }
 

--- a/targets/furi_hal_include/furi_hal_nfc.h
+++ b/targets/furi_hal_include/furi_hal_nfc.h
@@ -461,13 +461,15 @@ FuriHalNfcError furi_hal_nfc_iso15693_listener_tx_sof(void);
  * @param[in] idm_len IDm length in bytes.
  * @param[in] pmm pointer to a byte array containing the PMm.
  * @param[in] pmm_len PMm length in bytes.
+ * @param[in] sys_code System code from SYS_C block
  * @returns NfcErrorNone on success, any other error code on failure.
 */
 FuriHalNfcError furi_hal_nfc_felica_listener_set_sensf_res_data(
     const uint8_t* idm,
     const uint8_t idm_len,
     const uint8_t* pmm,
-    const uint8_t pmm_len);
+    const uint8_t pmm_len,
+    const uint16_t sys_code);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
# What's new

- Sensf_data in st chip is now filled up properly, previously there were missing parts(fix #3871)

# Verification 

- Put real card on proxmark and run such commands:
`hf felica raw -c 0600ffff0000`
`hf felica raw -c 0600ffff0100`
`hf felica raw -c 0600ffff0200`
The result will be smth like this:
![image](https://github.com/user-attachments/assets/6e63fc4a-c37d-4ac3-96d4-b7b82bb8aa10)
Bytes in the red rectangle are wrong on Flipper now
![image](https://github.com/user-attachments/assets/b9add6f9-df72-4dfa-a19b-6ba7a2ff888d)

- Read that card with Flipper, run its emulation and put it to proxmark
- The result must be the same as on the real card
![image](https://github.com/user-attachments/assets/6e63fc4a-c37d-4ac3-96d4-b7b82bb8aa10)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
