### PR TITLE
Furi, USB, BLE, Debug: various bug fixes and improvements

### DIFF
--- a/applications/main/gpio/usb_uart_bridge.c
+++ b/applications/main/gpio/usb_uart_bridge.c
@@ -183,7 +183,7 @@ static int32_t usb_uart_worker(void* context) {
     usb_uart->usb_mutex = furi_mutex_alloc(FuriMutexTypeNormal);
 
     usb_uart->tx_thread =
-        furi_thread_alloc_ex("UsbUartTxWorker", 512, usb_uart_tx_thread, usb_uart);
+        furi_thread_alloc_ex("UsbUartTxWorker", 768, usb_uart_tx_thread, usb_uart);
 
     usb_uart_vcp_init(usb_uart, usb_uart->cfg.vcp_ch);
     usb_uart_serial_init(usb_uart, usb_uart->cfg.uart_ch);
@@ -288,8 +288,6 @@ static int32_t usb_uart_worker(void* context) {
             usb_uart_update_ctrl_lines(usb_uart);
         }
     }
-    usb_uart_vcp_deinit(usb_uart, usb_uart->cfg.vcp_ch);
-    usb_uart_serial_deinit(usb_uart);
 
     furi_hal_gpio_init(USB_USART_DE_RE_PIN, GpioModeAnalog, GpioPullNo, GpioSpeedLow);
 
@@ -301,6 +299,9 @@ static int32_t usb_uart_worker(void* context) {
     furi_thread_flags_set(furi_thread_get_id(usb_uart->tx_thread), WorkerEvtTxStop);
     furi_thread_join(usb_uart->tx_thread);
     furi_thread_free(usb_uart->tx_thread);
+
+    usb_uart_vcp_deinit(usb_uart, usb_uart->cfg.vcp_ch);
+    usb_uart_serial_deinit(usb_uart);
 
     furi_stream_buffer_free(usb_uart->rx_stream);
     furi_mutex_free(usb_uart->usb_mutex);

--- a/furi/core/thread.c
+++ b/furi/core/thread.c
@@ -23,6 +23,8 @@
 
 #define THREAD_MAX_STACK_SIZE (UINT16_MAX * sizeof(StackType_t))
 
+#define THREAD_STACK_WATERMARK_MIN (256u)
+
 typedef struct {
     FuriThreadStdoutWriteCallback write_callback;
     FuriString* buffer;
@@ -114,6 +116,18 @@ static void furi_thread_body(void* context) {
     thread->ret = thread->callback(thread->context);
 
     furi_check(!thread->is_service, "Service threads MUST NOT return");
+
+    size_t stack_watermark = furi_thread_get_stack_space(thread);
+    if(stack_watermark < THREAD_STACK_WATERMARK_MIN) {
+#ifdef FURI_DEBUG
+        furi_crash("Stack watermark is dangerously low");
+#endif
+        FURI_LOG_E( //-V779
+            thread->name ? thread->name : "Thread",
+            "Stack watermark is too low %zu < " STRINGIFY(
+                THREAD_STACK_WATERMARK_MIN) ". Increase stack size.",
+            stack_watermark);
+    }
 
     if(thread->heap_trace_enabled == true) {
         furi_delay_ms(33);

--- a/targets/f7/ble_glue/ble_event_thread.c
+++ b/targets/f7/ble_glue/ble_event_thread.c
@@ -90,7 +90,7 @@ void ble_event_thread_stop(void) {
 void ble_event_thread_start(void) {
     furi_check(event_thread == NULL);
 
-    event_thread = furi_thread_alloc_ex("BleEventWorker", 1024, ble_event_thread, NULL);
+    event_thread = furi_thread_alloc_ex("BleEventWorker", 1280, ble_event_thread, NULL);
     furi_thread_set_priority(event_thread, FuriThreadPriorityHigh);
     furi_thread_start(event_thread);
 }

--- a/targets/f7/furi_hal/furi_hal_usb_cdc.c
+++ b/targets/f7/furi_hal/furi_hal_usb_cdc.c
@@ -392,10 +392,11 @@ static void cdc_on_suspend(usbd_device* dev);
 
 static usbd_respond cdc_ep_config(usbd_device* dev, uint8_t cfg);
 static usbd_respond cdc_control(usbd_device* dev, usbd_ctlreq* req, usbd_rqc_callback* callback);
+
 static usbd_device* usb_dev;
-static FuriHalUsbInterface* cdc_if_cur = NULL;
-static bool connected = false;
-static CdcCallbacks* callbacks[IF_NUM_MAX] = {NULL};
+static volatile FuriHalUsbInterface* cdc_if_cur = NULL;
+static volatile bool connected = false;
+static volatile CdcCallbacks* callbacks[IF_NUM_MAX] = {NULL};
 static void* cb_ctx[IF_NUM_MAX];
 
 FuriHalUsbInterface usb_cdc_single = {
@@ -506,8 +507,10 @@ uint8_t furi_hal_cdc_get_ctrl_line_state(uint8_t if_num) {
 void furi_hal_cdc_send(uint8_t if_num, uint8_t* buf, uint16_t len) {
     if(if_num == 0) {
         usbd_ep_write(usb_dev, CDC0_TXD_EP, buf, len);
-    } else {
+    } else if(if_num == 1) {
         usbd_ep_write(usb_dev, CDC1_TXD_EP, buf, len);
+    } else {
+        furi_crash();
     }
 }
 
@@ -515,8 +518,10 @@ int32_t furi_hal_cdc_receive(uint8_t if_num, uint8_t* buf, uint16_t max_len) {
     int32_t len = 0;
     if(if_num == 0) {
         len = usbd_ep_read(usb_dev, CDC0_RXD_EP, buf, max_len);
-    } else {
+    } else if(if_num == 1) {
         len = usbd_ep_read(usb_dev, CDC1_RXD_EP, buf, max_len);
+    } else {
+        furi_crash();
     }
     return (len < 0) ? 0 : len;
 }


### PR DESCRIPTION
# What's new

- Debug: color logging in apps/furi gdb helper, check and show crash message in gdb console
- Furi: thread watermark check on exit, explicitly crash if built with LIB_DEBUG=1
- Furi, USB, BLE: extra stack space for some threads, small code cleanup

# Verification 

- USB bridge crash should be gone. Enable system debug, heap trace(tree), debug logging, open and close bridge till it crash(now it shouldn't).
- Check new logging in `./fbt debug` (try to crash system so it will show you the message)
- Check console logs for apps with small stack size. Furi will tell you that you need to enlarge your...

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
