### PR TITLE
FBT: Don't lint JS packages

### DIFF
--- a/firmware.scons
+++ b/firmware.scons
@@ -29,6 +29,8 @@ env = ENV.Clone(
     TARGETS_ROOT=Dir("#/targets"),
     LINT_SOURCES=[
         Dir("applications"),
+        # Not C code
+        Dir("!applications/system/js_app/packages"),
     ],
     LIBPATH=[
         "${LIB_DIST_DIR}",


### PR DESCRIPTION
# What's new

- support for excluding folders in linter with `!` prefix
- exclude js packages dir as they have js naming convention (using dashes) so fbt would always complain

# Verification 

- `./fbt format` does not complain of `applications/system/js_app/packages/fz-sdk` and `applications/system/js_app/packages/create-fz-app`

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
