### PR TITLE
Furi: A Lot of Fixes

### DIFF
--- a/applications/services/bt/bt_service/bt.c
+++ b/applications/services/bt/bt_service/bt.c
@@ -430,13 +430,11 @@ static void bt_change_profile(Bt* bt, BtMessage* message) {
             *message->profile_instance = NULL;
         }
     }
-    if(message->lock) api_lock_unlock(message->lock);
 }
 
-static void bt_close_connection(Bt* bt, BtMessage* message) {
+static void bt_close_connection(Bt* bt) {
     bt_close_rpc_connection(bt);
     furi_hal_bt_stop_advertising();
-    if(message->lock) api_lock_unlock(message->lock);
 }
 
 static void bt_apply_settings(Bt* bt) {
@@ -484,19 +482,13 @@ static void bt_load_settings(Bt* bt) {
 }
 
 static void bt_handle_get_settings(Bt* bt, BtMessage* message) {
-    furi_assert(message->lock);
     *message->data.settings = bt->bt_settings;
-    api_lock_unlock(message->lock);
 }
 
 static void bt_handle_set_settings(Bt* bt, BtMessage* message) {
-    furi_assert(message->lock);
     bt->bt_settings = *message->data.csettings;
-
     bt_apply_settings(bt);
     bt_settings_save(&bt->bt_settings);
-
-    api_lock_unlock(message->lock);
 }
 
 static void bt_handle_reload_keys_settings(Bt* bt) {
@@ -548,6 +540,12 @@ int32_t bt_srv(void* p) {
     while(1) {
         furi_check(
             furi_message_queue_get(bt->message_queue, &message, FuriWaitForever) == FuriStatusOk);
+        FURI_LOG_D(
+            TAG,
+            "call %d, lock 0x%p, result 0x%p",
+            message.type,
+            (void*)message.lock,
+            (void*)message.result);
         if(message.type == BtMessageTypeUpdateStatus) {
             // Update view ports
             bt_statusbar_update(bt);
@@ -571,7 +569,7 @@ int32_t bt_srv(void* p) {
         } else if(message.type == BtMessageTypeSetProfile) {
             bt_change_profile(bt, &message);
         } else if(message.type == BtMessageTypeDisconnect) {
-            bt_close_connection(bt, &message);
+            bt_close_connection(bt);
         } else if(message.type == BtMessageTypeForgetBondedDevices) {
             bt_keys_storage_delete(bt->keys_storage);
         } else if(message.type == BtMessageTypeGetSettings) {
@@ -581,6 +579,8 @@ int32_t bt_srv(void* p) {
         } else if(message.type == BtMessageTypeReloadKeysSettings) {
             bt_handle_reload_keys_settings(bt);
         }
+
+        if(message.lock) api_lock_unlock(message.lock);
     }
 
     return 0;

--- a/applications/services/dialogs/dialogs_module_file_browser.c
+++ b/applications/services/dialogs/dialogs_module_file_browser.c
@@ -54,11 +54,14 @@ bool dialogs_app_process_module_file_browser(const DialogsAppMessageDataFileBrow
     ret = file_browser_context->result;
 
     view_holder_set_view(view_holder, NULL);
-    view_holder_free(view_holder);
     file_browser_stop(file_browser);
+
     file_browser_free(file_browser);
+    view_holder_free(view_holder);
+
     api_lock_free(file_browser_context->lock);
     free(file_browser_context);
+
     furi_record_close(RECORD_GUI);
 
     return ret;

--- a/applications/services/rpc/rpc.c
+++ b/applications/services/rpc/rpc.c
@@ -67,7 +67,7 @@ static RpcSystemCallbacks rpc_systems[] = {
 struct RpcSession {
     Rpc* rpc;
 
-    FuriThreadId thread_id;
+    FuriThread* thread;
 
     RpcHandlerDict_t handlers;
     FuriStreamBuffer* stream;
@@ -172,7 +172,7 @@ size_t rpc_session_feed(
 
     size_t bytes_sent = furi_stream_buffer_send(session->stream, encoded_bytes, size, timeout);
 
-    furi_thread_flags_set(session->thread_id, RpcEvtNewData);
+    furi_thread_flags_set(furi_thread_get_id(session->thread), RpcEvtNewData);
 
     return bytes_sent;
 }
@@ -220,7 +220,7 @@ bool rpc_pb_stream_read(pb_istream_t* istream, pb_byte_t* buf, size_t count) {
                     break;
                 } else {
                     /* Save disconnect flag and continue reading buffer */
-                    furi_thread_flags_set(session->thread_id, RpcEvtDisconnect);
+                    furi_thread_flags_set(furi_thread_get_id(session->thread), RpcEvtDisconnect);
                 }
             } else if(flags & RpcEvtNewData) {
                 // Just wake thread up
@@ -347,32 +347,37 @@ static int32_t rpc_session_worker(void* context) {
     return 0;
 }
 
-static void rpc_session_thread_release_callback(
-    FuriThread* thread,
-    FuriThreadState thread_state,
-    void* context) {
-    if(thread_state == FuriThreadStateStopped) {
-        RpcSession* session = (RpcSession*)context;
+static void rpc_session_thread_pending_callback(void* context, uint32_t arg) {
+    UNUSED(arg);
+    RpcSession* session = (RpcSession*)context;
 
-        for(size_t i = 0; i < COUNT_OF(rpc_systems); ++i) {
-            if(rpc_systems[i].free) {
-                (rpc_systems[i].free)(session->system_contexts[i]);
-            }
+    for(size_t i = 0; i < COUNT_OF(rpc_systems); ++i) {
+        if(rpc_systems[i].free) {
+            (rpc_systems[i].free)(session->system_contexts[i]);
         }
-        free(session->system_contexts);
-        free(session->decoded_message);
-        RpcHandlerDict_clear(session->handlers);
-        furi_stream_buffer_free(session->stream);
+    }
+    free(session->system_contexts);
+    free(session->decoded_message);
+    RpcHandlerDict_clear(session->handlers);
+    furi_stream_buffer_free(session->stream);
 
-        furi_mutex_acquire(session->callbacks_mutex, FuriWaitForever);
-        if(session->terminated_callback) {
-            session->terminated_callback(session->context);
-        }
-        furi_mutex_release(session->callbacks_mutex);
+    furi_mutex_acquire(session->callbacks_mutex, FuriWaitForever);
+    if(session->terminated_callback) {
+        session->terminated_callback(session->context);
+    }
+    furi_mutex_release(session->callbacks_mutex);
 
-        furi_mutex_free(session->callbacks_mutex);
-        furi_thread_free(thread);
-        free(session);
+    furi_mutex_free(session->callbacks_mutex);
+    furi_thread_join(session->thread);
+    furi_thread_free(session->thread);
+    free(session);
+}
+
+static void
+    rpc_session_thread_state_callback(FuriThread* thread, FuriThreadState state, void* context) {
+    UNUSED(thread);
+    if(state == FuriThreadStateStopped) {
+        furi_timer_pending_callback(rpc_session_thread_pending_callback, context, 0);
     }
 }
 
@@ -404,14 +409,12 @@ RpcSession* rpc_session_open(Rpc* rpc, RpcOwner owner) {
     };
     rpc_add_handler(session, PB_Main_stop_session_tag, &rpc_handler);
 
-    FuriThread* thread =
-        furi_thread_alloc_ex("RpcSessionWorker", 3072, rpc_session_worker, session);
-    session->thread_id = furi_thread_get_id(thread);
+    session->thread = furi_thread_alloc_ex("RpcSessionWorker", 3072, rpc_session_worker, session);
 
-    furi_thread_set_state_context(thread, session);
-    furi_thread_set_state_callback(thread, rpc_session_thread_release_callback);
+    furi_thread_set_state_context(session->thread, session);
+    furi_thread_set_state_callback(session->thread, rpc_session_thread_state_callback);
 
-    furi_thread_start(thread);
+    furi_thread_start(session->thread);
 
     return session;
 }
@@ -423,7 +426,7 @@ void rpc_session_close(RpcSession* session) {
     rpc_session_set_send_bytes_callback(session, NULL);
     rpc_session_set_close_callback(session, NULL);
     rpc_session_set_buffer_is_empty_callback(session, NULL);
-    furi_thread_flags_set(session->thread_id, RpcEvtDisconnect);
+    furi_thread_flags_set(furi_thread_get_id(session->thread), RpcEvtDisconnect);
 }
 
 void rpc_on_system_start(void* p) {

--- a/furi/core/kernel.c
+++ b/furi/core/kernel.c
@@ -33,7 +33,7 @@ bool furi_kernel_is_irq_or_masked(void) {
 }
 
 bool furi_kernel_is_running(void) {
-    return xTaskGetSchedulerState() != taskSCHEDULER_RUNNING;
+    return xTaskGetSchedulerState() == taskSCHEDULER_RUNNING;
 }
 
 int32_t furi_kernel_lock(void) {
@@ -129,6 +129,8 @@ uint32_t furi_kernel_get_tick_frequency(void) {
 
 void furi_delay_tick(uint32_t ticks) {
     furi_check(!furi_kernel_is_irq_or_masked());
+    furi_check(furi_thread_get_current_id() != xTaskGetIdleTaskHandle());
+
     if(ticks == 0U) {
         taskYIELD();
     } else {
@@ -138,6 +140,7 @@ void furi_delay_tick(uint32_t ticks) {
 
 FuriStatus furi_delay_until_tick(uint32_t tick) {
     furi_check(!furi_kernel_is_irq_or_masked());
+    furi_check(furi_thread_get_current_id() != xTaskGetIdleTaskHandle());
 
     TickType_t tcnt, delay;
     FuriStatus stat;

--- a/furi/core/log.c
+++ b/furi/core/log.c
@@ -108,10 +108,17 @@ void furi_log_puts(const char* data) {
 }
 
 void furi_log_print_format(FuriLogLevel level, const char* tag, const char* format, ...) {
-    if(level <= furi_log.log_level &&
-       furi_mutex_acquire(furi_log.mutex, FuriWaitForever) == FuriStatusOk) {
-        FuriString* string;
-        string = furi_string_alloc();
+    do {
+        if(level > furi_log.log_level) {
+            break;
+        }
+
+        if(furi_mutex_acquire(furi_log.mutex, furi_kernel_is_running() ? FuriWaitForever : 0) !=
+           FuriStatusOk) {
+            break;
+        }
+
+        FuriString* string = furi_string_alloc();
 
         const char* color = _FURI_LOG_CLR_RESET;
         const char* log_letter = " ";
@@ -157,7 +164,7 @@ void furi_log_print_format(FuriLogLevel level, const char* tag, const char* form
         furi_log_puts("\r\n");
 
         furi_mutex_release(furi_log.mutex);
-    }
+    } while(0);
 }
 
 void furi_log_print_raw_format(FuriLogLevel level, const char* format, ...) {

--- a/furi/core/thread.h
+++ b/furi/core/thread.h
@@ -21,10 +21,10 @@ extern "C" {
  * Many of the FuriThread functions MUST ONLY be called when the thread is STOPPED.
  */
 typedef enum {
-    FuriThreadStateStopped, /**< Thread is stopped and is safe to release */
-    FuriThreadStateStopping, /**< Thread is stopping */
-    FuriThreadStateStarting, /**< Thread is starting */
-    FuriThreadStateRunning, /**< Thread is running */
+    FuriThreadStateStopped, /**< Thread is stopped and is safe to release. Event delivered from system init thread(TCB cleanup routine). It is safe to release thread instance. */
+    FuriThreadStateStopping, /**< Thread is stopping. Event delivered from child thread. */
+    FuriThreadStateStarting, /**< Thread is starting. Event delivered from parent(self) thread. */
+    FuriThreadStateRunning, /**< Thread is running. Event delivered from child thread. */
 } FuriThreadState;
 
 /**
@@ -32,6 +32,7 @@ typedef enum {
  */
 typedef enum {
     FuriThreadPriorityIdle = 0, /**< Idle priority */
+    FuriThreadPriorityInit = 4, /**< Init System Thread Priority */
     FuriThreadPriorityLowest = 14, /**< Lowest */
     FuriThreadPriorityLow = 15, /**< Low */
     FuriThreadPriorityNormal = 16, /**< Normal, system default */

--- a/furi/core/thread.h
+++ b/furi/core/thread.h
@@ -78,13 +78,15 @@ typedef int32_t (*FuriThreadCallback)(void* context);
 typedef void (*FuriThreadStdoutWriteCallback)(const char* data, size_t size);
 
 /**
- * @brief State change callback function pointer type.
+ * @brief         State change callback function pointer type.
  *
- * The function to be used as a state callback MUST follow this signature.
+ *                The function to be used as a state callback MUST follow this
+ *                signature.
  *
- * @param[in] pointer to the FuriThread instance that changed the state
- * @param[in] state identifier of the state the thread has transitioned to
- * @param[in,out] context pointer to a user-specified object
+ * @param[in]     thread   to the FuriThread instance that changed the state
+ * @param[in]     state    identifier of the state the thread has transitioned
+ *                         to
+ * @param[in,out] context  pointer to a user-specified object
  */
 typedef void (*FuriThreadStateCallback)(FuriThread* thread, FuriThreadState state, void* context);
 

--- a/furi/core/thread_i.h
+++ b/furi/core/thread_i.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "thread.h"
+
+void furi_thread_init(void);
+
+void furi_thread_scrub(void);

--- a/furi/core/timer.h
+++ b/furi/core/timer.h
@@ -35,6 +35,12 @@ FuriTimer* furi_timer_alloc(FuriTimerCallback func, FuriTimerType type, void* co
  */
 void furi_timer_free(FuriTimer* instance);
 
+/** Flush timer task control message queue
+ *
+ * Ensures that all commands before this point was processed.
+ */
+void furi_timer_flush(void);
+
 /** Start timer
  *
  * @warning    This is asynchronous call, real operation will happen as soon as
@@ -61,8 +67,7 @@ FuriStatus furi_timer_restart(FuriTimer* instance, uint32_t ticks);
 
 /** Stop timer
  *
- * @warning    This is asynchronous call, real operation will happen as soon as
- *             timer service process this request.
+ * @warning    This is synchronous call that will be blocked till timer queue processed.
  *
  * @param      instance  The pointer to FuriTimer instance
  *

--- a/furi/furi.c
+++ b/furi/furi.c
@@ -1,5 +1,7 @@
 #include "furi.h"
 
+#include "core/thread_i.h"
+
 #include <FreeRTOS.h>
 #include <queue.h>
 
@@ -7,6 +9,7 @@ void furi_init(void) {
     furi_check(!furi_kernel_is_irq_or_masked());
     furi_check(xTaskGetSchedulerState() == taskSCHEDULER_NOT_STARTED);
 
+    furi_thread_init();
     furi_log_init();
     furi_record_init();
 }
@@ -17,4 +20,8 @@ void furi_run(void) {
 
     /* Start the kernel scheduler */
     vTaskStartScheduler();
+}
+
+void furi_background(void) {
+    furi_thread_scrub();
 }

--- a/furi/furi.h
+++ b/furi/furi.h
@@ -35,6 +35,8 @@ void furi_init(void);
 
 void furi_run(void);
 
+void furi_background(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/targets/f18/api_symbols.csv
+++ b/targets/f18/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,76.0,,
+Version,+,77.0,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
 Header,+,applications/services/cli/cli.h,,
@@ -1102,6 +1102,7 @@ Function,-,ftello,off_t,FILE*
 Function,-,ftrylockfile,int,FILE*
 Function,-,funlockfile,void,FILE*
 Function,-,funopen,FILE*,"const void*, int (*)(void*, char*, int), int (*)(void*, const char*, int), fpos_t (*)(void*, fpos_t, int), int (*)(void*)"
+Function,+,furi_background,void,
 Function,+,furi_delay_ms,void,uint32_t
 Function,+,furi_delay_tick,void,uint32_t
 Function,+,furi_delay_until_tick,FuriStatus,uint32_t
@@ -1672,6 +1673,7 @@ Function,+,furi_thread_stdout_write,size_t,"const char*, size_t"
 Function,+,furi_thread_suspend,void,FuriThreadId
 Function,+,furi_thread_yield,void,
 Function,+,furi_timer_alloc,FuriTimer*,"FuriTimerCallback, FuriTimerType, void*"
+Function,+,furi_timer_flush,void,
 Function,+,furi_timer_free,void,FuriTimer*
 Function,+,furi_timer_get_expire_time,uint32_t,FuriTimer*
 Function,+,furi_timer_is_running,uint32_t,FuriTimer*

--- a/targets/f18/api_symbols.csv
+++ b/targets/f18/api_symbols.csv
@@ -1102,7 +1102,7 @@ Function,-,ftello,off_t,FILE*
 Function,-,ftrylockfile,int,FILE*
 Function,-,funlockfile,void,FILE*
 Function,-,funopen,FILE*,"const void*, int (*)(void*, char*, int), int (*)(void*, const char*, int), fpos_t (*)(void*, fpos_t, int), int (*)(void*)"
-Function,+,furi_background,void,
+Function,-,furi_background,void,
 Function,+,furi_delay_ms,void,uint32_t
 Function,+,furi_delay_tick,void,uint32_t
 Function,+,furi_delay_until_tick,FuriStatus,uint32_t

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,76.0,,
+Version,+,77.0,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
@@ -1207,6 +1207,7 @@ Function,-,ftello,off_t,FILE*
 Function,-,ftrylockfile,int,FILE*
 Function,-,funlockfile,void,FILE*
 Function,-,funopen,FILE*,"const void*, int (*)(void*, char*, int), int (*)(void*, const char*, int), fpos_t (*)(void*, fpos_t, int), int (*)(void*)"
+Function,-,furi_background,void,
 Function,+,furi_delay_ms,void,uint32_t
 Function,+,furi_delay_tick,void,uint32_t
 Function,+,furi_delay_until_tick,FuriStatus,uint32_t
@@ -1886,6 +1887,7 @@ Function,+,furi_thread_stdout_write,size_t,"const char*, size_t"
 Function,+,furi_thread_suspend,void,FuriThreadId
 Function,+,furi_thread_yield,void,
 Function,+,furi_timer_alloc,FuriTimer*,"FuriTimerCallback, FuriTimerType, void*"
+Function,+,furi_timer_flush,void,
 Function,+,furi_timer_free,void,FuriTimer*
 Function,+,furi_timer_get_expire_time,uint32_t,FuriTimer*
 Function,+,furi_timer_is_running,uint32_t,FuriTimer*

--- a/targets/f7/furi_hal/furi_hal_spi.c
+++ b/targets/f7/furi_hal/furi_hal_spi.c
@@ -202,7 +202,7 @@ bool furi_hal_spi_bus_trx_dma(
     furi_check(size > 0);
 
     // If scheduler is not running, use blocking mode
-    if(furi_kernel_is_running()) {
+    if(!furi_kernel_is_running()) {
         return furi_hal_spi_bus_trx(handle, tx_buffer, rx_buffer, size, timeout_ms);
     }
 

--- a/targets/f7/inc/FreeRTOSConfig.h
+++ b/targets/f7/inc/FreeRTOSConfig.h
@@ -84,6 +84,7 @@ to exclude the API function. */
 #define INCLUDE_xTaskGetCurrentTaskHandle   1
 #define INCLUDE_xTaskGetSchedulerState      1
 #define INCLUDE_xTimerPendFunctionCall      1
+#define INCLUDE_xTaskGetIdleTaskHandle      1
 
 /* Workaround for various notification issues:
  * - First one used by system primitives
@@ -129,24 +130,10 @@ See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
 #define configMAX_SYSCALL_INTERRUPT_PRIORITY \
     (configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
 
-/* Normal assert() semantics without relying on the provision of an assert.h
-header file. */
-#ifdef DEBUG
-#include <core/check.h>
-#define configASSERT(x)                \
-    if((x) == 0) {                     \
-        furi_crash("FreeRTOS Assert"); \
-    }
-#endif
-
 /* Definitions that map the FreeRTOS port interrupt handlers to their CMSIS
 standard names. */
 #define vPortSVCHandler    SVC_Handler
 #define xPortPendSVHandler PendSV_Handler
-
-#define USE_CUSTOM_SYSTICK_HANDLER_IMPLEMENTATION 1
-#define configOVERRIDE_DEFAULT_TICK_CONFIGURATION \
-    1 /* required only for Keil but does not hurt otherwise */
 
 #define traceTASK_SWITCHED_IN()                                          \
     extern void furi_hal_mpu_set_stack_protection(uint32_t* stack);      \
@@ -157,6 +144,14 @@ standard names. */
 // referencing `FreeRTOS_errno' here   vvvvv    because FreeRTOS calls our hook _before_ copying the value into the TCB, hence a manual write to the TCB would get overwritten
 #define traceTASK_SWITCHED_OUT() FreeRTOS_errno = errno
 
-#define portCLEAN_UP_TCB(pxTCB)                                   \
-    extern void furi_thread_cleanup_tcb_event(TaskHandle_t task); \
-    furi_thread_cleanup_tcb_event(pxTCB)
+/* Normal assert() semantics without relying on the provision of an assert.h
+header file. */
+#ifdef DEBUG
+#define configASSERT(x)                \
+    if((x) == 0) {                     \
+        furi_crash("FreeRTOS Assert"); \
+    }
+#endif
+
+// Must be last line of config because of recursion
+#include <core/check.h>

--- a/targets/f7/src/main.c
+++ b/targets/f7/src/main.c
@@ -15,6 +15,8 @@ int32_t init_task(void* context) {
     // Init flipper
     flipper_init();
 
+    furi_background();
+
     return 0;
 }
 
@@ -25,7 +27,8 @@ int main(void) {
     // Flipper critical FURI HAL
     furi_hal_init_early();
 
-    FuriThread* main_thread = furi_thread_alloc_ex("Init", 4096, init_task, NULL);
+    FuriThread* main_thread = furi_thread_alloc_ex("InitSrv", 1024, init_task, NULL);
+    furi_thread_set_priority(main_thread, FuriThreadPriorityInit);
 
 #ifdef FURI_RAM_EXEC
     // Prevent entering sleep mode when executed from RAM


### PR DESCRIPTION
# What's new

- BT Service: cleanup code
- Dialog: correct release order in file browser, fix various crashes and bus faults
- Rpc: rollback to pre #3881 state, fix deadlock on gui rpc shutdown
- Kernel: fix inverted behavior in furi_kernel_is_running, make it usable
- Log: properly take mutex when kernel is not running, prevent crash if kernel is not fully running
- Thread: rework tread control block scrubbing procedure, ensure that we don't do stupid things in idle task, add new priority for init task, prevent various deadlocks
- Timer: add control queue flush method, force flush on stop, prevent use after free if timers are incorrectly used
- Furi: system init task now performs thread scrubbing, delay now ensures that you are not using it from the idle task
- BleGlue: add some extra checks
- FreeRTOSConfig: fix bunch of issues that were preventing configuration from being properly applied and cleanup dead things

# Verification 

- Full set of integration tests
- No more lockup on BLE RCP streaming and profile change at the same time
- No more rare bus faults on app start

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
