### PR TITLE
Fix `fz-sdk` npm dependencies

### DIFF
--- a/applications/system/js_app/packages/fz-sdk/package.json
+++ b/applications/system/js_app/packages/fz-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flipperdevices/fz-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Type declarations and documentation for native JS modules available on Flipper Zero",
   "keywords": [
     "flipper",
@@ -15,14 +15,12 @@
     "directory": "applications/system/js_app/packages/fz-sdk"
   },
   "type": "module",
-  "devDependencies": {
+  "dependencies": {
     "esbuild": "^0.24.0",
     "esbuild-plugin-tsc": "^0.4.0",
     "json5": "^2.2.3",
     "typedoc": "^0.26.10",
-    "typedoc-material-theme": "^1.1.0"
-  },
-  "dependencies": {
+    "typedoc-material-theme": "^1.1.0",
     "prompts": "^2.4.2",
     "serialport": "^12.0.0"
   }


### PR DESCRIPTION
# What's new
After publishing the packages from #3963 manually, I was disappointed to see that the wizard did not set up the project correctly. Apparently `npm` does not install dev dependencies of dependencies. They _were_ "installed" (symlinked) when the packages were sourced locally, but apparently not when they're fetched from the `npm` registry.

I've already published the fix as `@flipperdevices/fz-sdk@0.1.1`. These changes now need to be reflected in the repo.

# Verification 
Create and run a JS app as per the instructions in [`@flipperdevices/create-fz-app`](https://www.npmjs.com/package/@flipperdevices/create-fz-app).

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
