### PR TITLE
JS packages folder included to the doxygen's exclude list

### DIFF
--- a/documentation/doxygen/Doxyfile.cfg
+++ b/documentation/doxygen/Doxyfile.cfg
@@ -1042,6 +1042,7 @@ EXCLUDE                = $(DOXY_SRC_ROOT)/lib/mlib \
                          $(DOXY_SRC_ROOT)/applications/plugins/dap_link/lib/free-dap \
                          $(DOXY_SRC_ROOT)/applications/debug \
                          $(DOXY_SRC_ROOT)/applications/main \
+                         $(DOXY_SRC_ROOT)/applications/system/js_app/packages \
                          $(DOXY_SRC_ROOT)/applications/settings \
                          $(DOXY_SRC_ROOT)/lib/micro-ecc \
                          $(DOXY_SRC_ROOT)/lib/ReadMe.md \


### PR DESCRIPTION
# What's new

- JS packages folder included to the doxygen's exclude list to prevent these sections from being displayed in the main developer docs menu

# Verification 

- **Flipper Zero JavaScript SDK Wizard** and **Flipper Zero JavaScript SDK** sections removed from the main developer docs menu

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
