### PR TITLE
Update protocol_pyramid.c malloc error handling

### DIFF
--- a/lib/lfrfid/protocols/protocol_pyramid.c
+++ b/lib/lfrfid/protocols/protocol_pyramid.c
@@ -36,7 +36,10 @@ typedef struct {
 } ProtocolPyramid;
 
 ProtocolPyramid* protocol_pyramid_alloc(void) {
-    ProtocolPyramid* protocol = malloc(sizeof(ProtocolPyramid));
+    ProtocolPyramid* protocol = (ProtocolPyramid*)malloc(sizeof(ProtocolPyramid));
+    if (!protocol) {
+        return NULL; // Handle memory allocation failure
+    }
     protocol->decoder.fsk_demod = fsk_demod_alloc(MIN_TIME, 6, MAX_TIME, 5);
     protocol->encoder.fsk_osc = fsk_osc_alloc(8, 10, 50);
 
@@ -44,9 +47,11 @@ ProtocolPyramid* protocol_pyramid_alloc(void) {
 }
 
 void protocol_pyramid_free(ProtocolPyramid* protocol) {
-    fsk_demod_free(protocol->decoder.fsk_demod);
-    fsk_osc_free(protocol->encoder.fsk_osc);
-    free(protocol);
+    if (protocol) {
+        fsk_demod_free(protocol->decoder.fsk_demod);
+        fsk_osc_free(protocol->encoder.fsk_osc);
+        free(protocol);
+    }
 }
 
 uint8_t* protocol_pyramid_get_data(ProtocolPyramid* protocol) {


### PR DESCRIPTION
added basic error handling to protocol_pyramid_alloc() by checking if malloc() fails before proceeding

# What's new

- Added basic error handling in protocol_pyramid_alloc() to check for malloc() failures.

# Verification 

- Verify that protocol_pyramid_alloc() returns NULL when memory allocation fails. Test protocol_pyramid_free() with a valid and null ProtocolPyramid pointer to ensure no crashes occur.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
