### PR TITLE
JS API: Fix PWM is-supported logic on pwmStop()

### DIFF
--- a/applications/system/js_app/modules/js_gpio.c
+++ b/applications/system/js_app/modules/js_gpio.c
@@ -308,7 +308,7 @@ static void js_gpio_is_pwm_running(struct mjs* mjs) {
  */
 static void js_gpio_pwm_stop(struct mjs* mjs) {
     JsGpioPinInst* manager_data = JS_GET_CONTEXT(mjs);
-    if(manager_data->pwm_output != FuriHalPwmOutputIdNone) {
+    if(manager_data->pwm_output == FuriHalPwmOutputIdNone) {
         JS_ERROR_AND_RETURN(mjs, MJS_BAD_ARGS_ERROR, "PWM is not supported on this pin");
     }
 


### PR DESCRIPTION
# What's new

- Fixes #4128

The logic for the PWM is-supported check in pwmStop() in the JS API gpio module was inverted, so there was no way to stop a running PWM.

# Verification 

- Build and run a JS script that tries to call pwmStop() on a valid PWM pin.

Example:
```js
let eventLoop = require("event_loop");
let gpio = require("gpio");
let led = gpio.get("pa4");
print("pa4 pwm support:", led.isPwmSupported());
print("pa4 pwm running:", led.isPwmRunning());
led.pwmWrite(10000, 50);
print("pa4 pwm running:", led.isPwmRunning());
led.pwmStop();
print("pa4 pwm running:", led.isPwmRunning());
```

Tested locally, and fixes the issue! (Also thanks for the awesome new PWM work!! ❤️)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
