### PR TITLE
JS: Add die() typedoc

### DIFF
--- a/applications/system/js_app/packages/fz-sdk/global.d.ts
+++ b/applications/system/js_app/packages/fz-sdk/global.d.ts
@@ -207,7 +207,7 @@ declare function require(module: string): any;
  * @param message The error message to show to user
  * @version Added in JS SDK 0.1
  */
-declare function die(message: string): void;
+declare function die(message: string): never;
 
 /**
  * @brief mJS Foreign Pointer type

--- a/applications/system/js_app/packages/fz-sdk/global.d.ts
+++ b/applications/system/js_app/packages/fz-sdk/global.d.ts
@@ -203,6 +203,13 @@ declare function chr(n: number): string | null;
 declare function require(module: string): any;
 
 /**
+ * @brief Exit JavaScript with given message
+ * @param message The error message to show to user
+ * @version Added in JS SDK 0.1
+ */
+declare function die(message: string): void;
+
+/**
  * @brief mJS Foreign Pointer type
  * 
  * JavaScript code cannot do anything with values of `RawPointer` type except


### PR DESCRIPTION
# What's new

- Added `die()` to global typedoc since it was missing
- Not sure if it should be 0.1 or count as a bump to 0.2 already... technically this was always available, just not documented... IMO it should still count as SDK 0.1 and go up as a semver "patch" increase of the npm module (0.1.2)

# Verification 

- Observe, the typedocs now magically contain the `die()` function definition

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
