### PR TITLE
NFC: Plantain parser Last payment amount fix

### DIFF
--- a/applications/main/nfc/plugins/supported_cards/plantain.c
+++ b/applications/main/nfc/plugins/supported_cards/plantain.c
@@ -310,9 +310,11 @@ static bool plantain_parse(const NfcDevice* device, FuriString* parsed_data) {
                 last_payment_date.year,
                 last_payment_date.hour,
                 last_payment_date.minute);
-            //payment amount. This needs to be investigated more, currently it shows incorrect amount on some cards.
-            uint16_t last_payment = (data->block[18].data[9] << 8) | data->block[18].data[8];
-            furi_string_cat_printf(parsed_data, "Amount: %d rub", last_payment / 100);
+            //Last payment amount.
+            uint16_t last_payment = ((data->block[18].data[10] << 16) |
+                                     (data->block[18].data[9] << 8) | (data->block[18].data[8])) /
+                                    100;
+            furi_string_cat_printf(parsed_data, "Amount: %d rub", last_payment);
             furi_string_free(card_number_s);
             furi_string_free(tmp_s);
             //This is for 4K Plantains.
@@ -369,9 +371,11 @@ static bool plantain_parse(const NfcDevice* device, FuriString* parsed_data) {
                 last_payment_date.year,
                 last_payment_date.hour,
                 last_payment_date.minute);
-            //payment amount
-            uint16_t last_payment = (data->block[18].data[9] << 8) | data->block[18].data[8];
-            furi_string_cat_printf(parsed_data, "Amount: %d rub", last_payment / 100);
+            //Last payment amount
+            uint16_t last_payment = ((data->block[18].data[10] << 16) |
+                                     (data->block[18].data[9] << 8) | (data->block[18].data[8])) /
+                                    100;
+            furi_string_cat_printf(parsed_data, "Amount: %d rub", last_payment);
             furi_string_free(card_number_s);
             furi_string_free(tmp_s);
         }


### PR DESCRIPTION
# What's new

- The current parser shows the correct result for "last payment amount" only if the top up amount was 3 digits long, if it is longer - the parser shows incorrect value instead of the real amount.  This should fix this issue for top ups highter than 999 RUB.

# Verification 

- Compile plantain_parser.fal with ./fbt fap_dist, then put it in /apps_data/nfc/plugins. Run the NFC app and read a plantain card which was topped up for >=1000 RUB. 

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
