### PR TITLE
LFRFID: Fix Detection Conflict Between Securakey and Noralsy Format

### DIFF
--- a/lib/lfrfid/protocols/protocol_securakey.c
+++ b/lib/lfrfid/protocols/protocol_securakey.c
@@ -61,17 +61,17 @@ uint8_t* protocol_securakey_get_data(ProtocolSecurakey* protocol) {
 static bool protocol_securakey_can_be_decoded(ProtocolSecurakey* protocol) {
     // check 19 bits preamble + format flag
     if(bit_lib_get_bits_32(protocol->RKKT_encoded_data, 0, 19) == 0b0111111111000000000) {
-        if (bit_lib_test_parity(protocol->RKKT_encoded_data, 2, 54, BitLibParityAlways0, 9)) {
+        if(bit_lib_test_parity(protocol->RKKT_encoded_data, 2, 54, BitLibParityAlways0, 9)) {
             protocol->bit_format = 0;
             return true;
         }
     } else if(bit_lib_get_bits_32(protocol->RKKT_encoded_data, 0, 19) == 0b0111111111001011010) {
-        if (bit_lib_test_parity(protocol->RKKT_encoded_data, 2, 90, BitLibParityAlways0, 9)) {
+        if(bit_lib_test_parity(protocol->RKKT_encoded_data, 2, 90, BitLibParityAlways0, 9)) {
             protocol->bit_format = 26;
             return true;
         }
     } else if(bit_lib_get_bits_32(protocol->RKKT_encoded_data, 0, 19) == 0b0111111111001100000) {
-        if (bit_lib_test_parity(protocol->RKKT_encoded_data, 2, 90, BitLibParityAlways0, 9)) { 
+        if(bit_lib_test_parity(protocol->RKKT_encoded_data, 2, 90, BitLibParityAlways0, 9)) {
             protocol->bit_format = 32;
             return true;
         }

--- a/lib/lfrfid/protocols/protocol_securakey.c
+++ b/lib/lfrfid/protocols/protocol_securakey.c
@@ -61,17 +61,22 @@ uint8_t* protocol_securakey_get_data(ProtocolSecurakey* protocol) {
 static bool protocol_securakey_can_be_decoded(ProtocolSecurakey* protocol) {
     // check 19 bits preamble + format flag
     if(bit_lib_get_bits_32(protocol->RKKT_encoded_data, 0, 19) == 0b0111111111000000000) {
-        protocol->bit_format = 0;
-        return true;
+        if (bit_lib_test_parity(protocol->RKKT_encoded_data, 2, 54, BitLibParityAlways0, 9)) {
+            protocol->bit_format = 0;
+            return true;
+        }
     } else if(bit_lib_get_bits_32(protocol->RKKT_encoded_data, 0, 19) == 0b0111111111001011010) {
-        protocol->bit_format = 26;
-        return true;
+        if (bit_lib_test_parity(protocol->RKKT_encoded_data, 2, 90, BitLibParityAlways0, 9)) {
+            protocol->bit_format = 26;
+            return true;
+        }
     } else if(bit_lib_get_bits_32(protocol->RKKT_encoded_data, 0, 19) == 0b0111111111001100000) {
-        protocol->bit_format = 32;
-        return true;
-    } else {
-        return false;
+        if (bit_lib_test_parity(protocol->RKKT_encoded_data, 2, 90, BitLibParityAlways0, 9)) { 
+            protocol->bit_format = 32;
+            return true;
+        }
     }
+    return false;
 }
 
 static void protocol_securakey_decode(ProtocolSecurakey* protocol) {


### PR DESCRIPTION
# What's new

- Added parity checks for Securakey protocol.
- This PR resolves the occasional conflict when a Noralsy tag can be detected as Securakey RKKTH tag when the signal is bad. https://github.com/flipperdevices/flipperzero-firmware/pull/4090#issuecomment-2670091105

# Verification 

- Write this Noralsy tag to a t5 and read. Previously if you wiggle the tag around and try to tear off, on the debug log there could be false detections as Securkey occasionally.
- With this PR it won't happen.
[Test_Nora.zip](https://github.com/user-attachments/files/18923422/Test_Nora.zip)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
