### PR TITLE
nfc: Attempt to detect MFP 2k in MFC mode

### DIFF
--- a/lib/nfc/protocols/mf_classic/mf_classic.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic.c
@@ -38,6 +38,14 @@ static const MfClassicFeatures mf_classic_features[MfClassicTypeNum] = {
             .full_name = "Mifare Classic 4K",
             .type_name = "4K",
         },
+    [MfClassicTypePlus2k] =
+        {
+            // TODO: need to validate whether 17 or 18 sectors are accessible
+            .sectors_total = 17,
+            .blocks_total = 544,
+            .full_name = "Mifare Plus 2K",
+            .type_name = "Plus 2K",
+        },
 };
 
 const NfcDeviceBase nfc_device_mf_classic = {

--- a/lib/nfc/protocols/mf_classic/mf_classic.h
+++ b/lib/nfc/protocols/mf_classic/mf_classic.h
@@ -49,6 +49,7 @@ typedef enum {
     MfClassicTypeMini,
     MfClassicType1k,
     MfClassicType4k,
+    MfClassicTypePlus2k,
 
     MfClassicTypeNum,
 } MfClassicType;

--- a/lib/nfc/protocols/mf_classic/mf_classic_poller.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller.c
@@ -135,6 +135,18 @@ NfcCommand mf_classic_poller_handler_detect_type(MfClassicPoller* instance) {
             instance->current_type_check = MfClassicType4k;
             FURI_LOG_D(TAG, "4K detected");
         } else {
+            instance->current_type_check = MfClassicTypePlus2k;
+        }
+    } else if(instance->current_type_check == MfClassicTypePlus2k) {
+        // Second-last block in sector 16, which may exist if said sector is not in SL3 mode
+        MfClassicError error =
+            mf_classic_poller_get_nt(instance, 66, MfClassicKeyTypeA, NULL, false);
+        if(error == MfClassicErrorNone) {
+            instance->data->type = MfClassicTypePlus2k;
+            instance->state = MfClassicPollerStateStart;
+            instance->current_type_check = MfClassicType4k;
+            FURI_LOG_D(TAG, "Plus 2K detected");
+        } else {
             instance->current_type_check = MfClassicType1k;
         }
     } else if(instance->current_type_check == MfClassicType1k) {


### PR DESCRIPTION
# What's new

- Read extra accessible sectors on a MIFARE Plus 2k compared to MIFARE Classic 1k

# Verification 

- Read a MIFARE Plus 2k in SL1 as a MIFARE Classic card. It should be detected as a MIFARE Plus 2k.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix

Not sure whether MIFARE Plus 2k has 17 or 18 sectors. On my sample MIFARE Plus EV1 2k, sector 17 is not accessible, however that may be an effect of some sectors set to SL3. Someone with other samples will have to determine how many sectors there actually are.

Fixes #4012