### PR TITLE
Issue 4082: Subghz Modulation Shortcut

### DIFF
--- a/applications/main/subghz/scenes/subghz_scene_receiver_config.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver_config.c
@@ -366,3 +366,123 @@ void subghz_scene_receiver_config_on_exit(void* context) {
     scene_manager_set_scene_state(
         subghz->scene_manager, SubGhzSceneReadRAW, SubGhzCustomEventManagerNoSet);
 }
+
+
+// Function to cycle modulation forwards
+void increase_modulation_preset(SubGhz* subghz) {
+    // Retrieve the current settings structure
+    SubGhzSetting* setting = subghz_txrx_get_setting(subghz->txrx);
+    uint8_t preset_count = subghz_setting_get_preset_count(setting);
+    
+    // Get the current preset from the radio
+    SubGhzRadioPreset current = subghz_txrx_get_preset(subghz->txrx);
+    const char* current_preset = furi_string_get_cstr(current.name);
+
+    uint8_t current_index = 0;
+    
+    // Find the current index by iterating through the available presets
+    for(uint8_t i = 0; i < preset_count; i++) {
+        if(strcmp(subghz_setting_get_preset_name(setting, i), current_preset) == 0) {
+            current_index = i;
+            break;
+        }
+    }
+    
+    // Cycle to the next preset (wrap-around)
+    uint8_t new_index = (current_index + 1) % preset_count;
+    const char* new_preset_name = subghz_setting_get_preset_name(setting, new_index);
+    
+    // Update the radio preset with the new modulation preset
+    subghz_txrx_set_preset(
+        subghz->txrx,
+        new_preset_name,
+        current.frequency,
+        subghz_setting_get_preset_data(setting, new_index),
+        subghz_setting_get_preset_data_size(setting, new_index)
+    );
+
+    // --- Update the receiver view's status bar --- //
+    FuriString* frequency_str = furi_string_alloc();
+    FuriString* modulation_str = furi_string_alloc();
+    FuriString* history_stat_str = furi_string_alloc();
+
+    // Retrieve updated frequency and modulation strings
+    subghz_txrx_get_frequency_and_modulation(subghz->txrx, frequency_str, modulation_str);
+    
+    // Update the history text (samples /50)
+    subghz_history_get_text_space_left(subghz->history, history_stat_str);
+    
+    // Update the receiver view status bar with the new values
+    subghz_view_receiver_add_data_statusbar(
+        subghz->subghz_receiver,
+        furi_string_get_cstr(frequency_str),
+        furi_string_get_cstr(modulation_str),
+        furi_string_get_cstr(history_stat_str)
+    );
+    
+    furi_string_free(frequency_str);
+    furi_string_free(modulation_str);
+    furi_string_free(history_stat_str);
+
+}
+
+
+// Function to cycle modulation backwards
+void decrease_modulation_preset(SubGhz* subghz) {
+    // Retrieve the current settings structure
+    SubGhzSetting* setting = subghz_txrx_get_setting(subghz->txrx);
+    uint8_t preset_count = subghz_setting_get_preset_count(setting);
+    
+    // Get the current preset from the radio
+    SubGhzRadioPreset current = subghz_txrx_get_preset(subghz->txrx);
+    const char* current_preset = furi_string_get_cstr(current.name);
+
+    uint8_t current_index = 0;
+    
+    // Find the current index by iterating through the available presets
+    for(uint8_t i = 0; i < preset_count; i++) {
+        if(strcmp(subghz_setting_get_preset_name(setting, i), current_preset) == 0) {
+            current_index = i;
+            break;
+        }
+    }
+    
+    // Cycle to the previous preset (wrap-around using modulo arithmetic)
+    uint8_t new_index = (current_index + preset_count - 1) % preset_count;
+    const char* new_preset_name = subghz_setting_get_preset_name(setting, new_index);
+    
+    // Update the radio preset with the new modulation preset
+    subghz_txrx_set_preset(
+        subghz->txrx,
+        new_preset_name,
+        current.frequency,
+        subghz_setting_get_preset_data(setting, new_index),
+        subghz_setting_get_preset_data_size(setting, new_index)
+    );
+
+    // --- Update the receiver view's status bar --- //
+    FuriString* frequency_str = furi_string_alloc();
+    FuriString* modulation_str = furi_string_alloc();
+    FuriString* history_stat_str = furi_string_alloc();
+
+    // Retrieve updated frequency and modulation strings
+    subghz_txrx_get_frequency_and_modulation(subghz->txrx, frequency_str, modulation_str);
+    
+    // Update the history text (samples /50)
+    subghz_history_get_text_space_left(subghz->history, history_stat_str);
+    
+    // Update the receiver view status bar with the new values
+    subghz_view_receiver_add_data_statusbar(
+        subghz->subghz_receiver,
+        furi_string_get_cstr(frequency_str),
+        furi_string_get_cstr(modulation_str),
+        furi_string_get_cstr(history_stat_str)
+    );
+    
+    furi_string_free(frequency_str);
+    furi_string_free(modulation_str);
+    furi_string_free(history_stat_str);
+
+    
+}
+

--- a/applications/main/subghz/scenes/subghz_scene_receiver_config.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver_config.c
@@ -1,6 +1,8 @@
 #include "../subghz_i.h"
 #include <lib/toolbox/value_index.h>
 
+typedef struct SubGhz SubGhz;
+
 enum SubGhzSettingIndex {
     SubGhzSettingIndexFrequency,
     SubGhzSettingIndexHopping,

--- a/applications/main/subghz/views/receiver.c
+++ b/applications/main/subghz/views/receiver.c
@@ -354,6 +354,11 @@ bool subghz_view_receiver_input(InputEvent* event, void* context) {
             SubGhzViewReceiverModel * model,
             {
                 if(model->idx != 0) model->idx--;
+                else {
+                	// Call helper function to cycle modulation
+                    increase_modulation_preset(subghz_receiver->context);
+                
+                }
             },
             true);
     } else if(
@@ -365,6 +370,11 @@ bool subghz_view_receiver_input(InputEvent* event, void* context) {
             {
                 if((model->history_item != 0) && (model->idx != model->history_item - 1))
                     model->idx++;
+
+                else {
+                	// Call helper function to cycle modulation
+                    decrease_modulation_preset(subghz_receiver->context);
+                }
             },
             true);
     } else if(event->key == InputKeyLeft && event->type == InputTypeShort) {

--- a/applications/main/subghz/views/receiver.c
+++ b/applications/main/subghz/views/receiver.c
@@ -246,7 +246,14 @@ void subghz_view_receiver_draw(Canvas* canvas, SubGhzViewReceiverModel* model) {
         canvas_draw_icon(canvas, 0, 0, &I_Scanning_short_96x52);
         canvas_set_font(canvas, FontPrimary);
         canvas_draw_str(canvas, 63, 44, "Scanning...");
+        // Up/down icon to indicate modulation change shortcut
+        canvas_draw_icon(canvas, 120, 16, &I_ButtonUp_7x4);
+		canvas_draw_icon(canvas, 120, 32, &I_ButtonDown_7x4);
+		
         canvas_set_font(canvas, FontSecondary);
+        // Draw preset name eg. AM
+        canvas_draw_str(canvas, 110, 29, furi_string_get_cstr(model->preset_str));
+
     }
 
     if(model->device_type == SubGhzRadioDeviceTypeInternal) {

--- a/applications/main/subghz/views/receiver.c
+++ b/applications/main/subghz/views/receiver.c
@@ -18,6 +18,8 @@ typedef struct {
     uint8_t type;
 } SubGhzReceiverMenuItem;
 
+typedef struct SubGhz SubGhz;
+
 ARRAY_DEF(SubGhzReceiverMenuItemArray, SubGhzReceiverMenuItem, M_POD_OPLIST)
 
 #define M_OPL_SubGhzReceiverMenuItemArray_t() \

--- a/applications/main/subghz/views/receiver.h
+++ b/applications/main/subghz/views/receiver.h
@@ -48,5 +48,4 @@ void subghz_view_receiver_exit(void* context);
 
 // Helper functions for subghz modulation shortcut
 void increase_modulation_preset(SubGhz* subghz);
-
 void decrease_modulation_preset(SubGhz* subghz);

--- a/applications/main/subghz/views/receiver.h
+++ b/applications/main/subghz/views/receiver.h
@@ -5,6 +5,7 @@
 #include "../helpers/subghz_custom_event.h"
 
 typedef struct SubGhzViewReceiver SubGhzViewReceiver;
+typedef struct SubGhz SubGhz;
 
 typedef void (*SubGhzViewReceiverCallback)(SubGhzCustomEvent event, void* context);
 
@@ -43,3 +44,9 @@ uint16_t subghz_view_receiver_get_idx_menu(SubGhzViewReceiver* subghz_receiver);
 void subghz_view_receiver_set_idx_menu(SubGhzViewReceiver* subghz_receiver, uint16_t idx);
 
 void subghz_view_receiver_exit(void* context);
+
+
+// Helper functions for subghz modulation shortcut
+void increase_modulation_preset(SubGhz* subghz);
+
+void decrease_modulation_preset(SubGhz* subghz);


### PR DESCRIPTION
Closes #4082 

This issue requested a shortcut feature for the subghz app (read mode) that allows the user to switch between modulations whilst actively reading,. This avoids having to go back to the configuration menu and modulation submenu, then back to reading. 
This fix was implemented by adding an up/down button press shortcut to change between modulation presets while actively reading subghz signals.
![Mod-Shortcut-Subghz](https://github.com/user-attachments/assets/d6b10b94-9057-4fd0-9ed7-f5e25dfb526c)


# What's new

Views/receiver.c:
- Changed void subghz_view_receiver_draw(Canvas* canvas, SubGhzViewReceiverModel* model)  to draw up/down buttons and reflect sbility to change modulation type in "read" mode view
- Changed bool subghz_view_receiver_input(InputEvent* event, void* context) to handle input from up/down buttons and call corresponding modulation change function (described below)
- Added typedef struct SubGhz SubGhz; at top of file to be able to access modulation fields

Scenes/subghz_scene_receiver_config.c:
- Added void decrease_modulation_preset(SubGhz* subghz), called when down button is pressed when scanning
- Added void increase_modulation_preset(SubGhz* subghz), called when up button is pressed when scanning
- Added typedef struct SubGhz SubGhz; at top of file to be able to access modulation fields

Views/receiver.h:
-Added the following function headers
		void increase_modulation_preset(SubGhz* subghz);
		void decrease_modulation_preset(SubGhz* subghz);
- Added typedef struct SubGhz SubGhz; at top of file to be able to access modulation fields

# Verification 
-Clone this fork locally
-Run the following bash commands from a terminal in the cloned firmware folder root:
		./fbt updater_package
		tar czvf update.tgz -C dist/f7-D f7-update-local to create .tgz update package

-Open qflipper desktop app and connect flipper zero device via USB cable the same as for a regular firmware update
- Choose option to install from file
-Select update.tgz package in firmware root created in previous step
-Update your flipper and reboot
-Open subghz app on the flipper device, and select "Read" from subghz menu
-Use up/down buttons to cycle through modulation preset list either forwards or backwards
-Full preset name can be viewed from the config->modulation submenu

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
