### PR TITLE
[FL-3966] Reduce IEEE754 parser size

### DIFF
--- a/lib/SConscript
+++ b/lib/SConscript
@@ -43,6 +43,7 @@ libs = env.BuildModules(
         "ble_profile",
         "bit_lib",
         "datetime",
+        "ieee754_parse_wrap",
     ],
 )
 

--- a/lib/ieee754_parse_wrap/SConscript
+++ b/lib/ieee754_parse_wrap/SConscript
@@ -1,0 +1,31 @@
+Import("env")
+
+wrapped_fn_list = [
+    "strtof",
+    "strtod",
+]
+
+for wrapped_fn in wrapped_fn_list:
+    env.Append(
+        LINKFLAGS=[
+            "-Wl,--wrap," + wrapped_fn,
+        ]
+    )
+
+env.Append(
+    SDK_HEADERS=[
+        File("wrappers.h"),
+    ],
+    LINT_SOURCES=[
+        Dir("."),
+    ],
+)
+
+libenv = env.Clone(FW_LIB_NAME="ieee754_parse_wrap")
+libenv.ApplyLibFlags()
+
+sources = libenv.GlobRecursive("*.c*", ".")
+
+lib = libenv.StaticLibrary("${FW_LIB_NAME}", sources)
+libenv.Install("${LIB_DIST_DIR}", lib)
+Return("lib")

--- a/lib/ieee754_parse_wrap/wrappers.c
+++ b/lib/ieee754_parse_wrap/wrappers.c
@@ -1,0 +1,14 @@
+#include "wrappers.h"
+
+// Based on the disassembly, providing NULL as `locale` is fine.
+// The default `strtof` and `strtod` provided in the same libc_nano also just
+// call these functions, but with an actual locale structure which was taking up
+// lots of .data space (364 bytes).
+
+float __wrap_strtof(const char* in, char** tail) {
+    return strtof_l(in, tail, NULL);
+}
+
+double __wrap_strtod(const char* in, char** tail) {
+    return strtod_l(in, tail, NULL);
+}

--- a/lib/ieee754_parse_wrap/wrappers.h
+++ b/lib/ieee754_parse_wrap/wrappers.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+float __wrap_strtof(const char* in, char** tail);
+double __wrap_strtod(const char* in, char** tail);
+
+#ifdef __cplusplus
+}
+#endif

--- a/targets/f18/api_symbols.csv
+++ b/targets/f18/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,82.1,,
+Version,+,82.2,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
 Header,+,applications/services/cli/cli.h,,
@@ -57,6 +57,7 @@ Header,+,lib/flipper_application/plugins/plugin_manager.h,,
 Header,+,lib/flipper_format/flipper_format.h,,
 Header,+,lib/flipper_format/flipper_format_i.h,,
 Header,+,lib/flipper_format/flipper_format_stream.h,,
+Header,+,lib/ieee754_parse_wrap/wrappers.h,,
 Header,+,lib/libusb_stm32/inc/hid_usage_button.h,,
 Header,+,lib/libusb_stm32/inc/hid_usage_consumer.h,,
 Header,+,lib/libusb_stm32/inc/hid_usage_desktop.h,,
@@ -382,6 +383,8 @@ Function,+,__wrap_putc,int,"int, FILE*"
 Function,+,__wrap_putchar,int,int
 Function,+,__wrap_puts,int,const char*
 Function,+,__wrap_snprintf,int,"char*, size_t, const char*, ..."
+Function,+,__wrap_strtod,double,"const char*, char**"
+Function,+,__wrap_strtof,float,"const char*, char**"
 Function,+,__wrap_ungetc,int,"int, FILE*"
 Function,+,__wrap_vsnprintf,int,"char*, size_t, const char*, va_list"
 Function,-,_asiprintf_r,int,"_reent*, char**, const char*, ..."
@@ -2361,13 +2364,13 @@ Function,-,pow,double,"double, double"
 Function,-,pow10,double,double
 Function,-,pow10f,float,float
 Function,+,power_enable_low_battery_level_notification,void,"Power*, _Bool"
+Function,+,power_enable_otg,void,"Power*, _Bool"
 Function,+,power_get_info,void,"Power*, PowerInfo*"
 Function,+,power_get_pubsub,FuriPubSub*,Power*
 Function,+,power_is_battery_healthy,_Bool,Power*
 Function,+,power_is_otg_enabled,_Bool,Power*
 Function,+,power_off,void,Power*
 Function,+,power_reboot,void,"Power*, PowerBootMode"
-Function,+,power_enable_otg,void,"Power*, _Bool"
 Function,+,powf,float,"float, float"
 Function,-,powl,long double,"long double, long double"
 Function,+,pretty_format_bytes_hex_canonical,void,"FuriString*, size_t, const char*, const uint8_t*, size_t"

--- a/targets/f18/target.json
+++ b/targets/f18/target.json
@@ -36,7 +36,8 @@
         "flipper18",
         "bit_lib",
         "toolbox",
-        "datetime"
+        "datetime",
+        "ieee754_parse_wrap"
     ],
     "excluded_sources": [
         "furi_hal_infrared.c",

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,82.1,,
+Version,+,82.2,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
@@ -61,6 +61,7 @@ Header,+,lib/flipper_format/flipper_format_stream.h,,
 Header,+,lib/ibutton/ibutton_key.h,,
 Header,+,lib/ibutton/ibutton_protocols.h,,
 Header,+,lib/ibutton/ibutton_worker.h,,
+Header,+,lib/ieee754_parse_wrap/wrappers.h,,
 Header,+,lib/infrared/encoder_decoder/infrared.h,,
 Header,+,lib/infrared/worker/infrared_transmit.h,,
 Header,+,lib/infrared/worker/infrared_worker.h,,
@@ -459,6 +460,8 @@ Function,+,__wrap_putc,int,"int, FILE*"
 Function,+,__wrap_putchar,int,int
 Function,+,__wrap_puts,int,const char*
 Function,+,__wrap_snprintf,int,"char*, size_t, const char*, ..."
+Function,+,__wrap_strtod,double,"const char*, char**"
+Function,+,__wrap_strtof,float,"const char*, char**"
 Function,+,__wrap_ungetc,int,"int, FILE*"
 Function,+,__wrap_vsnprintf,int,"char*, size_t, const char*, va_list"
 Function,-,_asiprintf_r,int,"_reent*, char**, const char*, ..."
@@ -2999,13 +3002,13 @@ Function,-,pow,double,"double, double"
 Function,-,pow10,double,double
 Function,-,pow10f,float,float
 Function,+,power_enable_low_battery_level_notification,void,"Power*, _Bool"
+Function,+,power_enable_otg,void,"Power*, _Bool"
 Function,+,power_get_info,void,"Power*, PowerInfo*"
 Function,+,power_get_pubsub,FuriPubSub*,Power*
 Function,+,power_is_battery_healthy,_Bool,Power*
 Function,+,power_is_otg_enabled,_Bool,Power*
 Function,+,power_off,void,Power*
 Function,+,power_reboot,void,"Power*, PowerBootMode"
-Function,+,power_enable_otg,void,"Power*, _Bool"
 Function,+,powf,float,"float, float"
 Function,-,powl,long double,"long double, long double"
 Function,+,pretty_format_bytes_hex_canonical,void,"FuriString*, size_t, const char*, const uint8_t*, size_t"

--- a/targets/f7/target.json
+++ b/targets/f7/target.json
@@ -50,6 +50,7 @@
         "flipper7",
         "bit_lib",
         "toolbox",
-        "datetime"
+        "datetime",
+        "ieee754_parse_wrap"
     ]
 }


### PR DESCRIPTION
# What's new
  - Wrapped `strtof` and `strtod` to remove locale information from `.data`
  - As a result, freed up 404 bytes of flash and 364 bytes of `.data` (20% of that section)

# Verification 
  - Run unit tests. `test_flipper_format` and `test_js` depend on these functions.

# Checklist (For Reviewer)
  - [x] PR has description of feature/bug or link to Confluence/Jira task
  - [x] Description contains actions to verify feature/bugfix
  - [x] I've built this code, uploaded it to the device and verified feature/bugfix
