### PR TITLE
Docs: Fix doxygen references from PR 4168

### DIFF
--- a/documentation/doxygen/js.dox
+++ b/documentation/doxygen/js.dox
@@ -17,6 +17,7 @@ Flipper Zero's built-in JavaScript engine enables you to run lightweight scripts
 
 - @subpage js_badusb — This module allows you to emulate a standard USB keyboard
 - @subpage js_event_loop — The module for easy event-based developing
+- @subpage js_flipper — This module allows to query device information
 - @subpage js_gpio — This module allows you to control GPIO pins
 - @subpage js_gui — This module allows you to use GUI (graphical user interface)
 - @subpage js_math — This module contains mathematical methods and constants

--- a/documentation/js/js_gui.md
+++ b/documentation/js/js_gui.md
@@ -41,23 +41,23 @@ always access the canvas through a viewport.
 In Flipper's terminology, a "View" is a fullscreen design element that assumes
 control over the entire viewport and all input events. Different types of views
 are available (not all of which are unfortunately currently implemented in JS):
-| View                 | Has JS adapter?  |
-|----------------------|------------------|
-| `button_menu`        | ❌               |
-| `button_panel`       | ❌               |
-| `byte_input`         | ❌               |
-| `dialog_ex`          | ✅ (as `dialog`) |
-| `empty_screen`       | ✅               |
-| `file_browser`       | ❌               |
-| `loading`            | ✅               |
-| `menu`               | ❌               |
-| `number_input`       | ❌               |
-| `popup`              | ❌               |
-| `submenu`            | ✅               |
-| `text_box`           | ✅               |
-| `text_input`         | ✅               |
-| `variable_item_list` | ❌               |
-| `widget`             | ❌               |
+| View                 | Has JS adapter?       |
+|----------------------|-----------------------|
+| `button_menu`        | ❌                    |
+| `button_panel`       | ❌                    |
+| `byte_input`         | ✅                    |
+| `dialog_ex`          | ✅ (as `dialog`)      |
+| `empty_screen`       | ✅                    |
+| `file_browser`       | ✅ (as `file_picker`) |
+| `loading`            | ✅                    |
+| `menu`               | ❌                    |
+| `number_input`       | ❌                    |
+| `popup`              | ❌                    |
+| `submenu`            | ✅                    |
+| `text_box`           | ✅                    |
+| `text_input`         | ✅                    |
+| `variable_item_list` | ❌                    |
+| `widget`             | ✅                    |
 
 In JS, each view has its own set of properties (or just "props"). The programmer
 can manipulate these properties in two ways:

--- a/documentation/js/js_gui.md
+++ b/documentation/js/js_gui.md
@@ -10,12 +10,15 @@ let gui = require("gui");
 
 GUI module has several submodules:
 
-- @subpage js_gui__submenu — Displays a scrollable list of clickable textual entries
-- @subpage js_gui__loading — Displays an animated hourglass icon
-- @subpage js_gui__empty_screen — Just empty screen
-- @subpage js_gui__text_input — Keyboard-like text input
-- @subpage js_gui__text_box — Simple multiline text box
+- @subpage js_gui__byte_input — Keyboard-like hex input
 - @subpage js_gui__dialog — Dialog with up to 3 options
+- @subpage js_gui__empty_screen — Just empty screen
+- @subpage js_gui__file_picker — Displays a file selection prompt
+- @subpage js_gui__icon — Retrieves and loads icons for use in GUI
+- @subpage js_gui__loading — Displays an animated hourglass icon
+- @subpage js_gui__submenu — Displays a scrollable list of clickable textual entries
+- @subpage js_gui__text_box — Simple multiline text box
+- @subpage js_gui__text_input — Keyboard-like text input
 - @subpage js_gui__widget — Displays a combination of custom elements on one screen
 
 ---


### PR DESCRIPTION
# What's new

- my apologies, i did not realize i needed to add references to the added pages. without them, the new pages were added to the top-level sidebar, out of context and breaking navigation
- also updated the js gui adapter table with byte_input and file_picker

# Verification 

- if possible to run doxygen without deploying to production, check that this is fixed:
  
![image](https://github.com/user-attachments/assets/bd6c191c-94ee-4ee8-9d07-ff505b1c60eb)


# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
