### PR TITLE
nfc: Fix sector overrun in MFC nested dictionary attack

### DIFF
--- a/lib/nfc/protocols/mf_classic/mf_classic_poller.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller.c
@@ -1897,21 +1897,22 @@ NfcCommand mf_classic_poller_handler_nested_controller(MfClassicPoller* instance
             dict_attack_ctx->nested_phase = MfClassicNestedPhaseDictAttack;
         }
     }
-    if(dict_attack_ctx->reuse_key_sector == instance->sectors_total) {
-        // Reset target sector to first sector whose key has not been found
-        for(dict_attack_ctx->reuse_key_sector = 0;
-            dict_attack_ctx->reuse_key_sector < instance->sectors_total &&
-            mf_classic_nested_is_target_key_found(instance, true);
-            dict_attack_ctx->reuse_key_sector++)
-            ;
-        // Reset to sane value just in case we happen to have all of the keys
-        if(dict_attack_ctx->reuse_key_sector == instance->sectors_total) {
-            dict_attack_ctx->reuse_key_sector = 0;
-        }
-    }
     if((dict_attack_ctx->nested_phase == MfClassicNestedPhaseDictAttack ||
         dict_attack_ctx->nested_phase == MfClassicNestedPhaseDictAttackResume) &&
        (dict_attack_ctx->nested_target_key < dict_target_key_max)) {
+        if(dict_attack_ctx->reuse_key_sector == instance->sectors_total) {
+            // Reset target sector to first sector whose key has not been found
+            for(dict_attack_ctx->reuse_key_sector = 0;
+                dict_attack_ctx->reuse_key_sector < instance->sectors_total &&
+                mf_classic_nested_is_target_key_found(instance, true);
+                dict_attack_ctx->reuse_key_sector++)
+                ;
+            // Reset to sane value just in case we happen to have all of the keys
+            if(dict_attack_ctx->reuse_key_sector == instance->sectors_total) {
+                dict_attack_ctx->reuse_key_sector = 0;
+            }
+        }
+
         bool is_last_iter_for_hard_key =
             ((!is_weak) && ((dict_attack_ctx->nested_target_key % 8) == 7));
         if(initial_dict_attack_iter) {

--- a/lib/nfc/protocols/mf_classic/mf_classic_poller.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller.c
@@ -1897,6 +1897,18 @@ NfcCommand mf_classic_poller_handler_nested_controller(MfClassicPoller* instance
             dict_attack_ctx->nested_phase = MfClassicNestedPhaseDictAttack;
         }
     }
+    if(dict_attack_ctx->reuse_key_sector == instance->sectors_total) {
+        // Reset target sector to first sector whose key has not been found
+        for(dict_attack_ctx->reuse_key_sector = 0;
+            dict_attack_ctx->reuse_key_sector < instance->sectors_total &&
+            mf_classic_nested_is_target_key_found(instance, true);
+            dict_attack_ctx->reuse_key_sector++)
+            ;
+        // Reset to sane value just in case we happen to have all of the keys
+        if(dict_attack_ctx->reuse_key_sector == instance->sectors_total) {
+            dict_attack_ctx->reuse_key_sector = 0;
+        }
+    }
     if((dict_attack_ctx->nested_phase == MfClassicNestedPhaseDictAttack ||
         dict_attack_ctx->nested_phase == MfClassicNestedPhaseDictAttackResume) &&
        (dict_attack_ctx->nested_target_key < dict_target_key_max)) {


### PR DESCRIPTION
# What's new

- Fixes sector overrun that occurs when running nested dictionary attack on MIFARE Plus ~~X~~ 2k variants in SL1.

# Verification 

1. Provision a MIFARE Plus ~~X~~ 2k variants in SL1
2. Write a Vingcard credential to the card
3. Read the card as MIFARE Classic

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix

I'm not sure what the actual intended flow is supposed to be when the dictionary attack runs off the end of the card. I assume it would loop back and continue to check the first part of the dictionary, but it could also just move on to nonce collection, although that would involve some refactoring to free up the loaded dictionaries. Probably something for @noproto to clarify.

Edit: I've discovered that the test card in question is actually a MIFARE Plus EV1. Flipper's detection of this is not quite working, and because the card gave the same historical bytes as MIFARE Plus X, it was incorrectly assumed to be that chip.