### PR TITLE
[FL-3891] Folder rename fails

### DIFF
--- a/applications/debug/unit_tests/tests/storage/storage_test.c
+++ b/applications/debug/unit_tests/tests/storage/storage_test.c
@@ -6,8 +6,8 @@
 // This is a hack to access internal storage functions and definitions
 #include <storage/storage_i.h>
 
-#define UINTTEST_RESOURCES_PATH(path) EXT_PATH("unit_tests/" path)
-#define UNIT_TESTS_PATH(path)         EXT_PATH(".tmp/unit_tests/" path)
+#define UNIT_TESTS_RESOURCES_PATH(path) EXT_PATH("unit_tests/" path)
+#define UNIT_TESTS_PATH(path)           EXT_PATH(".tmp/unit_tests/" path)
 
 #define STORAGE_LOCKED_FILE UNIT_TESTS_PATH("locked_file.test")
 #define STORAGE_LOCKED_DIR  STORAGE_INT_PATH_PREFIX
@@ -702,7 +702,7 @@ MU_TEST(test_md5_calc) {
     Storage* storage = furi_record_open(RECORD_STORAGE);
     File* file = storage_file_alloc(storage);
 
-    const char* path = UINTTEST_RESOURCES_PATH("storage/md5.txt");
+    const char* path = UNIT_TESTS_RESOURCES_PATH("storage/md5.txt");
     const char* md5_cstr = "2a456fa43e75088fdde41c93159d62a2";
     const uint8_t md5[MD5_HASH_SIZE] = {
         0x2a,

--- a/applications/debug/unit_tests/tests/storage/storage_test.c
+++ b/applications/debug/unit_tests/tests/storage/storage_test.c
@@ -7,7 +7,7 @@
 #include <storage/storage_i.h>
 
 #define TEST_RESOURCES_PATH(path) EXT_PATH("unit_tests/" path)
-#define TEST_TMP_PATH(path) EXT_PATH(".tmp/unit_tests/" path)
+#define TEST_TMP_PATH(path)       EXT_PATH(".tmp/unit_tests/" path)
 
 #define STORAGE_LOCKED_FILE TEST_TMP_PATH("locked_file.test")
 #define STORAGE_LOCKED_DIR  STORAGE_INT_PATH_PREFIX
@@ -373,7 +373,8 @@ MU_TEST(storage_file_rename) {
     mu_check(write_file_13DA(storage, TEST_TMP_PATH("file.old")));
     mu_check(check_file_13DA(storage, TEST_TMP_PATH("file.old")));
     mu_assert_int_eq(
-        FSE_OK, storage_common_rename(storage, TEST_TMP_PATH("file.old"), TEST_TMP_PATH("file.new")));
+        FSE_OK,
+        storage_common_rename(storage, TEST_TMP_PATH("file.old"), TEST_TMP_PATH("file.new")));
     mu_assert_int_eq(FSE_NOT_EXIST, storage_common_stat(storage, TEST_TMP_PATH("file.old"), NULL));
     mu_assert_int_eq(FSE_OK, storage_common_stat(storage, TEST_TMP_PATH("file.new"), NULL));
     mu_check(check_file_13DA(storage, TEST_TMP_PATH("file.new")));
@@ -414,21 +415,30 @@ MU_TEST(storage_equiv_and_subdir) {
     Storage* storage = furi_record_open(RECORD_STORAGE);
 
     mu_assert_int_eq(
-        true, storage_common_equivalent_path(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah")));
+        true,
+        storage_common_equivalent_path(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah")));
     mu_assert_int_eq(
-        true, storage_common_equivalent_path(storage, TEST_TMP_PATH("blah/"), TEST_TMP_PATH("blah/")));
+        true,
+        storage_common_equivalent_path(storage, TEST_TMP_PATH("blah/"), TEST_TMP_PATH("blah/")));
     mu_assert_int_eq(
-        false, storage_common_equivalent_path(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah-blah")));
+        false,
+        storage_common_equivalent_path(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah-blah")));
     mu_assert_int_eq(
-        false, storage_common_equivalent_path(storage, TEST_TMP_PATH("blah/"), TEST_TMP_PATH("blah-blah/")));
+        false,
+        storage_common_equivalent_path(
+            storage, TEST_TMP_PATH("blah/"), TEST_TMP_PATH("blah-blah/")));
 
-    mu_assert_int_eq(true, storage_common_is_subdir(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah")));
     mu_assert_int_eq(
-        true, storage_common_is_subdir(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah/blah")));
+        true, storage_common_is_subdir(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah")));
     mu_assert_int_eq(
-        false, storage_common_is_subdir(storage, TEST_TMP_PATH("blah/blah"), TEST_TMP_PATH("blah")));
+        true,
+        storage_common_is_subdir(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah/blah")));
     mu_assert_int_eq(
-        false, storage_common_is_subdir(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah-blah")));
+        false,
+        storage_common_is_subdir(storage, TEST_TMP_PATH("blah/blah"), TEST_TMP_PATH("blah")));
+    mu_assert_int_eq(
+        false,
+        storage_common_is_subdir(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah-blah")));
 
     furi_record_close(RECORD_STORAGE);
 }

--- a/applications/debug/unit_tests/tests/storage/storage_test.c
+++ b/applications/debug/unit_tests/tests/storage/storage_test.c
@@ -6,13 +6,13 @@
 // This is a hack to access internal storage functions and definitions
 #include <storage/storage_i.h>
 
-#define TEST_RESOURCES_PATH(path) EXT_PATH("unit_tests/" path)
-#define TEST_TMP_PATH(path)       EXT_PATH(".tmp/unit_tests/" path)
+#define UINTTEST_RESOURCES_PATH(path) EXT_PATH("unit_tests/" path)
+#define UNIT_TESTS_PATH(path)         EXT_PATH(".tmp/unit_tests/" path)
 
-#define STORAGE_LOCKED_FILE TEST_TMP_PATH("locked_file.test")
+#define STORAGE_LOCKED_FILE UNIT_TESTS_PATH("locked_file.test")
 #define STORAGE_LOCKED_DIR  STORAGE_INT_PATH_PREFIX
 
-#define STORAGE_TEST_DIR TEST_TMP_PATH("test_dir")
+#define STORAGE_TEST_DIR UNIT_TESTS_PATH("test_dir")
 
 static bool storage_file_create(Storage* storage, const char* path, const char* data) {
     File* file = storage_file_alloc(storage);
@@ -117,7 +117,7 @@ MU_TEST(storage_file_open_close) {
 }
 
 static bool storage_file_read_write_test(File* file, uint8_t* data, size_t test_size) {
-    const char* filename = TEST_TMP_PATH("storage_chunk.test");
+    const char* filename = UNIT_TESTS_PATH("storage_chunk.test");
 
     // fill with pattern
     for(size_t i = 0; i < test_size; i++) {
@@ -370,24 +370,25 @@ MU_TEST(storage_file_rename) {
     Storage* storage = furi_record_open(RECORD_STORAGE);
     File* file = storage_file_alloc(storage);
 
-    mu_check(write_file_13DA(storage, TEST_TMP_PATH("file.old")));
-    mu_check(check_file_13DA(storage, TEST_TMP_PATH("file.old")));
+    mu_check(write_file_13DA(storage, UNIT_TESTS_PATH("file.old")));
+    mu_check(check_file_13DA(storage, UNIT_TESTS_PATH("file.old")));
     mu_assert_int_eq(
         FSE_OK,
-        storage_common_rename(storage, TEST_TMP_PATH("file.old"), TEST_TMP_PATH("file.new")));
-    mu_assert_int_eq(FSE_NOT_EXIST, storage_common_stat(storage, TEST_TMP_PATH("file.old"), NULL));
-    mu_assert_int_eq(FSE_OK, storage_common_stat(storage, TEST_TMP_PATH("file.new"), NULL));
-    mu_check(check_file_13DA(storage, TEST_TMP_PATH("file.new")));
-    mu_assert_int_eq(FSE_OK, storage_common_remove(storage, TEST_TMP_PATH("file.new")));
+        storage_common_rename(storage, UNIT_TESTS_PATH("file.old"), UNIT_TESTS_PATH("file.new")));
+    mu_assert_int_eq(
+        FSE_NOT_EXIST, storage_common_stat(storage, UNIT_TESTS_PATH("file.old"), NULL));
+    mu_assert_int_eq(FSE_OK, storage_common_stat(storage, UNIT_TESTS_PATH("file.new"), NULL));
+    mu_check(check_file_13DA(storage, UNIT_TESTS_PATH("file.new")));
+    mu_assert_int_eq(FSE_OK, storage_common_remove(storage, UNIT_TESTS_PATH("file.new")));
 
     storage_file_free(file);
     furi_record_close(RECORD_STORAGE);
 }
 
 static const char* dir_rename_tests[][2] = {
-    {TEST_TMP_PATH("dir.old"), TEST_TMP_PATH("dir.new")},
-    {TEST_TMP_PATH("test_dir"), TEST_TMP_PATH("test_dir-new")},
-    {TEST_TMP_PATH("test"), TEST_TMP_PATH("test-test")},
+    {UNIT_TESTS_PATH("dir.old"), UNIT_TESTS_PATH("dir.new")},
+    {UNIT_TESTS_PATH("test_dir"), UNIT_TESTS_PATH("test_dir-new")},
+    {UNIT_TESTS_PATH("test"), UNIT_TESTS_PATH("test-test")},
 };
 
 MU_TEST(storage_dir_rename) {
@@ -416,29 +417,31 @@ MU_TEST(storage_equiv_and_subdir) {
 
     mu_assert_int_eq(
         true,
-        storage_common_equivalent_path(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah")));
+        storage_common_equivalent_path(storage, UNIT_TESTS_PATH("blah"), UNIT_TESTS_PATH("blah")));
     mu_assert_int_eq(
         true,
-        storage_common_equivalent_path(storage, TEST_TMP_PATH("blah/"), TEST_TMP_PATH("blah/")));
-    mu_assert_int_eq(
-        false,
-        storage_common_equivalent_path(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah-blah")));
+        storage_common_equivalent_path(
+            storage, UNIT_TESTS_PATH("blah/"), UNIT_TESTS_PATH("blah/")));
     mu_assert_int_eq(
         false,
         storage_common_equivalent_path(
-            storage, TEST_TMP_PATH("blah/"), TEST_TMP_PATH("blah-blah/")));
+            storage, UNIT_TESTS_PATH("blah"), UNIT_TESTS_PATH("blah-blah")));
+    mu_assert_int_eq(
+        false,
+        storage_common_equivalent_path(
+            storage, UNIT_TESTS_PATH("blah/"), UNIT_TESTS_PATH("blah-blah/")));
 
     mu_assert_int_eq(
-        true, storage_common_is_subdir(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah")));
+        true, storage_common_is_subdir(storage, UNIT_TESTS_PATH("blah"), UNIT_TESTS_PATH("blah")));
     mu_assert_int_eq(
         true,
-        storage_common_is_subdir(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah/blah")));
+        storage_common_is_subdir(storage, UNIT_TESTS_PATH("blah"), UNIT_TESTS_PATH("blah/blah")));
     mu_assert_int_eq(
         false,
-        storage_common_is_subdir(storage, TEST_TMP_PATH("blah/blah"), TEST_TMP_PATH("blah")));
+        storage_common_is_subdir(storage, UNIT_TESTS_PATH("blah/blah"), UNIT_TESTS_PATH("blah")));
     mu_assert_int_eq(
         false,
-        storage_common_is_subdir(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah-blah")));
+        storage_common_is_subdir(storage, UNIT_TESTS_PATH("blah"), UNIT_TESTS_PATH("blah-blah")));
 
     furi_record_close(RECORD_STORAGE);
 }
@@ -530,164 +533,164 @@ MU_TEST(test_storage_common_migrate) {
     Storage* storage = furi_record_open(RECORD_STORAGE);
 
     // Setup test folders
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old"));
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new"));
 
     // Test migration from non existing
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, TEST_TMP_PATH("migrate_old"), TEST_TMP_PATH("migrate_new")));
+            storage, UNIT_TESTS_PATH("migrate_old"), UNIT_TESTS_PATH("migrate_new")));
 
     // Test migration from existing folder to non existing
-    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, TEST_TMP_PATH("migrate_old")));
-    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old/file1"), "test1"));
-    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old/file2.ext"), "test2"));
-    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old/file3.ext.ext"), "test3"));
+    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, UNIT_TESTS_PATH("migrate_old")));
+    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old/file1"), "test1"));
+    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old/file2.ext"), "test2"));
+    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old/file3.ext.ext"), "test3"));
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, TEST_TMP_PATH("migrate_old"), TEST_TMP_PATH("migrate_new")));
+            storage, UNIT_TESTS_PATH("migrate_old"), UNIT_TESTS_PATH("migrate_new")));
 
-    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file1")));
-    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file2.ext")));
-    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file3.ext.ext")));
-    mu_check(storage_dir_exists(storage, TEST_TMP_PATH("migrate_new")));
-    mu_check(!storage_dir_exists(storage, TEST_TMP_PATH("migrate_old")));
+    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file1")));
+    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file2.ext")));
+    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file3.ext.ext")));
+    mu_check(storage_dir_exists(storage, UNIT_TESTS_PATH("migrate_new")));
+    mu_check(!storage_dir_exists(storage, UNIT_TESTS_PATH("migrate_old")));
 
     // Test migration from existing folder to existing folder
-    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, TEST_TMP_PATH("migrate_old")));
-    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old/file1"), "test1"));
-    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old/file2.ext"), "test2"));
-    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old/file3.ext.ext"), "test3"));
+    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, UNIT_TESTS_PATH("migrate_old")));
+    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old/file1"), "test1"));
+    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old/file2.ext"), "test2"));
+    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old/file3.ext.ext"), "test3"));
 
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, TEST_TMP_PATH("migrate_old"), TEST_TMP_PATH("migrate_new")));
+            storage, UNIT_TESTS_PATH("migrate_old"), UNIT_TESTS_PATH("migrate_new")));
 
-    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file1")));
-    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file2.ext")));
-    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file3.ext.ext")));
-    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file11")));
-    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file21.ext")));
-    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file3.ext1.ext")));
-    mu_check(storage_dir_exists(storage, TEST_TMP_PATH("migrate_new")));
-    mu_check(!storage_dir_exists(storage, TEST_TMP_PATH("migrate_old")));
+    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file1")));
+    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file2.ext")));
+    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file3.ext.ext")));
+    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file11")));
+    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file21.ext")));
+    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file3.ext1.ext")));
+    mu_check(storage_dir_exists(storage, UNIT_TESTS_PATH("migrate_new")));
+    mu_check(!storage_dir_exists(storage, UNIT_TESTS_PATH("migrate_old")));
 
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old"));
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new"));
 
     // Test migration from empty folder to existing file
     // Expected result: FSE_OK, folder removed, file untouched
-    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, TEST_TMP_PATH("migrate_old")));
-    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_new"), "test1"));
+    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, UNIT_TESTS_PATH("migrate_old")));
+    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_new"), "test1"));
 
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, TEST_TMP_PATH("migrate_old"), TEST_TMP_PATH("migrate_new")));
+            storage, UNIT_TESTS_PATH("migrate_old"), UNIT_TESTS_PATH("migrate_new")));
 
-    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new")));
-    mu_check(!storage_dir_exists(storage, TEST_TMP_PATH("migrate_old")));
+    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new")));
+    mu_check(!storage_dir_exists(storage, UNIT_TESTS_PATH("migrate_old")));
 
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old"));
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new"));
 
     // Test migration from empty folder to existing folder
     // Expected result: FSE_OK, old folder removed, new folder untouched
-    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, TEST_TMP_PATH("migrate_old")));
-    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, TEST_TMP_PATH("migrate_new")));
+    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, UNIT_TESTS_PATH("migrate_old")));
+    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, UNIT_TESTS_PATH("migrate_new")));
 
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, TEST_TMP_PATH("migrate_old"), TEST_TMP_PATH("migrate_new")));
+            storage, UNIT_TESTS_PATH("migrate_old"), UNIT_TESTS_PATH("migrate_new")));
 
-    mu_check(storage_dir_exists(storage, TEST_TMP_PATH("migrate_new")));
-    mu_check(!storage_dir_exists(storage, TEST_TMP_PATH("migrate_old")));
+    mu_check(storage_dir_exists(storage, UNIT_TESTS_PATH("migrate_new")));
+    mu_check(!storage_dir_exists(storage, UNIT_TESTS_PATH("migrate_old")));
 
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old"));
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new"));
 
     // Test migration from existing file to non existing, no extension
-    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old"), "test1"));
+    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old"), "test1"));
 
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, TEST_TMP_PATH("migrate_old"), TEST_TMP_PATH("migrate_new")));
+            storage, UNIT_TESTS_PATH("migrate_old"), UNIT_TESTS_PATH("migrate_new")));
 
-    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new")));
-    mu_check(!storage_file_exists(storage, TEST_TMP_PATH("migrate_old")));
+    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new")));
+    mu_check(!storage_file_exists(storage, UNIT_TESTS_PATH("migrate_old")));
 
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old"));
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new"));
 
     // Test migration from existing file to non existing, with extension
-    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old.file"), "test1"));
+    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old.file"), "test1"));
 
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, TEST_TMP_PATH("migrate_old.file"), TEST_TMP_PATH("migrate_new.file")));
+            storage, UNIT_TESTS_PATH("migrate_old.file"), UNIT_TESTS_PATH("migrate_new.file")));
 
-    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new.file")));
-    mu_check(!storage_file_exists(storage, TEST_TMP_PATH("migrate_old.file")));
+    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new.file")));
+    mu_check(!storage_file_exists(storage, UNIT_TESTS_PATH("migrate_old.file")));
 
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old.file"));
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new.file"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old.file"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new.file"));
 
     // Test migration from existing file to existing file, no extension
-    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old"), "test1"));
-    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_new"), "test2"));
+    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old"), "test1"));
+    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_new"), "test2"));
 
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, TEST_TMP_PATH("migrate_old"), TEST_TMP_PATH("migrate_new")));
+            storage, UNIT_TESTS_PATH("migrate_old"), UNIT_TESTS_PATH("migrate_new")));
 
-    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new")));
-    mu_check(!storage_file_exists(storage, TEST_TMP_PATH("migrate_old")));
-    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new1")));
+    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new")));
+    mu_check(!storage_file_exists(storage, UNIT_TESTS_PATH("migrate_old")));
+    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new1")));
 
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old"));
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new"));
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new1"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new1"));
 
     // Test migration from existing file to existing file, with extension
-    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old.file"), "test1"));
-    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_new.file"), "test2"));
+    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old.file"), "test1"));
+    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_new.file"), "test2"));
 
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, TEST_TMP_PATH("migrate_old.file"), TEST_TMP_PATH("migrate_new.file")));
+            storage, UNIT_TESTS_PATH("migrate_old.file"), UNIT_TESTS_PATH("migrate_new.file")));
 
-    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new.file")));
-    mu_check(!storage_file_exists(storage, TEST_TMP_PATH("migrate_old.file")));
-    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new1.file")));
+    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new.file")));
+    mu_check(!storage_file_exists(storage, UNIT_TESTS_PATH("migrate_old.file")));
+    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new1.file")));
 
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old.file"));
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new.file"));
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new1.file"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old.file"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new.file"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new1.file"));
 
     // Test migration from existing file to existing folder
-    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old"), "test1"));
-    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, TEST_TMP_PATH("migrate_new")));
+    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old"), "test1"));
+    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, UNIT_TESTS_PATH("migrate_new")));
 
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, TEST_TMP_PATH("migrate_old"), TEST_TMP_PATH("migrate_new")));
+            storage, UNIT_TESTS_PATH("migrate_old"), UNIT_TESTS_PATH("migrate_new")));
 
-    mu_check(storage_dir_exists(storage, TEST_TMP_PATH("migrate_new")));
-    mu_check(!storage_file_exists(storage, TEST_TMP_PATH("migrate_old")));
-    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new1")));
+    mu_check(storage_dir_exists(storage, UNIT_TESTS_PATH("migrate_new")));
+    mu_check(!storage_file_exists(storage, UNIT_TESTS_PATH("migrate_old")));
+    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new1")));
 
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old"));
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new"));
-    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new1"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new"));
+    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new1"));
 
     furi_record_close(RECORD_STORAGE);
 }
@@ -699,7 +702,7 @@ MU_TEST(test_md5_calc) {
     Storage* storage = furi_record_open(RECORD_STORAGE);
     File* file = storage_file_alloc(storage);
 
-    const char* path = TEST_RESOURCES_PATH("storage/md5.txt");
+    const char* path = UINTTEST_RESOURCES_PATH("storage/md5.txt");
     const char* md5_cstr = "2a456fa43e75088fdde41c93159d62a2";
     const uint8_t md5[MD5_HASH_SIZE] = {
         0x2a,

--- a/applications/debug/unit_tests/tests/storage/storage_test.c
+++ b/applications/debug/unit_tests/tests/storage/storage_test.c
@@ -409,9 +409,33 @@ MU_TEST(storage_dir_rename) {
     furi_record_close(RECORD_STORAGE);
 }
 
+MU_TEST(storage_equiv_and_subdir) {
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+
+    mu_assert_int_eq(
+        true, storage_common_equivalent_path(storage, EXT_PATH("blah"), EXT_PATH("blah")));
+    mu_assert_int_eq(
+        true, storage_common_equivalent_path(storage, EXT_PATH("blah/"), EXT_PATH("blah/")));
+    mu_assert_int_eq(
+        false, storage_common_equivalent_path(storage, EXT_PATH("blah"), EXT_PATH("blah-blah")));
+    mu_assert_int_eq(
+        false, storage_common_equivalent_path(storage, EXT_PATH("blah/"), EXT_PATH("blah-blah/")));
+
+    mu_assert_int_eq(true, storage_common_is_subdir(storage, EXT_PATH("blah"), EXT_PATH("blah")));
+    mu_assert_int_eq(
+        true, storage_common_is_subdir(storage, EXT_PATH("blah"), EXT_PATH("blah/blah")));
+    mu_assert_int_eq(
+        false, storage_common_is_subdir(storage, EXT_PATH("blah/blah"), EXT_PATH("blah")));
+    mu_assert_int_eq(
+        false, storage_common_is_subdir(storage, EXT_PATH("blah"), EXT_PATH("blah-blah")));
+
+    furi_record_close(RECORD_STORAGE);
+}
+
 MU_TEST_SUITE(storage_rename) {
     MU_RUN_TEST(storage_file_rename);
     MU_RUN_TEST(storage_dir_rename);
+    MU_RUN_TEST(storage_equiv_and_subdir);
 
     Storage* storage = furi_record_open(RECORD_STORAGE);
     for(size_t i = 0; i < COUNT_OF(dir_rename_tests); i++) {

--- a/applications/debug/unit_tests/tests/storage/storage_test.c
+++ b/applications/debug/unit_tests/tests/storage/storage_test.c
@@ -382,20 +382,29 @@ MU_TEST(storage_file_rename) {
     furi_record_close(RECORD_STORAGE);
 }
 
+static const char* dir_rename_tests[][2] = {
+    {EXT_PATH("dir.old"), EXT_PATH("dir.new")},
+    {EXT_PATH("test_dir"), EXT_PATH("test_dir-new")},
+    {EXT_PATH("test"), EXT_PATH("test-test")},
+};
+
 MU_TEST(storage_dir_rename) {
     Storage* storage = furi_record_open(RECORD_STORAGE);
 
-    storage_dir_create(storage, EXT_PATH("dir.old"));
+    for(size_t i = 0; i < COUNT_OF(dir_rename_tests); i++) {
+        const char* old_path = dir_rename_tests[i][0];
+        const char* new_path = dir_rename_tests[i][1];
 
-    mu_check(storage_dir_rename_check(storage, EXT_PATH("dir.old")));
+        storage_dir_create(storage, old_path);
+        mu_check(storage_dir_rename_check(storage, old_path));
 
-    mu_assert_int_eq(
-        FSE_OK, storage_common_rename(storage, EXT_PATH("dir.old"), EXT_PATH("dir.new")));
-    mu_assert_int_eq(FSE_NOT_EXIST, storage_common_stat(storage, EXT_PATH("dir.old"), NULL));
-    mu_check(storage_dir_rename_check(storage, EXT_PATH("dir.new")));
+        mu_assert_int_eq(FSE_OK, storage_common_rename(storage, old_path, new_path));
+        mu_assert_int_eq(FSE_NOT_EXIST, storage_common_stat(storage, old_path, NULL));
+        mu_check(storage_dir_rename_check(storage, new_path));
 
-    storage_dir_remove(storage, EXT_PATH("dir.new"));
-    mu_assert_int_eq(FSE_NOT_EXIST, storage_common_stat(storage, EXT_PATH("dir.new"), NULL));
+        storage_dir_remove(storage, new_path);
+        mu_assert_int_eq(FSE_NOT_EXIST, storage_common_stat(storage, new_path, NULL));
+    }
 
     furi_record_close(RECORD_STORAGE);
 }
@@ -405,8 +414,10 @@ MU_TEST_SUITE(storage_rename) {
     MU_RUN_TEST(storage_dir_rename);
 
     Storage* storage = furi_record_open(RECORD_STORAGE);
-    storage_dir_remove(storage, EXT_PATH("dir.old"));
-    storage_dir_remove(storage, EXT_PATH("dir.new"));
+    for(size_t i = 0; i < COUNT_OF(dir_rename_tests); i++) {
+        storage_dir_remove(storage, dir_rename_tests[i][0]);
+        storage_dir_remove(storage, dir_rename_tests[i][1]);
+    }
     furi_record_close(RECORD_STORAGE);
 }
 

--- a/applications/debug/unit_tests/tests/storage/storage_test.c
+++ b/applications/debug/unit_tests/tests/storage/storage_test.c
@@ -6,12 +6,13 @@
 // This is a hack to access internal storage functions and definitions
 #include <storage/storage_i.h>
 
-#define UNIT_TESTS_PATH(path) EXT_PATH("unit_tests/" path)
+#define TEST_RESOURCES_PATH(path) EXT_PATH("unit_tests/" path)
+#define TEST_TMP_PATH(path) EXT_PATH(".tmp/unit_tests/" path)
 
-#define STORAGE_LOCKED_FILE EXT_PATH("locked_file.test")
+#define STORAGE_LOCKED_FILE TEST_TMP_PATH("locked_file.test")
 #define STORAGE_LOCKED_DIR  STORAGE_INT_PATH_PREFIX
 
-#define STORAGE_TEST_DIR UNIT_TESTS_PATH("test_dir")
+#define STORAGE_TEST_DIR TEST_TMP_PATH("test_dir")
 
 static bool storage_file_create(Storage* storage, const char* path, const char* data) {
     File* file = storage_file_alloc(storage);
@@ -116,7 +117,7 @@ MU_TEST(storage_file_open_close) {
 }
 
 static bool storage_file_read_write_test(File* file, uint8_t* data, size_t test_size) {
-    const char* filename = UNIT_TESTS_PATH("storage_chunk.test");
+    const char* filename = TEST_TMP_PATH("storage_chunk.test");
 
     // fill with pattern
     for(size_t i = 0; i < test_size; i++) {
@@ -369,23 +370,23 @@ MU_TEST(storage_file_rename) {
     Storage* storage = furi_record_open(RECORD_STORAGE);
     File* file = storage_file_alloc(storage);
 
-    mu_check(write_file_13DA(storage, EXT_PATH("file.old")));
-    mu_check(check_file_13DA(storage, EXT_PATH("file.old")));
+    mu_check(write_file_13DA(storage, TEST_TMP_PATH("file.old")));
+    mu_check(check_file_13DA(storage, TEST_TMP_PATH("file.old")));
     mu_assert_int_eq(
-        FSE_OK, storage_common_rename(storage, EXT_PATH("file.old"), EXT_PATH("file.new")));
-    mu_assert_int_eq(FSE_NOT_EXIST, storage_common_stat(storage, EXT_PATH("file.old"), NULL));
-    mu_assert_int_eq(FSE_OK, storage_common_stat(storage, EXT_PATH("file.new"), NULL));
-    mu_check(check_file_13DA(storage, EXT_PATH("file.new")));
-    mu_assert_int_eq(FSE_OK, storage_common_remove(storage, EXT_PATH("file.new")));
+        FSE_OK, storage_common_rename(storage, TEST_TMP_PATH("file.old"), TEST_TMP_PATH("file.new")));
+    mu_assert_int_eq(FSE_NOT_EXIST, storage_common_stat(storage, TEST_TMP_PATH("file.old"), NULL));
+    mu_assert_int_eq(FSE_OK, storage_common_stat(storage, TEST_TMP_PATH("file.new"), NULL));
+    mu_check(check_file_13DA(storage, TEST_TMP_PATH("file.new")));
+    mu_assert_int_eq(FSE_OK, storage_common_remove(storage, TEST_TMP_PATH("file.new")));
 
     storage_file_free(file);
     furi_record_close(RECORD_STORAGE);
 }
 
 static const char* dir_rename_tests[][2] = {
-    {EXT_PATH("dir.old"), EXT_PATH("dir.new")},
-    {EXT_PATH("test_dir"), EXT_PATH("test_dir-new")},
-    {EXT_PATH("test"), EXT_PATH("test-test")},
+    {TEST_TMP_PATH("dir.old"), TEST_TMP_PATH("dir.new")},
+    {TEST_TMP_PATH("test_dir"), TEST_TMP_PATH("test_dir-new")},
+    {TEST_TMP_PATH("test"), TEST_TMP_PATH("test-test")},
 };
 
 MU_TEST(storage_dir_rename) {
@@ -413,21 +414,21 @@ MU_TEST(storage_equiv_and_subdir) {
     Storage* storage = furi_record_open(RECORD_STORAGE);
 
     mu_assert_int_eq(
-        true, storage_common_equivalent_path(storage, EXT_PATH("blah"), EXT_PATH("blah")));
+        true, storage_common_equivalent_path(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah")));
     mu_assert_int_eq(
-        true, storage_common_equivalent_path(storage, EXT_PATH("blah/"), EXT_PATH("blah/")));
+        true, storage_common_equivalent_path(storage, TEST_TMP_PATH("blah/"), TEST_TMP_PATH("blah/")));
     mu_assert_int_eq(
-        false, storage_common_equivalent_path(storage, EXT_PATH("blah"), EXT_PATH("blah-blah")));
+        false, storage_common_equivalent_path(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah-blah")));
     mu_assert_int_eq(
-        false, storage_common_equivalent_path(storage, EXT_PATH("blah/"), EXT_PATH("blah-blah/")));
+        false, storage_common_equivalent_path(storage, TEST_TMP_PATH("blah/"), TEST_TMP_PATH("blah-blah/")));
 
-    mu_assert_int_eq(true, storage_common_is_subdir(storage, EXT_PATH("blah"), EXT_PATH("blah")));
+    mu_assert_int_eq(true, storage_common_is_subdir(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah")));
     mu_assert_int_eq(
-        true, storage_common_is_subdir(storage, EXT_PATH("blah"), EXT_PATH("blah/blah")));
+        true, storage_common_is_subdir(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah/blah")));
     mu_assert_int_eq(
-        false, storage_common_is_subdir(storage, EXT_PATH("blah/blah"), EXT_PATH("blah")));
+        false, storage_common_is_subdir(storage, TEST_TMP_PATH("blah/blah"), TEST_TMP_PATH("blah")));
     mu_assert_int_eq(
-        false, storage_common_is_subdir(storage, EXT_PATH("blah"), EXT_PATH("blah-blah")));
+        false, storage_common_is_subdir(storage, TEST_TMP_PATH("blah"), TEST_TMP_PATH("blah-blah")));
 
     furi_record_close(RECORD_STORAGE);
 }
@@ -519,164 +520,164 @@ MU_TEST(test_storage_common_migrate) {
     Storage* storage = furi_record_open(RECORD_STORAGE);
 
     // Setup test folders
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old"));
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new"));
 
     // Test migration from non existing
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, UNIT_TESTS_PATH("migrate_old"), UNIT_TESTS_PATH("migrate_new")));
+            storage, TEST_TMP_PATH("migrate_old"), TEST_TMP_PATH("migrate_new")));
 
     // Test migration from existing folder to non existing
-    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, UNIT_TESTS_PATH("migrate_old")));
-    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old/file1"), "test1"));
-    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old/file2.ext"), "test2"));
-    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old/file3.ext.ext"), "test3"));
+    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, TEST_TMP_PATH("migrate_old")));
+    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old/file1"), "test1"));
+    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old/file2.ext"), "test2"));
+    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old/file3.ext.ext"), "test3"));
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, UNIT_TESTS_PATH("migrate_old"), UNIT_TESTS_PATH("migrate_new")));
+            storage, TEST_TMP_PATH("migrate_old"), TEST_TMP_PATH("migrate_new")));
 
-    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file1")));
-    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file2.ext")));
-    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file3.ext.ext")));
-    mu_check(storage_dir_exists(storage, UNIT_TESTS_PATH("migrate_new")));
-    mu_check(!storage_dir_exists(storage, UNIT_TESTS_PATH("migrate_old")));
+    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file1")));
+    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file2.ext")));
+    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file3.ext.ext")));
+    mu_check(storage_dir_exists(storage, TEST_TMP_PATH("migrate_new")));
+    mu_check(!storage_dir_exists(storage, TEST_TMP_PATH("migrate_old")));
 
     // Test migration from existing folder to existing folder
-    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, UNIT_TESTS_PATH("migrate_old")));
-    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old/file1"), "test1"));
-    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old/file2.ext"), "test2"));
-    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old/file3.ext.ext"), "test3"));
+    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, TEST_TMP_PATH("migrate_old")));
+    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old/file1"), "test1"));
+    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old/file2.ext"), "test2"));
+    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old/file3.ext.ext"), "test3"));
 
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, UNIT_TESTS_PATH("migrate_old"), UNIT_TESTS_PATH("migrate_new")));
+            storage, TEST_TMP_PATH("migrate_old"), TEST_TMP_PATH("migrate_new")));
 
-    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file1")));
-    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file2.ext")));
-    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file3.ext.ext")));
-    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file11")));
-    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file21.ext")));
-    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new/file3.ext1.ext")));
-    mu_check(storage_dir_exists(storage, UNIT_TESTS_PATH("migrate_new")));
-    mu_check(!storage_dir_exists(storage, UNIT_TESTS_PATH("migrate_old")));
+    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file1")));
+    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file2.ext")));
+    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file3.ext.ext")));
+    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file11")));
+    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file21.ext")));
+    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new/file3.ext1.ext")));
+    mu_check(storage_dir_exists(storage, TEST_TMP_PATH("migrate_new")));
+    mu_check(!storage_dir_exists(storage, TEST_TMP_PATH("migrate_old")));
 
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old"));
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new"));
 
     // Test migration from empty folder to existing file
     // Expected result: FSE_OK, folder removed, file untouched
-    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, UNIT_TESTS_PATH("migrate_old")));
-    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_new"), "test1"));
+    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, TEST_TMP_PATH("migrate_old")));
+    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_new"), "test1"));
 
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, UNIT_TESTS_PATH("migrate_old"), UNIT_TESTS_PATH("migrate_new")));
+            storage, TEST_TMP_PATH("migrate_old"), TEST_TMP_PATH("migrate_new")));
 
-    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new")));
-    mu_check(!storage_dir_exists(storage, UNIT_TESTS_PATH("migrate_old")));
+    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new")));
+    mu_check(!storage_dir_exists(storage, TEST_TMP_PATH("migrate_old")));
 
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old"));
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new"));
 
     // Test migration from empty folder to existing folder
     // Expected result: FSE_OK, old folder removed, new folder untouched
-    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, UNIT_TESTS_PATH("migrate_old")));
-    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, UNIT_TESTS_PATH("migrate_new")));
+    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, TEST_TMP_PATH("migrate_old")));
+    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, TEST_TMP_PATH("migrate_new")));
 
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, UNIT_TESTS_PATH("migrate_old"), UNIT_TESTS_PATH("migrate_new")));
+            storage, TEST_TMP_PATH("migrate_old"), TEST_TMP_PATH("migrate_new")));
 
-    mu_check(storage_dir_exists(storage, UNIT_TESTS_PATH("migrate_new")));
-    mu_check(!storage_dir_exists(storage, UNIT_TESTS_PATH("migrate_old")));
+    mu_check(storage_dir_exists(storage, TEST_TMP_PATH("migrate_new")));
+    mu_check(!storage_dir_exists(storage, TEST_TMP_PATH("migrate_old")));
 
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old"));
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new"));
 
     // Test migration from existing file to non existing, no extension
-    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old"), "test1"));
+    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old"), "test1"));
 
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, UNIT_TESTS_PATH("migrate_old"), UNIT_TESTS_PATH("migrate_new")));
+            storage, TEST_TMP_PATH("migrate_old"), TEST_TMP_PATH("migrate_new")));
 
-    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new")));
-    mu_check(!storage_file_exists(storage, UNIT_TESTS_PATH("migrate_old")));
+    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new")));
+    mu_check(!storage_file_exists(storage, TEST_TMP_PATH("migrate_old")));
 
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old"));
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new"));
 
     // Test migration from existing file to non existing, with extension
-    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old.file"), "test1"));
+    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old.file"), "test1"));
 
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, UNIT_TESTS_PATH("migrate_old.file"), UNIT_TESTS_PATH("migrate_new.file")));
+            storage, TEST_TMP_PATH("migrate_old.file"), TEST_TMP_PATH("migrate_new.file")));
 
-    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new.file")));
-    mu_check(!storage_file_exists(storage, UNIT_TESTS_PATH("migrate_old.file")));
+    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new.file")));
+    mu_check(!storage_file_exists(storage, TEST_TMP_PATH("migrate_old.file")));
 
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old.file"));
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new.file"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old.file"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new.file"));
 
     // Test migration from existing file to existing file, no extension
-    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old"), "test1"));
-    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_new"), "test2"));
+    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old"), "test1"));
+    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_new"), "test2"));
 
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, UNIT_TESTS_PATH("migrate_old"), UNIT_TESTS_PATH("migrate_new")));
+            storage, TEST_TMP_PATH("migrate_old"), TEST_TMP_PATH("migrate_new")));
 
-    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new")));
-    mu_check(!storage_file_exists(storage, UNIT_TESTS_PATH("migrate_old")));
-    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new1")));
+    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new")));
+    mu_check(!storage_file_exists(storage, TEST_TMP_PATH("migrate_old")));
+    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new1")));
 
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old"));
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new"));
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new1"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new1"));
 
     // Test migration from existing file to existing file, with extension
-    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old.file"), "test1"));
-    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_new.file"), "test2"));
+    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old.file"), "test1"));
+    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_new.file"), "test2"));
 
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, UNIT_TESTS_PATH("migrate_old.file"), UNIT_TESTS_PATH("migrate_new.file")));
+            storage, TEST_TMP_PATH("migrate_old.file"), TEST_TMP_PATH("migrate_new.file")));
 
-    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new.file")));
-    mu_check(!storage_file_exists(storage, UNIT_TESTS_PATH("migrate_old.file")));
-    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new1.file")));
+    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new.file")));
+    mu_check(!storage_file_exists(storage, TEST_TMP_PATH("migrate_old.file")));
+    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new1.file")));
 
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old.file"));
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new.file"));
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new1.file"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old.file"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new.file"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new1.file"));
 
     // Test migration from existing file to existing folder
-    mu_check(storage_file_create(storage, UNIT_TESTS_PATH("migrate_old"), "test1"));
-    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, UNIT_TESTS_PATH("migrate_new")));
+    mu_check(storage_file_create(storage, TEST_TMP_PATH("migrate_old"), "test1"));
+    mu_assert_int_eq(FSE_OK, storage_common_mkdir(storage, TEST_TMP_PATH("migrate_new")));
 
     mu_assert_int_eq(
         FSE_OK,
         storage_common_migrate(
-            storage, UNIT_TESTS_PATH("migrate_old"), UNIT_TESTS_PATH("migrate_new")));
+            storage, TEST_TMP_PATH("migrate_old"), TEST_TMP_PATH("migrate_new")));
 
-    mu_check(storage_dir_exists(storage, UNIT_TESTS_PATH("migrate_new")));
-    mu_check(!storage_file_exists(storage, UNIT_TESTS_PATH("migrate_old")));
-    mu_check(storage_file_exists(storage, UNIT_TESTS_PATH("migrate_new1")));
+    mu_check(storage_dir_exists(storage, TEST_TMP_PATH("migrate_new")));
+    mu_check(!storage_file_exists(storage, TEST_TMP_PATH("migrate_old")));
+    mu_check(storage_file_exists(storage, TEST_TMP_PATH("migrate_new1")));
 
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_old"));
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new"));
-    storage_simply_remove_recursive(storage, UNIT_TESTS_PATH("migrate_new1"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_old"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new"));
+    storage_simply_remove_recursive(storage, TEST_TMP_PATH("migrate_new1"));
 
     furi_record_close(RECORD_STORAGE);
 }
@@ -688,7 +689,7 @@ MU_TEST(test_md5_calc) {
     Storage* storage = furi_record_open(RECORD_STORAGE);
     File* file = storage_file_alloc(storage);
 
-    const char* path = UNIT_TESTS_PATH("storage/md5.txt");
+    const char* path = TEST_RESOURCES_PATH("storage/md5.txt");
     const char* md5_cstr = "2a456fa43e75088fdde41c93159d62a2";
     const uint8_t md5[MD5_HASH_SIZE] = {
         0x2a,

--- a/applications/services/storage/storage.h
+++ b/applications/services/storage/storage.h
@@ -401,21 +401,26 @@ bool storage_common_exists(Storage* storage, const char* path);
  * - /int/Test and /int/test -> false (Case-sensitive storage),
  * - /ext/Test and /ext/test -> true (Case-insensitive storage).
  *
- * If the truncate parameter is set to true, the second path will be
- * truncated to be no longer than the first one. It is useful to determine
- * whether path2 is a subdirectory of path1.
- *
  * @param storage pointer to a storage API instance.
  * @param path1 pointer to a zero-terminated string containing the first path.
  * @param path2 pointer to a zero-terminated string containing the second path.
- * @param truncate whether to truncate path2 to be no longer than path1.
  * @return true if paths are equivalent, false otherwise.
  */
-bool storage_common_equivalent_path(
-    Storage* storage,
-    const char* path1,
-    const char* path2,
-    bool truncate);
+bool storage_common_equivalent_path(Storage* storage, const char* path1, const char* path2);
+
+/**
+ * @brief Check whether a path is a subpath of another path.
+ * 
+ * This function respects storage-defined equivalence rules
+ * (see `storage_common_equivalent_path`).
+ * 
+ * @param storage pointer to a storage API instance.
+ * @param parent pointer to a zero-terminated string containing the parent path.
+ * @param child pointer to a zero-terminated string containing the child path.
+ * @return true if `child` is a subpath of `parent`, or if `child` is equivalent
+ *         to `parent`; false otherwise.
+ */
+bool storage_common_is_subdir(Storage* storage, const char* parent, const char* child);
 
 /******************* Error Functions *******************/
 

--- a/applications/services/storage/storage_external_api.c
+++ b/applications/services/storage/storage_external_api.c
@@ -493,13 +493,13 @@ FS_Error storage_common_rename(Storage* storage, const char* old_path, const cha
             }
 
             // Cannot rename a directory to itself or to a nested directory
-            if(storage_common_equivalent_path(storage, old_path, new_path, true)) {
+            if(storage_common_is_subdir(storage, old_path, new_path)) {
                 error = FSE_INVALID_NAME;
                 break;
             }
 
             // Renaming a regular file to itself does nothing and always succeeds
-        } else if(storage_common_equivalent_path(storage, old_path, new_path, false)) {
+        } else if(storage_common_equivalent_path(storage, old_path, new_path)) {
             error = FSE_OK;
             break;
         }
@@ -816,11 +816,11 @@ bool storage_common_exists(Storage* storage, const char* path) {
     return storage_common_stat(storage, path, &file_info) == FSE_OK;
 }
 
-bool storage_common_equivalent_path(
+static bool storage_internal_equivalent_path(
     Storage* storage,
     const char* path1,
     const char* path2,
-    bool truncate) {
+    bool check_subdir) {
     furi_check(storage);
 
     S_API_PROLOGUE;
@@ -829,7 +829,7 @@ bool storage_common_equivalent_path(
         .cequivpath = {
             .path1 = path1,
             .path2 = path2,
-            .truncate = truncate,
+            .check_subdir = check_subdir,
             .thread_id = furi_thread_get_current_id(),
         }};
 
@@ -837,6 +837,14 @@ bool storage_common_equivalent_path(
     S_API_EPILOGUE;
 
     return S_RETURN_BOOL;
+}
+
+bool storage_common_equivalent_path(Storage* storage, const char* path1, const char* path2) {
+    return storage_internal_equivalent_path(storage, path1, path2, false);
+}
+
+bool storage_common_is_subdir(Storage* storage, const char* parent, const char* child) {
+    return storage_internal_equivalent_path(storage, parent, child, true);
 }
 
 /****************** ERROR ******************/

--- a/applications/services/storage/storage_message.h
+++ b/applications/services/storage/storage_message.h
@@ -72,7 +72,7 @@ typedef struct {
 typedef struct {
     const char* path1;
     const char* path2;
-    bool truncate;
+    bool check_subdir;
     FuriThreadId thread_id;
 } SADataCEquivPath;
 

--- a/applications/services/storage/storage_processing.c
+++ b/applications/services/storage/storage_processing.c
@@ -694,7 +694,23 @@ void storage_process_message_internal(Storage* app, StorageMessage* message) {
         storage_path_trim_trailing_slashes(path2);
         storage_process_alias(app, path1, message->data->cequivpath.thread_id, false);
         storage_process_alias(app, path2, message->data->cequivpath.thread_id, false);
-        if(message->data->cequivpath.truncate) {
+        if(message->data->cequivpath.check_subdir) {
+            // by appending slashes at the end and then truncating the first path, we can
+            // effectively check for shared path components:
+            // example 1:
+            //   path1: "/ext/blah"      -> "/ext/blah/"      -> "/ext/blah/"
+            //   path2: "/ext/blah-blah" -> "/ect/blah-blah/" -> "/ext/blah-"
+            //   results unequal, conclusion: path2 is not a subpath of path1
+            // example 2:
+            //   path1: "/ext/blah"      -> "/ext/blah/"      -> "/ext/blah/"
+            //   path2: "/ext/blah/blah" -> "/ect/blah/blah/" -> "/ext/blah/"
+            //   results equal, conclusion: path2 is a subpath of path1
+            // example 3:
+            //   path1: "/ext/blah/blah" -> "/ect/blah/blah/" -> "/ext/blah/blah/"
+            //   path2: "/ext/blah"      -> "/ext/blah/"      -> "/ext/blah/"
+            //   results unequal, conclusion: path2 is not a subpath of path1
+            furi_string_push_back(path1, '/');
+            furi_string_push_back(path2, '/');
             furi_string_left(path2, furi_string_size(path1));
         }
         message->return_data->bool_value =

--- a/applications/services/storage/storage_processing.c
+++ b/applications/services/storage/storage_processing.c
@@ -695,7 +695,7 @@ void storage_process_message_internal(Storage* app, StorageMessage* message) {
         storage_process_alias(app, path1, message->data->cequivpath.thread_id, false);
         storage_process_alias(app, path2, message->data->cequivpath.thread_id, false);
         if(message->data->cequivpath.check_subdir) {
-            // by appending slashes at the end and then truncating the first path, we can
+            // by appending slashes at the end and then truncating the second path, we can
             // effectively check for shared path components:
             // example 1:
             //   path1: "/ext/blah"      -> "/ext/blah/"      -> "/ext/blah/"

--- a/targets/f18/api_symbols.csv
+++ b/targets/f18/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,73.0,,
+Version,+,74.0,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
 Header,+,applications/services/cli/cli.h,,
@@ -2491,9 +2491,10 @@ Function,+,st25r3916_write_pttsn_mem,void,"FuriHalSpiBusHandle*, uint8_t*, size_
 Function,+,st25r3916_write_reg,void,"FuriHalSpiBusHandle*, uint8_t, uint8_t"
 Function,+,st25r3916_write_test_reg,void,"FuriHalSpiBusHandle*, uint8_t, uint8_t"
 Function,+,storage_common_copy,FS_Error,"Storage*, const char*, const char*"
-Function,+,storage_common_equivalent_path,_Bool,"Storage*, const char*, const char*, _Bool"
+Function,+,storage_common_equivalent_path,_Bool,"Storage*, const char*, const char*"
 Function,+,storage_common_exists,_Bool,"Storage*, const char*"
 Function,+,storage_common_fs_info,FS_Error,"Storage*, const char*, uint64_t*, uint64_t*"
+Function,+,storage_common_is_subdir,_Bool,"Storage*, const char*, const char*"
 Function,+,storage_common_merge,FS_Error,"Storage*, const char*, const char*"
 Function,+,storage_common_migrate,FS_Error,"Storage*, const char*, const char*"
 Function,+,storage_common_mkdir,FS_Error,"Storage*, const char*"

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,73.0,,
+Version,+,74.0,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
@@ -3168,9 +3168,10 @@ Function,+,st25tb_save,_Bool,"const St25tbData*, FlipperFormat*"
 Function,+,st25tb_set_uid,_Bool,"St25tbData*, const uint8_t*, size_t"
 Function,+,st25tb_verify,_Bool,"St25tbData*, const FuriString*"
 Function,+,storage_common_copy,FS_Error,"Storage*, const char*, const char*"
-Function,+,storage_common_equivalent_path,_Bool,"Storage*, const char*, const char*, _Bool"
+Function,+,storage_common_equivalent_path,_Bool,"Storage*, const char*, const char*"
 Function,+,storage_common_exists,_Bool,"Storage*, const char*"
 Function,+,storage_common_fs_info,FS_Error,"Storage*, const char*, uint64_t*, uint64_t*"
+Function,+,storage_common_is_subdir,_Bool,"Storage*, const char*, const char*"
 Function,+,storage_common_merge,FS_Error,"Storage*, const char*, const char*"
 Function,+,storage_common_migrate,FS_Error,"Storage*, const char*, const char*"
 Function,+,storage_common_mkdir,FS_Error,"Storage*, const char*"


### PR DESCRIPTION
# What's new
  - Split the `storage_common_equivalent_path` API function with a bool parameter at the end into two: `storage_common_equivalent_path` and `storage_common_is_subdir`
  - Fix the subdirectory checking functionality that setting the aforementioned parameter to `true` intends to achieve
  - By doing that, fix the bug where a folder rename would fail in some cases (e.g. `/ext/test` -> `/ext/test-test`)
  - A test for the aforementioned bug
  - Refactored storage tests a bit

# Verification 
  - Run unit tests

Or (in either qFlipper or the CLI):
  - Create a `/ext/test` folder
  - Try to rename the folder into `/ext/test-test`
  - Vierfy that the operation completes successfully
  
# Remarks
  - I decided to split the function into two because previously it was not immediately clear that the semantics of the function change drastically if the last argument is set to `true`. Among other things, the order of the string parameters suddenly starts to matter, which is not clear from their names (`path1` and `path2`). It still doesn't matter in the equivalence relation, but it does matter in the subdirectory relation.
  - That said, the implementation of both of these API functions is quite similar, so I decided not to add another message type in order to reduce code size.

# Checklist (For Reviewer)
  - [x] PR has description of feature/bug or link to Confluence/Jira task
  - [x] Description contains actions to verify feature/bugfix
  - [x] I've built this code, uploaded it to the device and verified feature/bugfix
