### PR TITLE
Fix typo for mf_classic_key_cahce_get_next_key() function

### DIFF
--- a/applications/main/nfc/helpers/mf_classic_key_cache.c
+++ b/applications/main/nfc/helpers/mf_classic_key_cache.c
@@ -166,7 +166,7 @@ void mf_classic_key_cache_load_from_data(MfClassicKeyCache* instance, const MfCl
     }
 }
 
-bool mf_classic_key_cahce_get_next_key(
+bool mf_classic_key_cache_get_next_key(
     MfClassicKeyCache* instance,
     uint8_t* sector_num,
     MfClassicKey* key,

--- a/applications/main/nfc/helpers/mf_classic_key_cache.h
+++ b/applications/main/nfc/helpers/mf_classic_key_cache.h
@@ -16,7 +16,7 @@ bool mf_classic_key_cache_load(MfClassicKeyCache* instance, const uint8_t* uid, 
 
 void mf_classic_key_cache_load_from_data(MfClassicKeyCache* instance, const MfClassicData* data);
 
-bool mf_classic_key_cahce_get_next_key(
+bool mf_classic_key_cache_get_next_key(
     MfClassicKeyCache* instance,
     uint8_t* sector_num,
     MfClassicKey* key,

--- a/applications/main/nfc/helpers/protocol_support/mf_classic/mf_classic.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_classic/mf_classic.c
@@ -72,7 +72,7 @@ static NfcCommand nfc_scene_read_poller_callback_mf_classic(NfcGenericEvent even
         uint8_t sector_num = 0;
         MfClassicKey key = {};
         MfClassicKeyType key_type = MfClassicKeyTypeA;
-        if(mf_classic_key_cahce_get_next_key(
+        if(mf_classic_key_cache_get_next_key(
                instance->mfc_key_cache, &sector_num, &key, &key_type)) {
             mfc_event->data->read_sector_request_data.sector_num = sector_num;
             mfc_event->data->read_sector_request_data.key = key;

--- a/applications/main/nfc/scenes/nfc_scene_mf_classic_update_initial.c
+++ b/applications/main/nfc/scenes/nfc_scene_mf_classic_update_initial.c
@@ -34,7 +34,7 @@ NfcCommand nfc_mf_classic_update_initial_worker_callback(NfcGenericEvent event, 
         uint8_t sector_num = 0;
         MfClassicKey key = {};
         MfClassicKeyType key_type = MfClassicKeyTypeA;
-        if(mf_classic_key_cahce_get_next_key(
+        if(mf_classic_key_cache_get_next_key(
                instance->mfc_key_cache, &sector_num, &key, &key_type)) {
             mfc_event->data->read_sector_request_data.sector_num = sector_num;
             mfc_event->data->read_sector_request_data.key = key;


### PR DESCRIPTION
# What's new

mf_classic_key_cahce_get_next_key() renamed to mf_classic_key_cache_get_next_key()

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
