### PR TITLE
nfc: Fix MFUL PWD_AUTH command creation

### DIFF
--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller_i.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller_i.c
@@ -37,7 +37,7 @@ MfUltralightError mf_ultralight_poller_auth_pwd(
     furi_check(data);
 
     uint8_t auth_cmd[5] = {MF_ULTRALIGHT_CMD_PWD_AUTH}; //-V1009
-    memccpy(&auth_cmd[1], data->password.data, 0, MF_ULTRALIGHT_AUTH_PASSWORD_SIZE);
+    memcpy(&auth_cmd[1], data->password.data, MF_ULTRALIGHT_AUTH_PASSWORD_SIZE);
     bit_buffer_copy_bytes(instance->tx_buffer, auth_cmd, sizeof(auth_cmd));
 
     MfUltralightError ret = MfUltralightErrorNone;


### PR DESCRIPTION
# What's new

- Prevents MFUL password from being truncated when it contains a null byte

# Verification 

- Ensure that a MFUL variant with password authentication can be authenticated against when its password contains a null byte at offset 0, 1, or 2. At least one byte after the null byte should not be null.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
