### PR TITLE
Furi: Detect use-after-free

### DIFF
--- a/furi/core/memmgr_heap.c
+++ b/furi/core/memmgr_heap.c
@@ -527,7 +527,7 @@ void vPortFree(void* pv) {
                     /* Add this block to the list of free blocks. */
                     xFreeBytesRemaining += pxLink->xBlockSize;
                     traceFREE(pv, pxLink->xBlockSize);
-                    memset(pv, 0, pxLink->xBlockSize - xHeapStructSize);
+                    memset(pv, 0xDD, pxLink->xBlockSize - xHeapStructSize);
                     prvInsertBlockIntoFreeList((BlockLink_t*)pxLink);
                 }
                 (void)xTaskResumeAll();

--- a/furi/core/semaphore.c
+++ b/furi/core/semaphore.c
@@ -104,6 +104,8 @@ FuriStatus furi_semaphore_release(FuriSemaphore* instance) {
 
     stat = FuriStatusOk;
 
+    FURI_CRITICAL_ENTER();
+
     if(FURI_IS_IRQ_MODE()) {
         yield = pdFALSE;
 
@@ -122,6 +124,8 @@ FuriStatus furi_semaphore_release(FuriSemaphore* instance) {
     if(stat == FuriStatusOk) {
         furi_event_loop_link_notify(&instance->event_loop_link, FuriEventLoopEventIn);
     }
+
+    FURI_CRITICAL_EXIT();
 
     return stat;
 }

--- a/targets/f7/furi_hal/furi_hal_interrupt.c
+++ b/targets/f7/furi_hal/furi_hal_interrupt.c
@@ -314,7 +314,52 @@ void MemManage_Handler(void) {
 }
 
 void BusFault_Handler(void) {
-    furi_crash("BusFault");
+    const char* crash_msg = "BusFault";
+
+    furi_log_puts("\r\n" _FURI_LOG_CLR_E "Bus fault:\r\n");
+    if(FURI_BIT(SCB->CFSR, SCB_CFSR_LSPERR_Pos)) {
+        furi_log_puts(" - lazy stacking for exception entry\r\n");
+    }
+
+    if(FURI_BIT(SCB->CFSR, SCB_CFSR_STKERR_Pos)) {
+        furi_log_puts(" - stacking for exception entry\r\n");
+    }
+
+    if(FURI_BIT(SCB->CFSR, SCB_CFSR_UNSTKERR_Pos)) {
+        furi_log_puts(" - unstacking for exception return\r\n");
+    }
+
+    if(FURI_BIT(SCB->CFSR, SCB_CFSR_IMPRECISERR_Pos)) {
+        furi_log_puts(" - imprecise data access\r\n");
+    }
+
+    if(FURI_BIT(SCB->CFSR, SCB_CFSR_PRECISERR_Pos)) {
+        furi_log_puts(" - precise data access\r\n");
+    }
+
+    if(FURI_BIT(SCB->CFSR, SCB_CFSR_IBUSERR_Pos)) {
+        furi_log_puts(" - instruction\r\n");
+    }
+
+    if(FURI_BIT(SCB->CFSR, SCB_CFSR_BFARVALID_Pos)) {
+        uint32_t busfault_address = SCB->BFAR;
+        furi_log_puts(" -- at 0x");
+
+        char tmp_str[] = "0xFFFFFFFF";
+        itoa(busfault_address, tmp_str, 16);
+        furi_log_puts(tmp_str);
+
+        furi_log_puts("\r\n");
+
+        if(busfault_address == (uint32_t)NULL) {
+            furi_log_puts(" -- NULL pointer dereference\r\n");
+        } else if(busfault_address >= 0xDDDDDDDD && busfault_address <= 0xDDDEDDDD) {
+            crash_msg = "Possible use-after-free";
+        }
+    }
+    furi_log_puts(_FURI_LOG_CLR_RESET);
+
+    furi_crash(crash_msg);
 }
 
 void UsageFault_Handler(void) {


### PR DESCRIPTION
# What's new

- `free()` now marks memory with `0xDD`
- `BusFault` handler checks for `0xDDDDDDDD` and 64K after it to determine "Possible use-after-free"
- if such memory address is not dereferenced no crash will happen, but this change is still useful while debugging, as seeing 0xDD in your data is a clear giveaway of use-after-free
- added back `BusFault` handler extra logging from old TLSF experiment
- fixed atomicity in `furi_semaphore_release()`:
  - if thread A is waiting for acquire() and thread B calls release()
  - then halfway through release() code, A would wake up and continue, before B finishes release()
  - this could cause use-after-free if A free()s semaphore after acquire(), because after this B would finish release() which dereferences instance->event_loop_link
  - for example, RpcCli had this use-after-free:
    - `rpc_cli_command_start_session()` is waiting for `furi_semaphore_acquire()`
    - `rpc_cli_session_terminated_callback()` will `furi_semaphore_release()`
    - this wakes up `rpc_cli_command_start_session()` which then does furi_semaphore_free()
    - later, `furi_semaphore_release()` inside of `rpc_cli_session_terminated_callback()` resumes, and dereferences the semaphore that `rpc_cli_command_start_session()` has already free'd
  - there might be more similar issues with event loop items being used after yielding, which would break atomicity and lead to possible use-after-free, but i have not looked for them or found other crashes like this yet

# Verification 

- test anything and everything for hidden use-after-free that were unknown until now

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
