### PR TITLE
[FL-3916] Require PIN on boot

### DIFF
--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -523,7 +523,7 @@ int32_t desktop_srv(void* p) {
 
     scene_manager_next_scene(desktop->scene_manager, DesktopSceneMain);
 
-    if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagLock)) {
+    if(desktop_pin_code_is_set()) {
         desktop_lock(desktop);
     }
 


### PR DESCRIPTION
# What's new
  - The Desktop service now always requests the PIN on boot if one is set (#3900, [FL-3916])

# Verification 
  - Set up a PIN
  - Reboot the device using all available methods
  - Verify that the device asks for the PIN

# Checklist (For Reviewer)
  - [x] PR has description of feature/bug or link to Confluence/Jira task
  - [x] Description contains actions to verify feature/bugfix
  - [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FL-3916]: https://flipperzero.atlassian.net/browse/FL-3916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ