### PR TITLE
Wi-Fi Devboard documentation rework

### DIFF
--- a/documentation/devboard/Debugging via the Devboard.md
+++ b/documentation/devboard/Debugging via the Devboard.md
@@ -1,0 +1,88 @@
+# Debugging via the Devboard {#dev_board_debugging_guide}
+
+On this page, you'll learn about how debugging via the Wi-Fi Developer Board works. To illustrate this process, we'll start a debug session for Flipper Zero's firmware in VS Code using the native Flipper Build Tool.
+
+***
+
+## Overview
+
+The Developer Board acts as the debug probe, which provides a bridge between the IDE (integrated development environment) with a debugger running on a host computer and the target microcontroller (in your Flipper Zero). The user controls the debugging process on the computer connected to the Developer Board via [Wi-Fi](#dev_board_wifi_connection) or [USB cable](#dev_board_usb_connection).
+
+\image html https://cdn.flipperzero.one/Flipper_Zero_WiFi_hardware_CDN.jpg width=700
+
+Data exchange between the Wi-Fi Developer Board and your Flipper Zero is conducted via the Serial Wire Debug interface. The following GPIO pins serve this purpose:
+
+- **Pin 10:** Serial Wire Clock (SWCLK)
+
+- **Pin 12:** Serial Wire Debug Data I/O (SWDIO)
+
+To learn more about Flipper Zero pinout, visit [GPIO & modules in Flipper Docs](https://docs.flipper.net/gpio-and-modules).
+
+***
+
+## Prerequisites
+
+### Step 1. Installing Git
+
+You'll need Git installed on your computer to clone the firmware repository. If you don't have Git, install it following the [official installation guide](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
+
+### Step 2. Building the firmware
+
+Before starting debugging, you need to clone and build Flipper Zero firmware:
+
+1. Open the **Terminal** (on Linux & macOS) or **PowerShell** (on Windows) in the directory where you want to store the firmware source code.
+
+2. Clone the firmware repository:
+
+    ```
+    git clone --recursive https://github.com/flipperdevices/flipperzero-firmware.git
+    cd flipperzero-firmware
+    ```
+
+3. Run the **Flipper Build Tool (FBT)** to build the firmware:
+
+    ```
+    ./fbt
+    ```
+
+***
+
+## Debugging the firmware
+
+From the **flipperzero-firmware** directory that you cloned earlier, run the following command:
+
+```
+./fbt flash
+```
+
+This will upload the firmware you've just built to your Flipper Zero via the Developer Board. After that, you can start debugging the firmware. We recommend using **VS Code** with the recommended extensions (as described below), and we have pre-made configurations for it.
+
+To debug in **VS Code**, do the following:
+
+1. In VS Code, open the **flipperzero-firmware** directory.
+
+2. You should see a notification about recommended extensions. Install them.
+
+    If there were no notifications, open the **Extensions** tab, enter `@recommended` in the search bar, and install the workspace recommendations.
+
+3. Run the `./fbt vscode_dist` command. This will generate the VS Code configuration files needed for debugging.
+
+4. In VS Code, open the **Run and Debug** tab and select a debugger from the dropdown menu:
+
+    - **Attach FW (blackmagic):** Can be used via **Wi-Fi** or **USB**
+    - **Attach FW (DAP):** Can be used via **USB** only
+
+    Note that when debugging via USB, you need to make sure the selected debugger matches the debug mode on your Devboard. To check the debug mode on your Devboard, access the Devboard's web interface as described [here](#dev_board_wifi_connection) and check the **USB mode** field. If you want to use a different debug mode, enable this mode by following the steps in [Devboard debug modes](#dev_board_debug_modes).
+
+5. If needed, flash your Flipper Zero with the `./fbt flash` command, then click the ▷ **Start Debugging** button in the debug sidebar to start the debugging session.
+
+6. Note that starting a debug session halts the execution of the firmware, so you'll need to click the I▷ **Continue** button on the toolbar at the top of your VS Code window to continue execution.
+
+\image html https://cdn.flipperzero.one/Flipper_Zero_Wi-Fi_devboard_VS_Code.jpg width=900
+
+> [!note]
+> If you want to use a different debug mode on your Developer Board, visit [Devboard debug modes](#dev_board_debug_modes).
+>
+> If you want to read logs via the Developer Board, see [Reading logs via the Devboard](#dev_board_reading_logs).
+> 
+> To learn about debugging in VS Code, see [VS Code official guide](https://code.visualstudio.com/docs/editor/debugging).

--- a/documentation/devboard/Devboard debug modes.md
+++ b/documentation/devboard/Devboard debug modes.md
@@ -1,0 +1,33 @@
+# Devboard debug modes {#dev_board_debug_modes}
+
+The Wi-Fi Devboard for Flipper Zero supports **Black Magic** and **DAPLink** debug modes, and you can switch between them depending on your needs. Note that available modes depend on connection:
+
+- **Wi-Fi:** Only **Black Magic** mode is available.
+- **USB:** Switch between **Black Magic** (default) and **DAPLink**. Learn more about switching debug modes for USB connection below.
+
+> [!note]
+> Black Magic mode doesn't support RTOS threads, but you can still perform other debugging operations.
+
+***
+
+## Switching debug modes for USB connection
+
+Switching debug modes for working via USB has to be done wirelessly (yes, you read that correctly). Additionally, depending on how the Devboard wireless connection is configured, you may need to follow different steps for **Wi-Fi access point mode** or **Wi-Fi client mode**:
+
+1. If the Devboard isn't connected to your Flipper Zero, turn off your Flipper Zero and connect the Developer Board, then turn the device back on.
+
+2. Access the Devboard's web interface:
+
+    - [Wi-Fi access point mode](#wifi-access-point)
+
+    - [Wi-Fi client mode](#wifi-client-mode)
+
+3. In the **WiFi** tab, click the **USB mode** option and select **BlackMagicProbe** or **DapLink**.
+
+4. Click **SAVE**, then click **REBOOT** to apply the changes.
+
+\image html https://cdn.flipperzero.one/Flipper_Zero_WiFi_devboard_switching_modes_CDN.jpg width=700
+
+> [!note]
+> After switching debug modes on your Devboard, remember to select the same debugger in **VS Code** in the **Run and Debug** tab, and click the ▷ **Start Debugging** button.
+

--- a/documentation/devboard/Firmware update on Developer Board.md
+++ b/documentation/devboard/Firmware update on Developer Board.md
@@ -1,122 +1,112 @@
 # Firmware update on Developer Board {#dev_board_fw_update}
 
-It's important to regularly update your Developer Board to ensure that you have access to the latest features and bug fixes. This tutorial will guide you through the necessary steps to update the firmware of your Developer Board.
+It's important to regularly update your Developer Board to ensure that you have access to the latest features and bug fixes. This page will guide you through the necessary steps to update the firmware of your Developer Board.
 
-This tutorial assumes that you're familiar with the basics of the command line. If you’re not, please refer to the [Windows](https://www.digitalcitizen.life/command-prompt-how-use-basic-commands/) or [MacOS/Linux](https://ubuntu.com/tutorials/command-line-for-beginners#1-overview) command line tutorials.
+> [!note]
+> This guide assumes that you're familiar with the basics of the command line. If you're new to it, we recommend checking out these [Windows](https://learn.microsoft.com/en-us/powershell/scripting/learn/ps101/01-getting-started?view=powershell-7.4) or [macOS/Linux](https://ubuntu.com/tutorials/command-line-for-beginners#1-overview) command line tutorials.
 
 ***
 
-## Installing the micro Flipper Build Tool
+## Step 1. Install the micro Flipper Build Tool
 
-Micro Flipper Build Tool (uFBT) is a cross-platform tool that enables basic development tasks for Flipper Zero, such as building and debugging applications, flashing firmware, and creating VS Code development configurations.
+ is a cross-platform tool developed and supported by our team that enables basic development tasks for Flipper Zero, such as building and debugging applications, flashing firmware, creating VS Code development configurations, and flashing firmware to the Wi-Fi Developer Board.
 
-Install uFBT on your computer by running the following command in the Terminal:
+**On Linux & macOS:**
 
-**For Linux & macOS:**
+Run the following command in the Terminal:
 
-```text
+```
 python3 -m pip install --upgrade ufbt
 ```
 
-**For Windows:**
+**On Windows:**
 
-```text
-py -m pip install --upgrade ufbt
-```
+1. Download the latest version of Python on 
+2. Run the following command in the PowerShell
 
-If you want to learn more about uFBT, visit [the project's page](https://pypi.org/project/ufbt/).
+    ```
+    py -m pip install --upgrade ufbt
+    ```
 
 ***
 
-## Connecting the Developer Board to your computer
+## Step 2. Connect the Devboard to PC
+
+To update the firmware, you need to switch your Developer Board to Bootloader mode, connect to a PC via a USB cable, and make sure that the PC detects the Developer Board:
 
 1. List all of the serial devices on your computer.
 
-    **Windows**
+    - **macOS:** Run the `ls /dev/cu.*` command in the Terminal.
 
-    On Windows, go to Device Manager and expand the Ports (COM & LPT) section.
+    - **Linux:** Run the `ls /dev/tty*` command in the Terminal.
 
-    **macOS**
-
-    On macOS, you can run the following command in the Terminal:
-
-    ```text
-    ls /dev/cu.*
-    ```
-
-    **Linux**
-
-    On Linux, you can run the following command in the Terminal:
-
-    ```text
-    ls /dev/tty*
-    ```
-
-    View the devices in the list.
+    - **Windows:** Go to **Device Manager** and expand the **Ports (COM & LPT)** section.
 
 2. Connect the Developer Board to your computer using a USB-C cable.
-![The Developer Board in Wired mode](https://archbee-image-uploads.s3.amazonaws.com/3StCFqarJkJQZV-7N79yY/Aq7gfMI-m_5H6sGGjwb4I_monosnap-miro-2023-07-19-19-47-39.jpg)
+
+    \image html https://cdn.flipperzero.one/Flipper_Zero_Wi-Fi_devboard_update_wired_connection.jpg width=700
 
 3. Switch your Developer Board to Bootloader mode:
 
-    3.1.  Press and hold the **BOOT** button.
+    1. Press and hold the **BOOT** button.
+    2. Press the **RESET** button while holding the **BOOT** button.
+    3. Release the **BOOT** button.
 
-    3.2.  Press the **RESET** button while holding the **BOOT** button.
+    \image html https://cdn.flipperzero.one/Flipper_Zero_Wi-Fi_devboard_reboot_to_bootloader.png width=700
 
-    3.3. Release the **BOOT** button.\
-![You can easily switch the Dev Board to Bootloader mode](https://archbee-image-uploads.s3.amazonaws.com/3StCFqarJkJQZV-7N79yY/KynP9iT6sJ3mXLaLyI82__image.png)
-
-4. Repeat Step 1 and view the name of your Developer Board that appeared in the list.
-
-    For example, on macOS:
-
-    ```text
-    /dev/cu.usbmodem01
-    ```
+4. Repeat **Step 1** and view the name of your Developer Board that appeared in the list.
 
 ***
 
-## Flashing the firmware
+## Step 3. Flash the firmware
 
-To flash the firmware onto your Developer Board, run the following command in the terminal:
+**On Linux & macOS:**
 
-```text
+```
 python3 -m ufbt devboard_flash
+```
+
+**On Windows:** Run the following command in the PowerShell:
+
+```
+py -m ufbt devboard_flash
 ```
 
 You should see the following message: `WiFi board flashed successfully`.
 
-## If flashing failed
+### If flashing failed
 
-If you get an error message during the flashing process, such as this:
+Occasionally, you might get an error message during the flashing process, such as:
 
-```text
+```
 A fatal error occurred: Serial data stream stopped: Possible serial noise or corruption.
 ```
 
-Or this:
+*or*
 
-```text
+```
 FileNotFoundError: [Errno 2] No such file or directory: '/dev/cu.usbmodem01'
 ```
 
-Try doing the following:
+To fix it, try doing the following:
 
-* Disconnect the Developer Board from your computer, then reconnect it.
+- Disconnect the Developer Board from your computer, then reconnect it. After that, switch your Developer Board to Bootloader mode once again, as described in 
 
-* Use a different USB port on your computer.
+- Use a different USB port on your computer.
 
-* Use a different USB-C cable.
+- Use a different USB-C cable.
 
 ***
 
-## Finishing the installation
-
-After flashing the firmware:
+## Step 4. Finish the installation
 
 1. Reboot the Developer Board by pressing the **RESET** button.
-![Reset the Developer Board](https://archbee-image-uploads.s3.amazonaws.com/3StCFqarJkJQZV-7N79yY/rcQeKARgrVwa51tLoo-qY_monosnap-miro-2023-07-20-18-29-33.jpg)
+
+    \image html https://cdn.flipperzero.one/Flipper_Zero_Wi-Fi_devboard_reboot_after_flashing.jpg width=700
 
 2. Disconnect and reconnect the USB-C cable.
 
-The Developer Board should appear as a serial device on your computer. Now, you can use it with the Black Magic Debug client of your choice.
+    You've successfully updated the firmware of your Developer Board!
+
+If you followed the **Get started with the Devboard** guide, you're ready for the next step: [Step 3. Plug the Devboard into Flipper Zero](#dev_board_get_started_step-3).
+

--- a/documentation/devboard/Get started with the Dev Board.md
+++ b/documentation/devboard/Get started with the Dev Board.md
@@ -1,178 +1,80 @@
 # Get started with the Dev Board {#dev_board_get_started}
 
-The Wi-Fi Developer Board serves as a tool to debug the Flipper Zero firmware. To debug the firmware, the initial step involves compiling the firmware from its source code. This process enables the debugging functionality within the firmware and generates all the necessary files required for debugging purposes.
+\image html https://cdn.flipperzero.one/Flipper_Zero_WiFi_developer_board_box_CDN.jpg width=700
 
-> **NOTE:**  Building and debugging the Flipper Zero firmware is fully supported on MacOS and Linux. Support for Windows is in beta test.
-
-***
-
-## Updating the firmware of your Developer Board
-
-Update the firmware of your Developer Board before using it. For more information, visit [Firmware update on Developer Board](https://docs.flipperzero.one/development/hardware/wifi-debugger-module/update).
+Before you start using your Devboard, you need to prepare your Flipper Zero and Devboard for debugging. In this guide, we'll walk you through all the necessary steps and provide links to explore the Devboard's capabilities further.
 
 ***
 
-## Installing Git
+## Step 1. Enable Debug Mode on your Flipper Zero
 
-You'll need Git installed on your computer to clone the firmware repository. If you don't have Git, install it by doing the following:
+Since the main purpose of the Developer board is to debug applications on Flipper Zero, you first need to enable Debug Mode. To do so, go to **Settings → System** and set **Debug** to **ON**.
 
-* **MacOS**
+\image html https://cdn.flipperzero.one/Flipper_Zero_enamble_debug_CDN.jpg width=700
 
-    On MacOS, install the **Xcode Command Line Tools** package, which includes Git as one of the pre-installed command-line utilities, by running in the Terminal the following command:
+> [!note]
+> Debug Mode needs to be re-enabled after each update of Flipper Zero's firmware.
 
-    ```text
-    xcode-select --install
-    ```
+Debug Mode allows you to debug your apps for Flipper Zero, as well as access debugging options in apps via the user interface and CLI. To learn more about Flipper Zero CLI, visit [Command-line interface in Flipper Docs](https://docs.flipper.net/development/cli).
 
-* **Linux**
-
-    On Linux, you can install Git using your package manager. For example, on Ubuntu, run in the Terminal the following command:
-
-    ```text
-    sudo apt install git
-    ```
-
-For other distributions, refer to your package manager documentation.
+\image html https://cdn.flipperzero.one/Flipper_Zero_Command_Line_Interface_CDN.jpg width=700
 
 ***
 
-## Building the firmware
+## Step 2. Update firmware on the Developer Board
 
-First, clone the firmware repository:
-
-```text
-git clone --recursive https://github.com/flipperdevices/flipperzero-firmware.git
-cd flipperzero-firmware
-```
-
-Then, run the **Flipper Build Tool** (FBT) to build the firmware:
-
-```text
-./fbt
-```
+The Developer Board comes with stock firmware that may not include all the latest features and bug fixes. To ensure optimal performance, please update your board's firmware using the instructions in [Firmware update on Devboard](#dev_board_fw_update).
 
 ***
 
-## Connecting the Developer Board
+## Step 3. Plug the Devboard into Flipper Zero {#dev_board_get_started_step-3}
 
-The Developer Board can work in the **Wired** mode and two **Wireless** modes: **Wi-Fi access point (AP)** mode and **Wi-Fi client (STA)** mode. The Wired mode is the simplest to set up, but requires a USB Type-C cable. The Wireless modes are more complex to set up, but they allow you to debug your Flipper Zero wirelessly.
+Once your Developer Board firmware is up to date, you can proceed to plug it into your Flipper Zero. Two important things to keep in mind:
 
-   > **NOTE:**  Use the following credentials when connecting to the Developer Board in **Wi-Fi access point** mode:\n
-    Name: **blackmagic**\n
-    Password: **iamwitcher**
+1. **Power off your Flipper Zero before plugging in the Developer Board.**
 
-## Wired
+    If you skip this step, you may corrupt the data stored on the microSD card. Connecting external modules with a large capacitive load may affect the microSD card's power supply since both the microSD card and external module are powered from the same 3.3 V power source inside Flipper Zero.
 
-![The Developer Board in Wired mode](https://archbee-image-uploads.s3.amazonaws.com/3StCFqarJkJQZV-7N79yY/jZdVlRTPVdSQVegzCyXp7_monosnap-miro-2023-06-22-16-28-06.jpg)
+2. **Make sure the Developer Board is inserted all the way in.**
 
-To connect the Developer Board in **Wired** mode, do the following:
+    If your Flipper Zero isn't in a silicone case, insert the module all the way in so there is no gap between your Flipper Zero and the Devboard. You may need to apply more force to insert it completely. After that, press and hold the **BACK** button to power on your Flipper Zero.
 
-1. Cold-plug the Developer Board by turning off your Flipper Zero and connecting the Developer Board, and then turning it back on.
+    \image html https://cdn.flipperzero.one/Flipper_Zero_external_module_without_case_CDN.jpg width=700
 
-2. On your computer, open the **Terminal** and run the following:
+    If your Flipper Zero is in a silicone case, insert the module all the way in so there is no gap in the middle between the silicone case and the module. After that, press and hold the **BACK** button to power on your Flipper Zero.
 
-    * **MacOS**
-
-        ```text
-        ls /dev/cu.*
-        ```
-
-    * **Linux**
-
-        ```text
-        ls /dev/tty*
-        ```
-
-   Note the list of devices.
-
-3. Connect the Developer Board to your computer via a USB-C cable.
-
-4. Rerun the command. Two new devices have to appear: this is the Developer Board.
-
-   > **NOTE:**  If the Developer Board doesn't appear in the list of devices, try using a different cable, USB port, or computer.
-   >
-   > **NOTE:**  Flipper Zero logs can only be viewed when the Developer Board is connected via USB. The option to view logs over Wi-Fi will be added in future updates. For more information, visit [Reading logs via the Dev Board](https://docs.flipperzero.one/development/hardware/wifi-debugger-module/reading-logs).
-
-## Wireless
-
-### Wi-Fi access point (AP) mode
-
-![The Developer Board in Wi-Fi access point mode](https://archbee-image-uploads.s3.amazonaws.com/3StCFqarJkJQZV-7N79yY/tKRTMHAuruiLSEce2a8Ve_monosnap-miro-2023-06-22-16-39-17.jpg)
-
-Out of the box, the Developer Board is configured to work as a **Wi-Fi access point**. This means it'll create its own Wi-Fi network to which you can connect. If your Developer Board doesn't create a Wi-Fi network, it is probably configured to work in **Wi-Fi client** mode. To reset your Developer Board back to **Wi-Fi access point** mode, press and hold the **BOOT** button for 10 seconds, then wait for the module to reboot.
-
-![You can reconfigure the Developer Board mode by pressing and holding the BOOT button](https://archbee-image-uploads.s3.amazonaws.com/3StCFqarJkJQZV-7N79yY/57eELJsAwMxeZCEA1NMJw_monosnap-miro-2023-06-22-20-33-27.jpg)
-
-To connect the Developer Board in **Wi-Fi access point** mode, do the following:
-
-1. Cold-plug the Developer Board by turning off your Flipper Zero and connecting the Developer Board, and then turning it back on.
-
-2. Open Wi-Fi settings on your client device (phone, laptop, or other).
-
-3. Connect to the network:
-
-    * Name: **blackmagic**
-
-    * Password: **iamwitcher**
-
-4. To configure the Developer Board, open a browser and go to `http://192.168.4.1`.
-
-### Wi-Fi client (STA) mode
-
-![The Developer Board in Wi-Fi client mode](https://archbee-image-uploads.s3.amazonaws.com/3StCFqarJkJQZV-7N79yY/xLQpFyYPfUS5Cx0uQhrNd_monosnap-miro-2023-06-23-12-34-36.jpg)
-
-To connect the Developer Board in **Wi-Fi client** mode, you need to configure it to connect to your Wi-Fi network by doing the following:
-
-1. Cold-plug the Developer Board by turning off your Flipper Zero and connecting the Developer Board, and then turning it back on.
-
-2. Connect to the Developer Board in **Wi-Fi access point** mode.
-
-3. In a browser, go to the configuration page on `http://192.168.4.1`.
-
-4. Select the **STA** mode and enter your network's **SSID** (name) and **password**. For convenience, you can click the **+** button to see the list of nearby networks.
-
-5. Save the configuration and reboot the Developer Board.
-
-![In the Wi-Fi tab, you can set the Developer Board mode](https://archbee-image-uploads.s3.amazonaws.com/3StCFqarJkJQZV-7N79yY/klbLVj8lz2bEvm7j4wRaj_monosnap-miro-2023-06-23-13-06-32.jpg)
-
-After rebooting, the Developer Board connects to your Wi-Fi network. You can connect to the device using the mDNS name **blackmagic.local** or the IP address it got from your router (you'll have to figure this out yourself, every router is different).
-
-After connecting to your debugger via <http://blackmagic.local>, you can find its IP address in the **SYS** tab. You can also change the debugger's mode to **AP** or **STA** there.
-
-![In the SYS tab, you can view the IP address of your Developer Board](https://archbee-image-uploads.s3.amazonaws.com/3StCFqarJkJQZV-7N79yY/5XbUptlfqzlV0p6hRUqiG_monosnap-miro-2023-06-22-18-11-30.jpg)
+    \image html https://cdn.flipperzero.one/Flipper_Zero_external_module_with_case_CDN.jpg width=700
 
 ***
 
-## Debugging the firmware
+## Step 4. Connect to a computer
 
-Open the **Terminal** in the **flipperzero-firmware** directory that you cloned earlier and run the following command:
+Now, you can connect the Developer Board to your computer via USB or Wi-Fi, depending on your needs. We described both methods in separate documents:
 
-```text
-./fbt flash
-```
+- **[Via USB cable](#dev_board_usb_connection)** for debugging in DAP Link or Black Magic mode, and reading logs.
+- [Via Wi-Fi](#dev_board_wifi_connection) for debugging in Black Magic mode.
 
-This will upload the firmware you've just built to your Flipper Zero via the Developer Board. After that, you can start debugging the firmware using the [GDB](https://www.gnu.org/software/gdb/) debugger. We recommend using **VSCode** with the recommended extensions, and we have pre-made configurations for it.
+***
 
-To debug in **VSCode**, do the following:
+## Next steps
 
-1. In VSCode, open the **flipperzero-firmware** directory.
+You are ready to debug now! To further explore what you can do with the Devboard, check out these pages:
 
-2. You should see a notification about recommended extensions. Install them.
+- [Debugging via the Devboard](#dev_board_debugging_guide)
+- [Devboard debug modes](#dev_board_debug_modes)
+- [Reading logs via the Devboard](#dev_board_reading_logs)
 
-    If there were no notifications, open the **Extensions** tab, enter `@recommended` in the search bar, and install the workspace recommendations.
+These guides should help you get started with your Devboard. If you have any questions or you want to share your experience, don't hesitate to join our community on [Reddit](https://www.reddit.com/r/flipperzero/) and [Discord](https://discord.com/invite/flipper), where we have a dedicated #wifi-devboard channel.
 
-3. In the **Terminal**, run the `./fbt vscode_dist` command. This will generate the VSCode configuration files needed for debugging.
 
-4. In VSCode, open the **Run and Debug** tab and select **Attach FW (blackmagic)** from the dropdown menu.
 
-5. If needed, flash your Flipper Zero with the `./fbt flash` command, then click the **Play** button in the debug sidebar to start the debugging session.
 
-6. Note that starting a debug session halts the execution of the firmware, so you'll need to click the **Continue** button on the toolbar at the top of your VSCode window to continue execution.
 
-![Click Continue in the toolbar to continue execution of the firmware](https://archbee-image-uploads.s3.amazonaws.com/3StCFqarJkJQZV-7N79yY/lp8ygGaZ3DvWD3OSI9yGO_monosnap-miro-2023-06-23-17-58-09.jpg)
 
-To learn about debugging, visit the following pages:
 
-* [Debugging with GDB](https://sourceware.org/gdb/current/onlinedocs/gdb.pdf)
 
-* [Debugging in VS Code](https://code.visualstudio.com/docs/editor/debugging)
+
+
+
+
+

--- a/documentation/devboard/Reading logs via the Dev Board.md
+++ b/documentation/devboard/Reading logs via the Dev Board.md
@@ -8,9 +8,9 @@ The Developer Board allows you to read Flipper Zero logs via UART. Unlike readin
 
 ## Setting the log level
 
-Depending on your needs, you can set the log level by going to **Main Menu → Settings → Log Level**. To learn more about logging levels, visit [Settings](https://docs.flipperzero.one/basics/settings#d5TAt).
+Depending on your needs, you can set the log level by going to **Main Menu → Settings → Log Level**. To learn more about logging levels, visit [Settings](https://docs.flipper.net/basics/settings#d5TAt).
 
-![You can manually set the preferred log level](https://archbee-image-uploads.s3.amazonaws.com/3StCFqarJkJQZV-7N79yY/INzQMw8QUsG9PXi30WFS0_monosnap-miro-2023-07-11-13-29-47.jpg)
+\image html https://cdn.flipperzero.one/Flipper_Zero_log_level.jpg "You can manually set the preferred log level" width=700
 
 ***
 
@@ -18,9 +18,9 @@ Depending on your needs, you can set the log level by going to **Main Menu → S
 
 Depending on your operating system, you need to install an additional application on your computer to read logs via the Developer Board:
 
-### MacOS
+### macOS
 
-On MacOS, you need to install the **minicom** communication program by doing the following:
+On macOS, you need to install the **minicom** communication program by doing the following:
 
 1. [Install Homebrew](https://brew.sh/) by running the following command in the Terminal:
 
@@ -47,7 +47,7 @@ After installation of minicom on your macOS computer, you can connect to the Dev
    Note the list of devices.
 
 3. Connect the developer board to your computer using a USB Type-C cable.
-![Connect the developer board with a USB-C cable](https://archbee-image-uploads.s3.amazonaws.com/3StCFqarJkJQZV-7N79yY/iPpsMt2-is4aIjiVeFu5t_hjxs2i1oovrnps74v5jgsimage.png)
+\image html https://cdn.flipperzero.one/Flipper_Zero_Wi-Fi_developer_board_wired.png width=700
 
 4. Rerun the command. Two new devices have to appear: this is the Developer Board.
 
@@ -100,7 +100,7 @@ After installation of minicom on your Linux computer, you can connect to the Dev
     Note the list of devices.
 
 3. Connect the developer board to your computer using a USB Type-C cable.
-![Connect the developer board with a USB-C cable](https://archbee-image-uploads.s3.amazonaws.com/3StCFqarJkJQZV-7N79yY/iPpsMt2-is4aIjiVeFu5t_hjxs2i1oovrnps74v5jgsimage.png)
+\image html https://cdn.flipperzero.one/Flipper_Zero_Wi-Fi_developer_board_wired.png width=700
 
 4. Rerun the command. Two new devices have to appear: this is the Developer Board.
 
@@ -143,17 +143,17 @@ On Windows, do the following:
 2. Cold-plug the Developer Board into your Flipper Zero by turning off the Flipper Zero, connecting the developer board, and then turning it back on.
 
 3. Connect the developer board to your computer using a USB Type-C cable.
-![Connect the developer board with a USB-C cable](https://archbee-image-uploads.s3.amazonaws.com/3StCFqarJkJQZV-7N79yY/iPpsMt2-is4aIjiVeFu5t_hjxs2i1oovrnps74v5jgsimage.png)
+\image html https://cdn.flipperzero.one/Flipper_Zero_Wi-Fi_developer_board_wired.png width=700
 
 4. Find the serial port that the developer board is connected to by going to **Device Manager → Ports (COM & LPT)** and looking for a new port that appears when you connect the Wi-Fi developer board.
-![Find the serial port in your Device Manager](https://archbee-image-uploads.s3.amazonaws.com/3StCFqarJkJQZV-7N79yY/KKLQJK1lvqmI5iab3d__C_image.png)
+\image html https://cdn.flipperzero.one/Flipper_Zero_Wi-Fi_devboard_Device_Manager.png width=700
 
 5. Run the PuTTY application and select **Serial** as the connection type.
 
 6. Enter the port number you found in the previous step into the **Serial line** field.
 
 7. Set the **Speed** parameter to **230400** and click **Open**.
-![Set speed to 230400](https://archbee-image-uploads.s3.amazonaws.com/3StCFqarJkJQZV-7N79yY/ROBSJyfQ_CXiy4GUZcPbs_monosnap-miro-2023-07-12-13-56-47.jpg)
+\image html https://cdn.flipperzero.one/Flipper_Zero_Wi-Fi_devboard_PuTTy.jpg width=700
 
 8. View logs of your Flipper Zero in the PuTTY terminal window.
 

--- a/documentation/devboard/USB connection to the Devboard.md
+++ b/documentation/devboard/USB connection to the Devboard.md
@@ -1,0 +1,22 @@
+# USB connection to the Devboard {#dev_board_usb_connection}
+
+\image html https://cdn.flipperzero.one/Flipper_Zero_WiFi_devboard_USB_connection_CDN.jpg width=700
+
+To connect to the Developer Board via USB, do the following:
+
+1. If the Devboard isn't connected to your Flipper Zero, turn off your Flipper Zero and connect the Developer Board to it. Then, turn your Flipper Zero back on.
+
+2. On your computer, check the list of serial devices.
+
+    - **macOS:** On your computer, run `ls /dev/cu.*` in the Terminal.
+
+    - **Linux:** On your computer, run `ls /dev/tty*` in the Terminal.
+
+    - **Windows:** Go to **Device Manager** and expand the **Ports (COM & LPT)** section.
+
+3. Connect the Devboard to your computer via a USB-C cable.
+
+4. Repeat **Step 2**. Two new devices will appear — this is the Developer Board.
+
+> [!warning]
+> If the Developer Board doesn't appear in the list of devices, try using a different cable, USB port, or computer.

--- a/documentation/devboard/Wi-Fi connection to the Devboard.md
+++ b/documentation/devboard/Wi-Fi connection to the Devboard.md
@@ -1,0 +1,60 @@
+# Wi-Fi connection to the Devboard {#dev_board_wifi_connection}
+
+You can connect to the Developer Board wirelessly in two ways:
+
+- **Wi-Fi access point mode (default):** The Devboard creates its own Wi-Fi network, which you can connect to in order to access its web interface and debug via Wi-Fi. The downside is that you will need to disconnect from your current Wi-Fi network, resulting in a loss of internet connection.
+
+- **Wi-Fi client mode:** You can connect to the Devboard through an existing Wi-Fi network, allowing you to access the Devboard web interface and debug via Wi-Fi without losing your internet connection.
+
+Let's go over both of these modes below.
+
+***
+
+## Wi-Fi access point (AP) mode {#wifi-access-point}
+
+\image html https://cdn.flipperzero.one/Flipper_Zero_WiFi_devboard_Access_Point_CDN.jpg width=700
+
+Out of the box, the Developer Board is configured to work as a Wi-Fi access point. To connect the Developer Board in this mode, do the following:
+
+1. Plug the Wi-Fi Devboard into your Flipper Zero by turning off your Flipper Zero and connecting the Developer Board, and then turning it back on.
+
+2. Open Wi-Fi settings on your client device (phone, laptop, or other).
+
+3. Connect to the network:
+
+    Name: `blackmagic`
+    Password: `iamwitcher`
+
+    If your computer fails to find the **blackmagic** network, read the [troubleshooting section](#wifi-access-point_troubleshooting) below.
+
+4. To access the Devboard's web interface, open a browser and go to <http://192.168.4.1> or <http://blackmagic.local>.
+
+### If your computer fails to find the black magic network {#wifi-access-point_troubleshooting}
+
+- Reset Wi-Fi connection on your computer.
+
+- The Developer Board is probably configured to work in Wi-Fi client mode. → Reset your Developer Board settings to default by pressing and holding the **BOOT** button for **10 seconds**, then wait for the Devboard to reboot. After the reset, the Devboard will work in Wi-Fi access point mode.
+
+\image html https://cdn.flipperzero.one/Flipper_Zero_Wi-Fi_devboard_reboot.jpg width=700
+
+***
+
+## Wi-Fi client (STA) mode {#wifi-client-mode}
+
+\image html https://cdn.flipperzero.one/Flipper_Zero_WiFi_devboard_STA_CDN.jpg width=700
+
+To connect the Developer Board in **Wi-Fi client** mode, you need to configure it to connect to your Wi-Fi network by doing the following:
+
+1. Plug the Wi-Fi Devboard into your Flipper Zero by turning off your Flipper Zero and connecting the Developer Board, and then turning the device back on.
+
+2. Connect to the Developer Board in [Wi-Fi access point](#wifi-access-point) mode.
+
+3. In a browser, go to the Devboard's web interface at <http://192.168.4.1> or <http://blackmagic.local>.
+
+4. Select the **STA** mode and enter your network's **SSID** (name) and **password**. For convenience, you can click the **+** button to see the list of nearby 2.4 GHz networks (5 GHz networks aren't supported).
+
+5. Save the configuration and reboot the Developer Board.
+
+    \image html https://cdn.flipperzero.one/Flipper_Zero_WiFi_devboard_connect_to_WiFi_CDN.jpg width=700
+
+6. Now, you can access the Devboard's web interface at [http://blackmagic.local](https://blackmagic.local) via the existing Wi-Fi network without losing connection to the internet.

--- a/documentation/doxygen/dev_board.dox
+++ b/documentation/doxygen/dev_board.dox
@@ -1,10 +1,37 @@
 /**
-@page dev_board Developer Board
+@page dev_board Wi-Fi Developer Board
 
-[ESP32-based development board](https://shop.flipperzero.one/collections/flipper-zero-accessories/products/wifi-devboard).
+\image html https://cdn.flipperzero.one/Flipper_Zero_WiFi_devboard_laptop_CDN.jpg width=700
+
+Wi-Fi-enabled Developer Board brings debugging and firmware update capabilities to your Flipper Zero. The Developer Board is based on the ESP32-S2 MCU with custom firmware incorporating Black Magic Debug and CMSIS-DAP, and is built with ESP-IDF. It can flash and debug various microprocessors and microcontrollers (including the one used in your Flipper Zero) via Wi-Fi or USB cable.
+
+The Developer Board provides a debug interface, allowing developers to halt program execution, set breakpoints, inspect variables and memory, and step through code execution. 
+
+<div align="center">
+<a href="https://shop.flipperzero.one/products/wifi-devboard"><img src="https://cdn.flipperzero.one/Get_developer_board_button_green_600.png" width="350" align="center" alt="Get your Wi-Fi Developer Board"/></a>
+</div>
+<br>
+
+Check out these guides to get started with the Devboard:
 
 - @subpage dev_board_get_started — Quick start for new users
+- @subpage dev_board_fw_update — Keep the Developer Board up to date
+- @subpage dev_board_usb_connection — Instructions for Windows, macOS and Linux
+- @subpage dev_board_wifi_connection — Instructions for Windows, macOS and Linux
+- @subpage dev_board_debugging_guide — Learn how it works
+- @subpage dev_board_debug_modes — Available modes and how to switch between them
 - @subpage dev_board_reading_logs — Find out what is currently happening on the system
-- @subpage dev_board_fw_update — Keep the developer board up to date
+
+## Hardware
+
+The Developer Board is equipped with an [ESP32-S2-WROVER](https://www.espressif.com/en/products/socs/esp32-s2) module, which includes built-in Wi-Fi capabilities. It also offers GPIO pins for easy connectivity to various targets. Additionally, the Developer Board features a USB Type-C connector for data transfer and power supply. For user interaction, the Developer Board has tactile switches.
+
+\image html https://cdn.flipperzero.one/Flipper_Zero_WiFi_developer_board_hardware_CDN.jpg width=700
+
+## Additional resources
+
+To learn more about the Wi-Fi Developer Board hardware, visit [Schematics in Flipper Docs](https://docs.flipperzero.one/development/hardware/wifi-debugger-module/schematics).
+
+For additional information about Flipper Zero GPIO pins, visit [GPIO & modules in Flipper Docs](https://docs.flipperzero.one/gpio-and-modules).
 
 */

--- a/documentation/doxygen/header.html
+++ b/documentation/doxygen/header.html
@@ -52,7 +52,7 @@ $extrastylesheet
   <!--END PROJECT_LOGO-->
   <!--BEGIN PROJECT_NAME-->
   <td id="projectalign">
-   <div id="projectname"><a href="index.html">$projectname</a><!--BEGIN PROJECT_NUMBER--><span id="projectnumber">&#160;$projectnumber</span><!--END PROJECT_NUMBER-->
+   <div id="projectname"><a href="index.html" style="background: none; color: var(--foreground_color) !important;">$projectname</a><!--BEGIN PROJECT_NUMBER--><span id="projectnumber">&#160;$projectnumber</span><!--END PROJECT_NUMBER-->
    </div>
    <!--BEGIN PROJECT_BRIEF--><div id="projectbrief">$projectbrief</div><!--END PROJECT_BRIEF-->
   </td>

--- a/documentation/fbt.md
+++ b/documentation/fbt.md
@@ -44,7 +44,7 @@ To run cleanup (think of `make clean`) for specified targets, add the `-c` optio
 
 ## VSCode integration
 
-`fbt` includes basic development environment configuration for VS Code. Run `./fbt vscode_dist` to deploy it. That will copy the initial environment configuration to the `.vscode` folder. After that, you can use that configuration by starting VS Code and choosing the firmware root folder in the "File > Open Folder" menu.
+`fbt` includes basic development environment configuration for VS Code. Run `./fbt vscode_dist` to deploy it. That will copy the initial environment configuration to the `.vscode` folder. After that, you can use that configuration by starting VS Code and choosing the firmware root folder in the "File > Open Folder" menu.
 
 To use language servers other than the default VS Code C/C++ language server, use `./fbt vscode_dist LANG_SERVER=<language-server>` instead. Currently `fbt` supports the default language server (`cpptools`) and `clangd`.
 

--- a/furi/core/thread.h
+++ b/furi/core/thread.h
@@ -81,7 +81,7 @@ typedef void (*FuriThreadStdoutWriteCallback)(const char* data, size_t size);
  *
  * The function to be used as a state callback MUST follow this signature.
  *
- * @param[in] pointer to the FuriThread instance that changed the state
+ * @param[in] thread to the FuriThread instance that changed the state
  * @param[in] state identifier of the state the thread has transitioned to
  * @param[in,out] context pointer to a user-specified object
  */


### PR DESCRIPTION
What's new
---
* New step-by-step documentation structure for Wi-Fi Devboard
* Added a description of working under Windows
* Added a description of switching Devboard operation mode (Black Magic, DAPLink)
* The images for the documentation are uploaded to the CDN
* The text in the sidebar, near the dolphin logo, changed from blue to black/white

Verification
---

Checklist (For Reviewer)
---

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
 


