### PR TITLE
 Support binded and symlinked devices

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: 'Flash unit tests firmware'
         id: flashing
         if: success()
-        timeout-minutes: 10
+        timeout-minutes: 5
         run: |
           source scripts/toolchain/fbtenv.sh
           ./fbt resources firmware_latest flash LIB_DEBUG=1 FIRMWARE_APP_SET=unit_tests FORCE=1
@@ -30,7 +30,7 @@ jobs:
       - name: 'Copy assets and unit data, reboot and wait for flipper'
         id: copy
         if: steps.flashing.outcome == 'success'
-        timeout-minutes: 7
+        timeout-minutes: 5
         run: |
           source scripts/toolchain/fbtenv.sh
           python3 scripts/testops.py -t=15 await_flipper
@@ -42,7 +42,7 @@ jobs:
       - name: 'Run units and validate results'
         id: run_units
         if: steps.copy.outcome == 'success'
-        timeout-minutes: 7
+        timeout-minutes: 5
         run: |
           source scripts/toolchain/fbtenv.sh
           python3 scripts/testops.py run_units

--- a/.github/workflows/updater_test.yml
+++ b/.github/workflows/updater_test.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: 'Flashing target firmware'
         id: first_full_flash
-        timeout-minutes: 10
+        timeout-minutes: 5
         run: |
           source scripts/toolchain/fbtenv.sh
           python3 scripts/testops.py -t=180 await_flipper
@@ -29,7 +29,7 @@ jobs:
 
       - name: 'Validating updater'
         id: second_full_flash
-        timeout-minutes: 10
+        timeout-minutes: 5
         if: success()
         run: |
           source scripts/toolchain/fbtenv.sh

--- a/scripts/flipper/utils/cdc.py
+++ b/scripts/flipper/utils/cdc.py
@@ -1,3 +1,4 @@
+import glob
 import serial.tools.list_ports as list_ports
 
 
@@ -12,6 +13,16 @@ def resolve_port(logger, portname: str = "auto"):
         logger.info(f"Using {flipper.serial_number} on {flipper.device}")
         return flipper.device
     elif len(flippers) == 0:
+        # Fallback: check for tty_flip_{serial} devices
+        tty_flip_devices = glob.glob("/dev/tty_flip_*")
+        if tty_flip_devices:
+            device_path = tty_flip_devices[0]
+            # Extract serial from path
+            serial = device_path.split("_")[-1]
+            logger.info(
+                f"Fallback: Found Flipper device with serial {serial} at {device_path}"
+            )
+            return device_path
         logger.error("Failed to find connected Flipper")
     elif len(flippers) > 1:
         logger.error("More than one Flipper is attached")

--- a/scripts/flipper/utils/cdc.py
+++ b/scripts/flipper/utils/cdc.py
@@ -1,4 +1,4 @@
-import glob
+import os
 import serial.tools.list_ports as list_ports
 
 
@@ -13,16 +13,11 @@ def resolve_port(logger, portname: str = "auto"):
         logger.info(f"Using {flipper.serial_number} on {flipper.device}")
         return flipper.device
     elif len(flippers) == 0:
-        # Fallback: check for tty_flip_{serial} devices
-        tty_flip_devices = glob.glob("/dev/tty_flip_*")
-        if tty_flip_devices:
-            device_path = tty_flip_devices[0]
-            # Extract serial from path
-            serial = device_path.split("_")[-1]
-            logger.info(
-                f"Fallback: Found Flipper device with serial {serial} at {device_path}"
-            )
-            return device_path
         logger.error("Failed to find connected Flipper")
     elif len(flippers) > 1:
         logger.error("More than one Flipper is attached")
+    env_path = os.environ.get("FLIPPER_PATH")
+    if env_path:
+        if os.path.exists(env_path):
+            logger.info(f"Using FLIPPER_PATH from environment: {env_path}")
+            return env_path

--- a/scripts/power.py
+++ b/scripts/power.py
@@ -3,6 +3,8 @@
 import time
 from typing import Optional
 
+from serial.serialutil import SerialException
+
 from flipper.app import App
 from flipper.storage import FlipperStorage
 from flipper.utils.cdc import resolve_port
@@ -47,7 +49,13 @@ class Main(App):
             return None
 
         flipper = FlipperStorage(port)
-        flipper.start()
+        for i in range(retry_count):
+            try:
+                flipper.start()
+                break
+            except SerialException as e:
+                self.logger.error(f"Failed to start flipper: {e}")
+                time.sleep(1)
         return flipper
 
     def power_off(self):

--- a/scripts/power.py
+++ b/scripts/power.py
@@ -34,11 +34,11 @@ class Main(App):
 
     def _get_flipper(self, retry_count: Optional[int] = 1):
         port = None
-        self.logger.info(f"Attempting to find flipper with {retry_count} attempts.")
-
         for i in range(retry_count):
             time.sleep(1)
-            self.logger.info(f"Attempting to find flipper #{i}.")
+            self.logger.info(
+                f"Attempting to find flipper (Attempt {i + 1}/{retry_count})."
+            )
 
             if port := resolve_port(self.logger, self.args.port):
                 self.logger.info(f"Found flipper at {port}")
@@ -54,9 +54,13 @@ class Main(App):
                 flipper.start()
                 break
             except SerialException as e:
-                self.logger.error(f"Failed to start flipper: {e}")
+                self.logger.info(
+                    f"Failed to start flipper (Attempt {i + 1}/{retry_count})"
+                )
                 time.sleep(1)
-        return flipper
+
+        self.logger.error("Flipper failed to start after all retries.")
+        return None
 
     def power_off(self):
         if not (flipper := self._get_flipper(retry_count=10)):

--- a/scripts/power.py
+++ b/scripts/power.py
@@ -52,15 +52,13 @@ class Main(App):
         for i in range(retry_count):
             try:
                 flipper.start()
-                break
-            except SerialException as e:
+                self.logger.info("Flipper successfully started.")
+                return flipper
+            except IOError as e:
                 self.logger.info(
-                    f"Failed to start flipper (Attempt {i + 1}/{retry_count})"
+                    f"Failed to start flipper (Attempt {i + 1}/{retry_count}): {e}"
                 )
                 time.sleep(1)
-
-        self.logger.error("Flipper failed to start after all retries.")
-        return None
 
     def power_off(self):
         if not (flipper := self._get_flipper(retry_count=10)):

--- a/scripts/testops.py
+++ b/scripts/testops.py
@@ -4,6 +4,8 @@ import time
 from datetime import datetime
 from typing import Optional
 
+from serial.serialutil import SerialException
+
 from flipper.app import App
 from flipper.storage import FlipperStorage
 from flipper.utils.cdc import resolve_port
@@ -38,18 +40,24 @@ class Main(App):
 
         for i in range(retry_count):
             time.sleep(1)
-            self.logger.info(f"Attempt to find flipper #{i}.")
+            self.logger.info(f"Attempting to find flipper #{i}.")
 
             if port := resolve_port(self.logger, self.args.port):
                 self.logger.info(f"Found flipper at {port}")
                 break
 
         if not port:
-            self.logger.info(f"Failed to find flipper {port}")
+            self.logger.info(f"Failed to find flipper")
             return None
 
         flipper = FlipperStorage(port)
-        flipper.start()
+        for i in range(retry_count):
+            try:
+                flipper.start()
+                break
+            except SerialException as e:
+                self.logger.error(f"Failed to start flipper: {e}")
+                time.sleep(1)
         return flipper
 
     def await_flipper(self):

--- a/scripts/testops.py
+++ b/scripts/testops.py
@@ -56,9 +56,9 @@ class Main(App):
                 flipper.start()
                 self.logger.info("Flipper successfully started.")
                 return flipper
-            except SerialException as e:
+            except IOError as e:
                 self.logger.info(
-                    f"Failed to start flipper (Attempt {i + 1}/{retry_count})"
+                    f"Failed to start flipper (Attempt {i + 1}/{retry_count}): {e}"
                 )
                 time.sleep(1)
 

--- a/scripts/testops.py
+++ b/scripts/testops.py
@@ -36,11 +36,11 @@ class Main(App):
 
     def _get_flipper(self, retry_count: Optional[int] = 1):
         port = None
-        self.logger.info(f"Attempting to find flipper with {retry_count} attempts.")
-
         for i in range(retry_count):
             time.sleep(1)
-            self.logger.info(f"Attempting to find flipper #{i}.")
+            self.logger.info(
+                f"Attempting to find flipper (Attempt {i + 1}/{retry_count})."
+            )
 
             if port := resolve_port(self.logger, self.args.port):
                 self.logger.info(f"Found flipper at {port}")
@@ -54,11 +54,16 @@ class Main(App):
         for i in range(retry_count):
             try:
                 flipper.start()
-                break
+                self.logger.info("Flipper successfully started.")
+                return flipper
             except SerialException as e:
-                self.logger.error(f"Failed to start flipper: {e}")
+                self.logger.info(
+                    f"Failed to start flipper (Attempt {i + 1}/{retry_count})"
+                )
                 time.sleep(1)
-        return flipper
+
+        self.logger.error("Flipper failed to start after all retries.")
+        return None
 
     def await_flipper(self):
         if not (flipper := self._get_flipper(retry_count=self.args.timeout)):


### PR DESCRIPTION
# What's new

- Reworked flipper port detection to check also for env variable FLIPPER_PATH
- await_flipper now checks that device port can be opened for the case when symlink/bind exists but device is not connected

# Verification 

- Changes effecting code that used for unit_tests and updater_tests. Successfully executed jobs should be enough

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
