### PR TITLE
nfc/clipper: Update BART station codes

### DIFF
--- a/applications/main/nfc/plugins/supported_cards/clipper.c
+++ b/applications/main/nfc/plugins/supported_cards/clipper.c
@@ -106,7 +106,7 @@ static const IdMapping bart_zones[] = {
     {.id = 0x0023, .name = "South Hayward"},
     {.id = 0x0024, .name = "Union City"},
     {.id = 0x0025, .name = "Fremont"},
-    {.id = 0x0026, .name = "Daly City(2)?"},
+    {.id = 0x0026, .name = "Castro Valley"},
     {.id = 0x0027, .name = "Dublin/Pleasanton"},
     {.id = 0x0028, .name = "South San Francisco"},
     {.id = 0x0029, .name = "San Bruno"},
@@ -115,6 +115,8 @@ static const IdMapping bart_zones[] = {
     {.id = 0x002c, .name = "West Dublin/Pleasanton"},
     {.id = 0x002d, .name = "OAK Airport"},
     {.id = 0x002e, .name = "Warm Springs/South Fremont"},
+    {.id = 0x002f, .name = "Milpitas"},
+    {.id = 0x0030, .name = "Berryessa/North San Jose"},
 };
 static const size_t kNumBARTZones = COUNT(bart_zones);
 


### PR DESCRIPTION
In the NFC Clipper card plugin, update the BART station codes for two newer East Bay stations (Milpitas, and Berryessa/North San Jose), and correct the station code for Castro Valley. These station ids come from visiting the stations and checking what id they presented as in the Clipper card data.

# What's new

- New station codes for East Bay stations
- Corrected name for Castro Valley

# Verification 

To fully verify this would require tagging in and out at these three BART stations. I did this with my real Clipper card and read it with my Flipper Zero afterwards. Here's a screenshot of a ride I took on BART (in the San Francisco Bay Area) from Berryessa/North San Jose to Milpitas, on Sunday afternoon (Pacific time), running with my code change to fill in the station codes:

![flipper-ride1-after](https://github.com/user-attachments/assets/80ca6c68-3956-4c03-9954-e0b5d75895a1)

And a second ride I took, from Milpitas to Castro Valley:

![flipper-ride2-after](https://github.com/user-attachments/assets/25a0fc78-ea41-433a-bb99-8a2160d6ec1b)

On the released firmware, the Berryessa and Milpitas stations show as "Unknown", and the Castro Valley station shows as "Daly City(2)?".

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
