### PR TITLE
NFC TRT Parser: Additional checks to prevent false positives

### DIFF
--- a/applications/main/nfc/plugins/supported_cards/trt.c
+++ b/applications/main/nfc/plugins/supported_cards/trt.c
@@ -40,7 +40,10 @@ static bool trt_parse(const NfcDevice* device, FuriString* parsed_data) {
         const uint8_t* full_record_pointer = &data->page[FULL_SALE_TIME_STAMP_PAGE].data[0];
         uint32_t latest_sale_record = bit_lib_get_bits_32(partial_record_pointer, 3, 20);
         uint32_t latest_sale_full_record = bit_lib_get_bits_32(full_record_pointer, 0, 27);
-        if(latest_sale_record != (latest_sale_full_record & 0xFFFFF)) break;
+        if(latest_sale_record != (latest_sale_full_record & 0xFFFFF))
+            break; // check if the copy matches
+        if((latest_sale_record == 0) | (latest_sale_full_record == 0))
+            break; // prevent false positive
 
         // Parse date
         // yyy yyyymmmm dddddhhh hhnnnnnn

--- a/applications/main/nfc/plugins/supported_cards/trt.c
+++ b/applications/main/nfc/plugins/supported_cards/trt.c
@@ -42,7 +42,7 @@ static bool trt_parse(const NfcDevice* device, FuriString* parsed_data) {
         uint32_t latest_sale_full_record = bit_lib_get_bits_32(full_record_pointer, 0, 27);
         if(latest_sale_record != (latest_sale_full_record & 0xFFFFF))
             break; // check if the copy matches
-        if((latest_sale_record == 0) | (latest_sale_full_record == 0))
+        if((latest_sale_record == 0) || (latest_sale_full_record == 0))
             break; // prevent false positive
 
         // Parse date


### PR DESCRIPTION
# What's new

- Add a check for non-zero content to ensure blank UL tags won't be mistakenly parsed. This is mainly because 00s are too commonly seen in most tags.

# Verification 

- Try reading this
[example.nfc.zip](https://github.com/user-attachments/files/17447953/example.nfc.zip)


# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
