### PR TITLE
fix: flipper detected before reboot

### DIFF
--- a/scripts/testops.py
+++ b/scripts/testops.py
@@ -37,14 +37,12 @@ class Main(App):
         self.logger.info(f"Attempting to find flipper with {retry_count} attempts.")
 
         for i in range(retry_count):
+            time.sleep(1)
             self.logger.info(f"Attempt to find flipper #{i}.")
 
             if port := resolve_port(self.logger, self.args.port):
                 self.logger.info(f"Found flipper at {port}")
-                time.sleep(1)
                 break
-
-            time.sleep(1)
 
         if not port:
             self.logger.info(f"Failed to find flipper {port}")


### PR DESCRIPTION
# What's new

- Moved sleep to more reliable place

# Verification 

- `python3 scripts/power.py reboot && python3 scripts/testops.py -t=15 await_flipper` should reboot and detect already rebooted flipper
- was:
`python3 scripts/power.py reboot && python3 scripts/testops.py -t=15 await_flipper
2025-03-12 11:32:29,391 [INFO] Attempting to find flipper with 10 attempts.
2025-03-12 11:32:30,392 [INFO] Attempting to find flipper #0.
2025-03-12 11:32:30,393 [INFO] Using flip_Teharg on /dev/ttyACM4
2025-03-12 11:32:30,393 [INFO] Found flipper at /dev/ttyACM4
2025-03-12 11:32:30,458 [INFO] Rebooting
2025-03-12 11:32:30,490 [INFO] Attempting to find flipper with 15 attempts.
2025-03-12 11:32:30,490 [INFO] Attempt to find flipper #0.
2025-03-12 11:32:30,490 [INFO] Using flip_Teharg on /dev/ttyACM4
2025-03-12 11:32:30,490 [INFO] Found flipper at /dev/ttyACM4
Traceback (most recent call last):
  File "/opt/flipperzero-firmware/toolchain/x86_64-linux/lib/python3.11/site-packages/serial/serialposix.py", line 322, in open
    self.fd = os.open(self.portstr, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: [Errno 6] No such device or address: '/dev/ttyACM4'`

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
