### PR TITLE
[FL-3290] Support for granular NFC debug settings

### DIFF
--- a/applications/main/nfc/api/mosgortrans/mosgortrans_util.c
+++ b/applications/main/nfc/api/mosgortrans/mosgortrans_util.c
@@ -479,9 +479,12 @@ bool mosgortrans_parse_transport_block(const MfClassicBlock* block, FuriString* 
     BlockData data_block = {};
     const uint16_t valid_departments[] = {0x106, 0x108, 0x10A, 0x10E, 0x110, 0x117};
     uint16_t transport_department = bit_lib_get_bits_16(block->data, 0, 10);
-    if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagDebug)) {
+    NfcSettings* settings = malloc(sizeof(NfcSettings));
+    nfc_settings_load(settings);
+    if(settings->parser_debug) {
         furi_string_cat_printf(result, "Transport department: %x\n", transport_department);
     }
+    free(settings);
     bool department_valid = false;
     for(uint8_t i = 0; i < 6; i++) {
         if(transport_department == valid_departments[i]) {
@@ -499,9 +502,12 @@ bool mosgortrans_parse_transport_block(const MfClassicBlock* block, FuriString* 
     } else if(layout_type == 0xF) {
         layout_type = bit_lib_get_bits_16(block->data, 52, 14);
     }
-    if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagDebug)) {
+    settings = malloc(sizeof(NfcSettings));
+    nfc_settings_load(settings);
+    if(settings->parser_debug) {
         furi_string_cat_printf(result, "Layout: %x\n", layout_type);
     }
+    free(settings);
     FURI_LOG_D(TAG, "Layout type %x", layout_type);
     switch(layout_type) {
     case 0x02: {

--- a/applications/main/nfc/api/mosgortrans/mosgortrans_util.h
+++ b/applications/main/nfc/api/mosgortrans/mosgortrans_util.h
@@ -4,6 +4,7 @@
 #include <datetime.h>
 #include <furi/core/string.h>
 #include <nfc/protocols/mf_classic/mf_classic.h>
+#include <nfc/helpers/nfc_settings.h>
 #include <furi_hal_rtc.h>
 
 #ifdef __cplusplus

--- a/applications/main/nfc/helpers/nfc_settings.c
+++ b/applications/main/nfc/helpers/nfc_settings.c
@@ -1,0 +1,39 @@
+#include "nfc_settings.h"
+
+#include <furi.h>
+#include <storage/storage.h>
+#include <toolbox/saved_struct.h>
+
+#define TAG "NfcSettings"
+
+#define NFC_SETTINGS_PATH         INT_PATH(NFC_SETTINGS_FILE_NAME)
+#define NFC_SETTINGS_FILE_VERSION (0)
+#define NFC_SETTINGS_FILE_MAGIC   (0x99)
+
+bool nfc_settings_save(NfcSettings* settings) {
+    furi_assert(settings);
+
+    return saved_struct_save(
+        NFC_SETTINGS_PATH,
+        settings,
+        sizeof(NfcSettings),
+        NFC_SETTINGS_FILE_MAGIC,
+        NFC_SETTINGS_FILE_VERSION);
+}
+
+void nfc_settings_load(NfcSettings* settings) {
+    furi_assert(settings);
+
+    const bool success = saved_struct_load(
+        NFC_SETTINGS_PATH,
+        settings,
+        sizeof(NfcSettings),
+        NFC_SETTINGS_FILE_MAGIC,
+        NFC_SETTINGS_FILE_VERSION);
+
+    if(!success) {
+        FURI_LOG_W(TAG, "Failed to load settings, using defaults");
+        memset(settings, 0, sizeof(NfcSettings));
+        nfc_settings_save(settings);
+    }
+}

--- a/applications/main/nfc/helpers/nfc_settings.h
+++ b/applications/main/nfc/helpers/nfc_settings.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <stdbool.h>
+
+#define NFC_SETTINGS_FILE_NAME ".nfc.settings"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    bool parser_debug;
+} NfcSettings;
+
+bool nfc_settings_save(NfcSettings* settings);
+
+void nfc_settings_load(NfcSettings* settings);
+
+#ifdef __cplusplus
+}
+#endif

--- a/applications/main/nfc/nfc_app.c
+++ b/applications/main/nfc/nfc_app.c
@@ -60,6 +60,10 @@ NfcApp* nfc_app_alloc(void) {
     instance->nfc_device = nfc_device_alloc();
     nfc_device_set_loading_callback(instance->nfc_device, nfc_show_loading_popup, instance);
 
+    // Debug settings
+    instance->debug_settings = malloc(sizeof(NfcSettings));
+    nfc_settings_load(instance->debug_settings);
+
     // Open GUI record
     instance->gui = furi_record_open(RECORD_GUI);
 
@@ -113,6 +117,13 @@ NfcApp* nfc_app_alloc(void) {
     view_dispatcher_add_view(
         instance->view_dispatcher, NfcViewWidget, widget_get_view(instance->widget));
 
+    // Variable Item List
+    instance->var_item_list = variable_item_list_alloc();
+    view_dispatcher_add_view(
+        instance->view_dispatcher,
+        NfcViewVariableItemList,
+        variable_item_list_get_view(instance->var_item_list));
+
     // Dict attack
     instance->dict_attack = dict_attack_alloc();
     view_dispatcher_add_view(
@@ -152,6 +163,10 @@ void nfc_app_free(NfcApp* instance) {
     // Nfc device
     nfc_device_free(instance->nfc_device);
 
+    // Debug settings
+    nfc_settings_save(instance->debug_settings);
+    free(instance->debug_settings);
+
     // Submenu
     view_dispatcher_remove_view(instance->view_dispatcher, NfcViewMenu);
     submenu_free(instance->submenu);
@@ -184,6 +199,10 @@ void nfc_app_free(NfcApp* instance) {
     // Custom Widget
     view_dispatcher_remove_view(instance->view_dispatcher, NfcViewWidget);
     widget_free(instance->widget);
+
+    // Variable Item List
+    view_dispatcher_remove_view(instance->view_dispatcher, NfcViewVariableItemList);
+    variable_item_list_free(instance->var_item_list);
 
     // Dict attack
     view_dispatcher_remove_view(instance->view_dispatcher, NfcViewDictAttack);

--- a/applications/main/nfc/nfc_app_i.h
+++ b/applications/main/nfc/nfc_app_i.h
@@ -21,6 +21,7 @@
 #include <gui/modules/byte_input.h>
 #include <gui/modules/text_box.h>
 #include <gui/modules/widget.h>
+#include <gui/modules/variable_item_list.h>
 #include "views/dict_attack.h"
 #include "views/detect_reader.h"
 #include "views/dict_attack.h"
@@ -35,6 +36,7 @@
 #include "helpers/nfc_supported_cards.h"
 #include "helpers/felica_auth.h"
 #include "helpers/slix_unlock.h"
+#include "helpers/nfc_settings.h"
 
 #include <dialogs/dialogs.h>
 #include <storage/storage.h>
@@ -119,6 +121,8 @@ struct NfcApp {
 
     NfcDetectedProtocols* detected_protocols;
 
+    NfcSettings* debug_settings;
+
     RpcAppSystem* rpc_ctx;
     NfcRpcState rpc_state;
 
@@ -131,6 +135,7 @@ struct NfcApp {
     ByteInput* byte_input;
     TextBox* text_box;
     Widget* widget;
+    VariableItemList* var_item_list;
     DetectReader* detect_reader;
     DictAttack* dict_attack;
 
@@ -164,6 +169,7 @@ typedef enum {
     NfcViewByteInput,
     NfcViewTextBox,
     NfcViewWidget,
+    NfcViewVariableItemList,
     NfcViewDictAttack,
     NfcViewDetectReader,
 } NfcView;

--- a/applications/main/nfc/scenes/nfc_scene_debug.c
+++ b/applications/main/nfc/scenes/nfc_scene_debug.c
@@ -44,7 +44,6 @@ void nfc_scene_debug_on_enter(void* context) {
 
     variable_item_list_add(nfc->var_item_list, "Field", 1, NULL, NULL);
 
-
     item = variable_item_list_add(
         nfc->var_item_list,
         "Parser debug",

--- a/applications/main/nfc/scenes/nfc_scene_debug.c
+++ b/applications/main/nfc/scenes/nfc_scene_debug.c
@@ -1,27 +1,65 @@
 #include "../nfc_app_i.h"
 
-enum SubmenuDebugIndex {
-    SubmenuDebugIndexField,
-    SubmenuDebugIndexApdu,
+const char* const debug_text[] = {
+    "OFF",
+    "ON",
 };
 
-void nfc_scene_debug_submenu_callback(void* context, uint32_t index) {
+enum NfcDebugIndex {
+    NfcDebugIndexField,
+    NfcDebugIndexParserDebug,
+};
+
+static void nfc_scene_debug_var_list_enter_callback(void* context, uint32_t index) {
     NfcApp* nfc = context;
 
     view_dispatcher_send_custom_event(nfc->view_dispatcher, index);
 }
 
+static void nfc_scene_debug_parser_debug_changed(VariableItem* item) {
+    uint8_t index = variable_item_get_current_value_index(item);
+    NfcApp* nfc = variable_item_get_context(item);
+
+    variable_item_set_current_value_text(item, debug_text[index]);
+    if(index) {
+        FURI_LOG_D("NFC", "NFC parser debug enabled");
+        nfc->debug_settings->parser_debug = true;
+    } else {
+        FURI_LOG_D("NFC", "NFC parser debug disabled");
+        nfc->debug_settings->parser_debug = false;
+    }
+
+    if(nfc_settings_save(nfc->debug_settings)) {
+        FURI_LOG_D("NFC", "Debug settings saved");
+    } else {
+        FURI_LOG_E("NFC", "Failed to save debug settings");
+    }
+}
+
 void nfc_scene_debug_on_enter(void* context) {
     NfcApp* nfc = context;
-    Submenu* submenu = nfc->submenu;
+    VariableItem* item;
 
-    submenu_add_item(
-        submenu, "Field", SubmenuDebugIndexField, nfc_scene_debug_submenu_callback, nfc);
+    variable_item_list_reset(nfc->var_item_list);
 
-    submenu_set_selected_item(
-        submenu, scene_manager_get_scene_state(nfc->scene_manager, NfcSceneDebug));
+    variable_item_list_add(nfc->var_item_list, "Field", 1, NULL, NULL);
 
-    view_dispatcher_switch_to_view(nfc->view_dispatcher, NfcViewMenu);
+
+    item = variable_item_list_add(
+        nfc->var_item_list,
+        "Parser debug",
+        COUNT_OF(debug_text),
+        nfc_scene_debug_parser_debug_changed,
+        nfc);
+    variable_item_set_current_value_index(item, nfc->debug_settings->parser_debug);
+    variable_item_set_current_value_text(item, debug_text[nfc->debug_settings->parser_debug]);
+
+    // TODO: Add logging toggle here when #4039 finished
+
+    variable_item_list_set_enter_callback(
+        nfc->var_item_list, nfc_scene_debug_var_list_enter_callback, nfc);
+
+    view_dispatcher_switch_to_view(nfc->view_dispatcher, NfcViewVariableItemList);
 }
 
 bool nfc_scene_debug_on_event(void* context, SceneManagerEvent event) {
@@ -29,9 +67,8 @@ bool nfc_scene_debug_on_event(void* context, SceneManagerEvent event) {
     bool consumed = false;
 
     if(event.type == SceneManagerEventTypeCustom) {
-        if(event.event == SubmenuDebugIndexField) {
-            scene_manager_set_scene_state(
-                nfc->scene_manager, NfcSceneDebug, SubmenuDebugIndexField);
+        if(event.event == NfcDebugIndexField) {
+            scene_manager_set_scene_state(nfc->scene_manager, NfcSceneDebug, NfcDebugIndexField);
             scene_manager_next_scene(nfc->scene_manager, NfcSceneField);
             consumed = true;
         }


### PR DESCRIPTION
# What's new

- NFC debug menu now has a toggle for verbose parser output
- Debug settings persist through restarts etc
- Further customization options can be added in the future

# Verification 

- Enable Debug in system settings
- Open the NFC app, navigate to the Debug menu
- Enable "Parser Debug"
- Read a Troika card, check that layout type and transport department are listed
- Try restarting the app, rebooting the device, etc, check that the setting didn't get reset to OFF
- Turn "Parser Debug" off, check that the Troika parser doesn't output the extra info.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
