### PR TITLE
Add IR command for NAD DR2 D7050 D3020

### DIFF
--- a/applications/main/infrared/resources/infrared/assets/audio.ir
+++ b/applications/main/infrared/resources/infrared/assets/audio.ir
@@ -4650,3 +4650,42 @@ type: parsed
 protocol: NECext
 address: 7F 01 00 00
 command: 69 96 00 00
+#
+# Model : NAD DR2 remote for NAD D7050 and D3020
+#
+name: Power
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 25 DA 00 00
+#
+name: Vol_up
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 88 77 00 00
+#
+name: Vol_dn
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 8C 73 00 00
+#
+name: Mute
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 94 6B 00 00
+#
+name: Next
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 1A E5 00 00
+#
+name: Prev
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 1D E2 00 00
+#


### PR DESCRIPTION
# What's new

I have added to the file "applications/main/infrared/resources/infrared/assets/audio.ir" the command for NAD DR2 D3020 and D7050.

# Verification 

- The ir command added to this file has been tested with a NAD D3020 audio amplifier and comfirmed by a off-the-shelf-china DR2 remote replica.
- However I haven't tested with my flipper zero the changes in the universal remote. Do i need to compile a custom firmware ? Can i only inject my new file audio.ir into my device ?

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
