### PR TITLE
[FL-3957] EventLoop unsubscribe fix

### DIFF
--- a/applications/debug/unit_tests/tests/furi/furi_test.c
+++ b/applications/debug/unit_tests/tests/furi/furi_test.c
@@ -8,6 +8,7 @@ void test_furi_concurrent_access(void);
 void test_furi_pubsub(void);
 void test_furi_memmgr(void);
 void test_furi_event_loop(void);
+void test_furi_event_loop_self_unsubscribe(void);
 void test_errno_saving(void);
 void test_furi_primitives(void);
 void test_stdin(void);
@@ -46,6 +47,10 @@ MU_TEST(mu_test_furi_event_loop) {
     test_furi_event_loop();
 }
 
+MU_TEST(mu_test_furi_event_loop_self_unsubscribe) {
+    test_furi_event_loop_self_unsubscribe();
+}
+
 MU_TEST(mu_test_errno_saving) {
     test_errno_saving();
 }
@@ -68,6 +73,7 @@ MU_TEST_SUITE(test_suite) {
     MU_RUN_TEST(mu_test_furi_pubsub);
     MU_RUN_TEST(mu_test_furi_memmgr);
     MU_RUN_TEST(mu_test_furi_event_loop);
+    MU_RUN_TEST(mu_test_furi_event_loop_self_unsubscribe);
     MU_RUN_TEST(mu_test_stdio);
     MU_RUN_TEST(mu_test_errno_saving);
     MU_RUN_TEST(mu_test_furi_primitives);

--- a/furi/core/event_loop.c
+++ b/furi/core/event_loop.c
@@ -32,22 +32,6 @@ static void furi_event_loop_item_notify(FuriEventLoopItem* instance);
 
 static bool furi_event_loop_item_is_waiting(FuriEventLoopItem* instance);
 
-static void furi_event_loop_process_pending_callbacks(FuriEventLoop* instance) {
-    for(; !PendingQueue_empty_p(instance->pending_queue);
-        PendingQueue_pop_back(NULL, instance->pending_queue)) {
-        const FuriEventLoopPendingQueueItem* item = PendingQueue_back(instance->pending_queue);
-        item->callback(item->context);
-    }
-}
-
-static void furi_event_loop_process_deleted_items(FuriEventLoop* instance) {
-    while(!WaitingList_empty_p(instance->waiting_list)) {
-        FuriEventLoopItem* item = WaitingList_pop_front(instance->waiting_list);
-        furi_check(!item->owner);
-        furi_event_loop_item_free(item);
-    }
-}
-
 static bool furi_event_loop_signal_callback(uint32_t signal, void* arg, void* context) {
     furi_assert(context);
     FuriEventLoop* instance = context;
@@ -93,7 +77,6 @@ void furi_event_loop_free(FuriEventLoop* instance) {
 
     furi_event_loop_process_timer_queue(instance);
     furi_check(TimerList_empty_p(instance->timer_list));
-    furi_event_loop_process_deleted_items(instance);
     furi_check(WaitingList_empty_p(instance->waiting_list));
 
     FuriEventLoopTree_clear(instance->tree);
@@ -133,19 +116,27 @@ static inline FuriEventLoopProcessStatus
 
 static inline FuriEventLoopProcessStatus
     furi_event_loop_process_event(FuriEventLoop* instance, FuriEventLoopItem* item) {
-    if(item->owner == NULL) {
-        return FuriEventLoopProcessStatusFreeLater;
-    }
+    FuriEventLoopProcessStatus status;
 
     if(item->event & FuriEventLoopEventFlagOnce) {
         furi_event_loop_unsubscribe(instance, item->object);
     }
 
+    instance->current_item = item;
+
     if(item->event & FuriEventLoopEventFlagEdge) {
-        return furi_event_loop_process_edge_event(item);
+        status = furi_event_loop_process_edge_event(item);
     } else {
-        return furi_event_loop_process_level_event(item);
+        status = furi_event_loop_process_level_event(item);
     }
+
+    instance->current_item = NULL;
+
+    if(item->owner == NULL) {
+        status = FuriEventLoopProcessStatusFreeLater;
+    }
+
+    return status;
 }
 
 static inline FuriEventLoopItem* furi_event_loop_get_waiting_item(FuriEventLoop* instance) {
@@ -198,6 +189,14 @@ static void furi_event_loop_process_waiting_list(FuriEventLoop* instance) {
     furi_event_loop_sync_flags(instance);
 }
 
+static void furi_event_loop_process_pending_callbacks(FuriEventLoop* instance) {
+    for(; !PendingQueue_empty_p(instance->pending_queue);
+        PendingQueue_pop_back(NULL, instance->pending_queue)) {
+        const FuriEventLoopPendingQueueItem* item = PendingQueue_back(instance->pending_queue);
+        item->callback(item->context);
+    }
+}
+
 static void furi_event_loop_restore_flags(FuriEventLoop* instance, uint32_t flags) {
     if(flags) {
         xTaskNotifyIndexed(
@@ -208,7 +207,6 @@ static void furi_event_loop_restore_flags(FuriEventLoop* instance, uint32_t flag
 void furi_event_loop_run(FuriEventLoop* instance) {
     furi_check(instance);
     furi_check(instance->thread_id == furi_thread_get_current_id());
-
     FuriThread* thread = furi_thread_get_current();
 
     // Set the default signal callback if none was previously set
@@ -218,9 +216,9 @@ void furi_event_loop_run(FuriEventLoop* instance) {
 
     furi_event_loop_init_tick(instance);
 
-    while(true) {
-        instance->state = FuriEventLoopStateIdle;
+    instance->state = FuriEventLoopStateRunning;
 
+    while(true) {
         const TickType_t ticks_to_sleep =
             MIN(furi_event_loop_get_timer_wait_time(instance),
                 furi_event_loop_get_tick_wait_time(instance));
@@ -228,8 +226,6 @@ void furi_event_loop_run(FuriEventLoop* instance) {
         uint32_t flags = 0;
         BaseType_t ret = xTaskNotifyWaitIndexed(
             FURI_EVENT_LOOP_FLAG_NOTIFY_INDEX, 0, FuriEventLoopFlagAll, &flags, ticks_to_sleep);
-
-        instance->state = FuriEventLoopStateProcessing;
 
         if(ret == pdTRUE) {
             if(flags & FuriEventLoopFlagStop) {
@@ -453,7 +449,7 @@ void furi_event_loop_unsubscribe(FuriEventLoop* instance, FuriEventLoopObject* o
         WaitingList_unlink(item);
     }
 
-    if(instance->state == FuriEventLoopStateProcessing) {
+    if(instance->current_item == item) {
         furi_event_loop_item_free_later(item);
     } else {
         furi_event_loop_item_free(item);
@@ -506,9 +502,7 @@ static void furi_event_loop_item_free(FuriEventLoopItem* instance) {
 
 static void furi_event_loop_item_free_later(FuriEventLoopItem* instance) {
     furi_assert(instance);
-    furi_assert(instance->owner);
     furi_assert(!furi_event_loop_item_is_waiting(instance));
-    WaitingList_push_back(instance->owner->waiting_list, instance);
     instance->owner = NULL;
 }
 

--- a/furi/core/event_loop.c
+++ b/furi/core/event_loop.c
@@ -40,6 +40,14 @@ static void furi_event_loop_process_pending_callbacks(FuriEventLoop* instance) {
     }
 }
 
+static void furi_event_loop_process_deleted_items(FuriEventLoop* instance) {
+    while(!WaitingList_empty_p(instance->waiting_list)) {
+        FuriEventLoopItem* item = WaitingList_pop_front(instance->waiting_list);
+        furi_check(!item->owner);
+        furi_event_loop_item_free(item);
+    }
+}
+
 static bool furi_event_loop_signal_callback(uint32_t signal, void* arg, void* context) {
     furi_assert(context);
     FuriEventLoop* instance = context;
@@ -85,6 +93,7 @@ void furi_event_loop_free(FuriEventLoop* instance) {
 
     furi_event_loop_process_timer_queue(instance);
     furi_check(TimerList_empty_p(instance->timer_list));
+    furi_event_loop_process_deleted_items(instance);
     furi_check(WaitingList_empty_p(instance->waiting_list));
 
     FuriEventLoopTree_clear(instance->tree);
@@ -124,23 +133,19 @@ static inline FuriEventLoopProcessStatus
 
 static inline FuriEventLoopProcessStatus
     furi_event_loop_process_event(FuriEventLoop* instance, FuriEventLoopItem* item) {
-    FuriEventLoopProcessStatus status;
+    if(item->owner == NULL) {
+        return FuriEventLoopProcessStatusFreeLater;
+    }
 
     if(item->event & FuriEventLoopEventFlagOnce) {
         furi_event_loop_unsubscribe(instance, item->object);
     }
 
     if(item->event & FuriEventLoopEventFlagEdge) {
-        status = furi_event_loop_process_edge_event(item);
+        return furi_event_loop_process_edge_event(item);
     } else {
-        status = furi_event_loop_process_level_event(item);
+        return furi_event_loop_process_level_event(item);
     }
-
-    if(item->owner == NULL) {
-        status = FuriEventLoopProcessStatusFreeLater;
-    }
-
-    return status;
 }
 
 static inline FuriEventLoopItem* furi_event_loop_get_waiting_item(FuriEventLoop* instance) {
@@ -501,7 +506,9 @@ static void furi_event_loop_item_free(FuriEventLoopItem* instance) {
 
 static void furi_event_loop_item_free_later(FuriEventLoopItem* instance) {
     furi_assert(instance);
+    furi_assert(instance->owner);
     furi_assert(!furi_event_loop_item_is_waiting(instance));
+    WaitingList_push_back(instance->owner->waiting_list, instance);
     instance->owner = NULL;
 }
 

--- a/furi/core/event_loop_i.h
+++ b/furi/core/event_loop_i.h
@@ -64,8 +64,7 @@ typedef enum {
 
 typedef enum {
     FuriEventLoopStateStopped,
-    FuriEventLoopStateIdle,
-    FuriEventLoopStateProcessing,
+    FuriEventLoopStateRunning,
 } FuriEventLoopState;
 
 typedef struct {
@@ -81,6 +80,7 @@ struct FuriEventLoop {
 
     // Poller state
     volatile FuriEventLoopState state;
+    volatile FuriEventLoopItem* current_item;
 
     // Event handling
     FuriEventLoopTree_t tree;


### PR DESCRIPTION
# What's new
  - Unsubscribing from within an EventLoop callback doesn't crash anymore (fix by gsurkov)
  - Unit test for the fix

# Verification 
  - Run unit tests

# Checklist (For Reviewer)
  - [x] PR has description of feature/bug or link to Confluence/Jira task
  - [x] Description contains actions to verify feature/bugfix
  - [x] I've built this code, uploaded it to the device and verified feature/bugfix
