### PR TITLE
vscode: disabled auto-update for clangd 

### DIFF
--- a/.vscode/example/settings.json.tmpl
+++ b/.vscode/example/settings.json.tmpl
@@ -12,6 +12,7 @@
         "SConstruct": "python",
         "*.fam": "python"
     },
+    "clangd.checkUpdates": false,
     "clangd.path": "${workspaceFolder}/toolchain/current/bin/clangd@FBT_PLATFORM_EXECUTABLE_EXT@",
     "clangd.arguments": [
         "--query-driver=**/arm-none-eabi-*",

--- a/scripts/ufbt/project_template/.vscode/settings.json
+++ b/scripts/ufbt/project_template/.vscode/settings.json
@@ -19,6 +19,7 @@
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter"
     },
+    "clangd.checkUpdates": false,
     "clangd.path": "@UFBT_TOOLCHAIN_CLANGD@",
     "clangd.arguments": [
         "--query-driver=**/arm-none-eabi-*",


### PR DESCRIPTION
# What's new

- vscode: disabled auto-update for clangd so IDE does not suggest upgrades for toolchain's bundled versions

- # Verification 

- deploy vscode config (`./fbt vscode_dist`)
- check that code completion with clangd works
- check that vscode's clang plugin does not suggest updates for clangd binary

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
