### PR TITLE
Added Vivax and Sansui under Elitelux section

### DIFF
--- a/applications/main/infrared/resources/infrared/assets/tv.ir
+++ b/applications/main/infrared/resources/infrared/assets/tv.ir
@@ -2474,7 +2474,7 @@ protocol: RC5
 address: 01 00 00 00
 command: 14 00 00 00
 #
-# Model: Elitelux L32HD1000
+# Model: Elitelux L32HD1000 / Vivax TV-32LE114T2S2SM / Sansui
 #
 name: Power
 type: parsed


### PR DESCRIPTION
Apparently both the mentioned Elitelux and Vivax models are the same, so they share the same codes. Sansui is a brand that is also associated with them as one of the available Sansui codes is the same as this one. This code might also work for the non-smart version of the Vivax TV, the TV-32LE114T2S2, but it has not been tested.

I tested this morning with my TV, which is a Vivax TV-32LE114T2S2SM and it shares the same code as the mentioned Elitelux in the comment. I then performed a web search to find out that Elitelux and Sansui share some products. This is confirmed by the fact that my Fire Stick has been configured with a Sansui profile for IR and it works with the Vivax.

# What's new

- Added a comment for people who don't know that Vivax, Elitelux and Sansui are correlated.

# Verification 

- Nothing at code level to be verified. It's just a comment.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
