### PR TITLE
[JS] Make sdk.js serialport selection more universal.

### DIFF
--- a/applications/system/js_app/packages/fz-sdk/sdk.js
+++ b/applications/system/js_app/packages/fz-sdk/sdk.js
@@ -85,22 +85,14 @@ async function build(config) {
 
 async function upload(config) {
     const appFile = fs.readFileSync(config.input, "utf8");
-    const flippers = (await SerialPort.list()).filter(x => x.serialNumber?.startsWith("flip_"));
+    let ports = await SerialPort.list();
 
-    if (!flippers) {
-        console.error("No Flippers found");
-        process.exit(1);
-    }
-
-    let portPath = flippers[0].path;
-    if (flippers.length > 1) {
-        port = (await prompts([{
-            type: "select",
-            name: "port",
-            message: "Select Flipper to run the app on",
-            choices: flippers.map(x => ({ title: x.serialNumber.replace("flip_", ""), value: x.path })),
-        }])).port;
-    }
+    let portPath = (await prompts([{
+        type: "select",
+        name: "port",
+        message: "Select Flipper to run the app on",
+        choices: ports.map(x => ({ title: x.path, value: x.path })),
+    }])).port;
 
     console.log(`Connecting to Flipper at ${portPath}`);
     let port = new SerialPort({ path: portPath, baudRate: 230400 });


### PR DESCRIPTION
# What's new

- On windows when using NPM for creating JS project and starting with 'npm start' it will throw this error:

```
file:///C:/Users/hazic/Documents/temp/NodeTest/my-flip-app/node_modules/@flipperdevices/fz-sdk/sdk.js:95
    let portPath = flippers[0].path;
                               ^

TypeError: Cannot read properties of undefined (reading 'path')
    at Object.upload (file:///C:/Users/hazic/Documents/temp/NodeTest/my-flip-app/node_modules/@flipperdevices/fz-sdk/sdk.js:95:32)
    at async file:///C:/Users/hazic/Documents/temp/NodeTest/my-flip-app/node_modules/@flipperdevices/fz-sdk/sdk.js:175:5
```

It's clear that it can't find the flipper. The code searching for ports which 'serialNumber' starts with "flip_", but in windows it the port looking like this:

```
{
    path: 'COM4',
    manufacturer: 'Microsoft',
    serialNumber: '7&359A65E1&0&0000',
    pnpId: 'USB\\VID_0483&PID_5740&MI_00\\7&359A65E1&0&0000',
    locationId: '0001.0000.0000.007.000.000.000.000.000',
    friendlyName: 'Soros USB-eszköz (COM4)',
    vendorId: '0483',
    productId: '5740'
  }
```

It shows that the serial number is not starting with 'flip_'.
Another problem with the code is that checking for `if (!flippers)` is useless because when we create the array, a line above it should check for its length instead.

Also, when multiple flippers are connected and found when calling the prompts and assigning it to the port, it is simply not initialized yet. It will be initialized a few lines later.

I think it would be much better if the user has to define the COM port all the time they want to run on the device.



# Verification 

- Tried on my Windows PC.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
