### PR TITLE
gpio: clear irq status before calling user handler

### DIFF
--- a/targets/f7/furi_hal/furi_hal_gpio.c
+++ b/targets/f7/furi_hal/furi_hal_gpio.c
@@ -250,93 +250,93 @@ void furi_hal_gpio_remove_int_callback(const GpioPin* gpio) {
 }
 
 FURI_ALWAYS_INLINE static void furi_hal_gpio_int_call(uint16_t pin_num) {
-    if(gpio_interrupt[pin_num].callback) {
+    if (gpio_interrupt[pin_num].callback) {
         gpio_interrupt[pin_num].callback(gpio_interrupt[pin_num].context);
     }
 }
 
 /* Interrupt handlers */
 void EXTI0_IRQHandler(void) {
-    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_0)) {
-        furi_hal_gpio_int_call(0);
+    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_0)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_0);
+        furi_hal_gpio_int_call(0);
     }
 }
 
 void EXTI1_IRQHandler(void) {
-    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_1)) {
-        furi_hal_gpio_int_call(1);
+    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_1)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_1);
+        furi_hal_gpio_int_call(1);
     }
 }
 
 void EXTI2_IRQHandler(void) {
-    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_2)) {
-        furi_hal_gpio_int_call(2);
+    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_2)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_2);
+        furi_hal_gpio_int_call(2);
     }
 }
 
 void EXTI3_IRQHandler(void) {
-    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_3)) {
-        furi_hal_gpio_int_call(3);
+    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_3)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_3);
+        furi_hal_gpio_int_call(3);
     }
 }
 
 void EXTI4_IRQHandler(void) {
-    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_4)) {
-        furi_hal_gpio_int_call(4);
+    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_4)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_4);
+        furi_hal_gpio_int_call(4);
     }
 }
 
 void EXTI9_5_IRQHandler(void) {
-    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_5)) {
-        furi_hal_gpio_int_call(5);
+    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_5)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_5);
+        furi_hal_gpio_int_call(5);
     }
-    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_6)) {
-        furi_hal_gpio_int_call(6);
+    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_6)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_6);
+        furi_hal_gpio_int_call(6);
     }
-    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_7)) {
-        furi_hal_gpio_int_call(7);
+    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_7)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_7);
+        furi_hal_gpio_int_call(7);
     }
-    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_8)) {
-        furi_hal_gpio_int_call(8);
+    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_8)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_8);
+        furi_hal_gpio_int_call(8);
     }
-    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_9)) {
-        furi_hal_gpio_int_call(9);
+    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_9)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_9);
+        furi_hal_gpio_int_call(9);
     }
 }
 
 void EXTI15_10_IRQHandler(void) {
-    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_10)) {
-        furi_hal_gpio_int_call(10);
+    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_10)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_10);
+        furi_hal_gpio_int_call(10);
     }
-    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_11)) {
-        furi_hal_gpio_int_call(11);
+    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_11)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_11);
+        furi_hal_gpio_int_call(11);
     }
-    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_12)) {
-        furi_hal_gpio_int_call(12);
+    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_12)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_12);
+        furi_hal_gpio_int_call(12);
     }
-    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_13)) {
-        furi_hal_gpio_int_call(13);
+    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_13)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_13);
+        furi_hal_gpio_int_call(13);
     }
-    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_14)) {
-        furi_hal_gpio_int_call(14);
+    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_14)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_14);
+        furi_hal_gpio_int_call(14);
     }
-    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_15)) {
-        furi_hal_gpio_int_call(15);
+    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_15)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_15);
+        furi_hal_gpio_int_call(15);
     }
 }

--- a/targets/f7/furi_hal/furi_hal_gpio.c
+++ b/targets/f7/furi_hal/furi_hal_gpio.c
@@ -250,92 +250,92 @@ void furi_hal_gpio_remove_int_callback(const GpioPin* gpio) {
 }
 
 FURI_ALWAYS_INLINE static void furi_hal_gpio_int_call(uint16_t pin_num) {
-    if (gpio_interrupt[pin_num].callback) {
+    if(gpio_interrupt[pin_num].callback) {
         gpio_interrupt[pin_num].callback(gpio_interrupt[pin_num].context);
     }
 }
 
 /* Interrupt handlers */
 void EXTI0_IRQHandler(void) {
-    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_0)) {
+    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_0)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_0);
         furi_hal_gpio_int_call(0);
     }
 }
 
 void EXTI1_IRQHandler(void) {
-    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_1)) {
+    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_1)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_1);
         furi_hal_gpio_int_call(1);
     }
 }
 
 void EXTI2_IRQHandler(void) {
-    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_2)) {
+    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_2)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_2);
         furi_hal_gpio_int_call(2);
     }
 }
 
 void EXTI3_IRQHandler(void) {
-    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_3)) {
+    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_3)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_3);
         furi_hal_gpio_int_call(3);
     }
 }
 
 void EXTI4_IRQHandler(void) {
-    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_4)) {
+    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_4)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_4);
         furi_hal_gpio_int_call(4);
     }
 }
 
 void EXTI9_5_IRQHandler(void) {
-    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_5)) {
+    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_5)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_5);
         furi_hal_gpio_int_call(5);
     }
-    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_6)) {
+    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_6)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_6);
         furi_hal_gpio_int_call(6);
     }
-    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_7)) {
+    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_7)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_7);
         furi_hal_gpio_int_call(7);
     }
-    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_8)) {
+    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_8)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_8);
         furi_hal_gpio_int_call(8);
     }
-    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_9)) {
+    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_9)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_9);
         furi_hal_gpio_int_call(9);
     }
 }
 
 void EXTI15_10_IRQHandler(void) {
-    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_10)) {
+    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_10)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_10);
         furi_hal_gpio_int_call(10);
     }
-    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_11)) {
+    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_11)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_11);
         furi_hal_gpio_int_call(11);
     }
-    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_12)) {
+    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_12)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_12);
         furi_hal_gpio_int_call(12);
     }
-    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_13)) {
+    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_13)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_13);
         furi_hal_gpio_int_call(13);
     }
-    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_14)) {
+    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_14)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_14);
         furi_hal_gpio_int_call(14);
     }
-    if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_15)) {
+    if(LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_15)) {
         LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_15);
         furi_hal_gpio_int_call(15);
     }


### PR DESCRIPTION
This patch clears IRQ status on EXTI handlers before calling the user's handler.

Behavior without this patch was to clear IRQ afterwards (pseudocode):

    if (irq_enabled) {
        call_user_handler();
        clear_irq_status();
    }

This behavior meant that interrupts which fired during the user handler wouldn't be observed, since the IRQ status was unconditionally cleared afterwards &mdash; this throws away information. It risks the following:

```
IRQ -> USER CODE -> CLEAR IRQ
                ^
            INTERRUPT
```

The user code will never see or handle this interrupt condition. So if instead we clear the IRQ first, the handler will just be called again in this case.

# Verification 

Build a ring oscillator circuit: feed an output pin back into an input pin and invert the input level in an interrupt. Observe the feedback line on an oscilloscope. The circuit doesn't oscillate without this patch, but with it, it does.

This application can be used to verify: https://pub.npry.dev/irqfix ([built .fap](https://github.com/user-attachments/files/18844680/irqfix.fap.gz) (API 80.1), gzipped so github will accept it). I symlinked into `applications_user/` to build. It uses pins PA7 and PA6 as input and output, respectively. 

The `Toggle` button can be used to "kick" the oscillator to start it if it doesn't start running automatically. This is what we see in the "no fix" image -- the toggle button inverts the level, the irq handler runs once, but then it stops, as the IRQ already fired within the handler and was then cleared.

**Flipper in circuit**
![breadboard](https://github.com/user-attachments/assets/0a13e790-763e-46f5-b3f4-595bf2ddf791)

**No Fix**
![no_fix](https://github.com/user-attachments/assets/3ebe0c41-4b57-4571-8e73-d8e0998b7315)

**With Fix**
![with_fix](https://github.com/user-attachments/assets/4f35dee9-d18a-4c96-820c-53c4d72e88d3)


# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
