### PR TITLE
u2f: Fix leaking message digest contexts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,7 @@ jobs:
           python3 scripts/get_env.py "--event_file=${{ github.event_path }}" "--type=$TYPE"
 
       - name: 'Generate documentation'
-        uses: mattnotmitt/doxygen-action@edge
+        uses: mattnotmitt/doxygen-action@1.12.0
         env:
           DOXY_SRC_ROOT: "${{ github.workspace }}"
           DOXY_CONFIG_DIR: "${{ github.workspace }}/documentation/doxygen"

--- a/applications/main/u2f/u2f.c
+++ b/applications/main/u2f/u2f.c
@@ -280,6 +280,8 @@ static uint16_t u2f_register(U2fData* U2F, uint8_t* buf) {
         MCHECK(mbedtls_md_hmac_update(&hmac_ctx, private, sizeof(private)));
         MCHECK(mbedtls_md_hmac_update(&hmac_ctx, req->app_id, sizeof(req->app_id)));
         MCHECK(mbedtls_md_hmac_finish(&hmac_ctx, handle.hash));
+
+        mbedtls_md_free(&hmac_ctx);
     }
 
     // Generate public key
@@ -387,6 +389,8 @@ static uint16_t u2f_authenticate(U2fData* U2F, uint8_t* buf) {
         MCHECK(mbedtls_md_hmac_update(&hmac_ctx, priv_key, sizeof(priv_key)));
         MCHECK(mbedtls_md_hmac_update(&hmac_ctx, req->app_id, sizeof(req->app_id)));
         MCHECK(mbedtls_md_hmac_finish(&hmac_ctx, mac_control));
+
+        mbedtls_md_free(&hmac_ctx);
     }
 
     if(memcmp(req->key_handle.hash, mac_control, sizeof(mac_control)) != 0) {


### PR DESCRIPTION
# What's new

- Frees two mbedtls MD contexts that have not been freed after use

# Verification 

- This may or may not get picked up in static analysis

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
