### PR TITLE
furi_hal_random: Wait for ready state and no errors before sampling

### DIFF
--- a/targets/f7/furi_hal/furi_hal_random.c
+++ b/targets/f7/furi_hal/furi_hal_random.c
@@ -11,7 +11,7 @@
 #define TAG "FuriHalRandom"
 
 static uint32_t furi_hal_random_read_rng(void) {
-    while(LL_RNG_IsActiveFlag_CECS(RNG) && LL_RNG_IsActiveFlag_SECS(RNG) &&
+    while(LL_RNG_IsActiveFlag_CECS(RNG) || LL_RNG_IsActiveFlag_SECS(RNG) ||
           !LL_RNG_IsActiveFlag_DRDY(RNG)) {
         /* Error handling as described in RM0434, pg. 582-583 */
         if(LL_RNG_IsActiveFlag_CECS(RNG)) {


### PR DESCRIPTION
When random output is not ready, but error state flags are not set, sampling of random generator samples zero until next value is ready.

# What's new

- Fixes #3932 
- Changed conditions in `furi_hal_random_read_rng` to wait for ready state of random generator

# Verification 

- Generate 40 bytes with simple random generator [app](https://gist.github.com/n1kolasM/1ef947fd2bb77737034c8f7d216ebccb). There are no zeroes in output with new firmware

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
