### PR TITLE
fbt: Deterministic STARTUP order & additional checks

### DIFF
--- a/applications/debug/unit_tests/application.fam
+++ b/applications/debug/unit_tests/application.fam
@@ -7,6 +7,7 @@ App(
     requires=["system_settings", "cli_subghz"],
     provides=["delay_test"],
     resources="resources",
+    order=10,
 )
 
 App(

--- a/applications/debug/unit_tests/application.fam
+++ b/applications/debug/unit_tests/application.fam
@@ -18,7 +18,7 @@ App(
     entry_point="delay_test_app",
     stack_size=1 * 1024,
     requires=["unit_tests"],
-    order=110,
+    order=30,
 )
 
 App(

--- a/applications/debug/unit_tests/application.fam
+++ b/applications/debug/unit_tests/application.fam
@@ -7,7 +7,7 @@ App(
     requires=["system_settings", "cli_subghz"],
     provides=["delay_test"],
     resources="resources",
-    order=10,
+    order=30,
 )
 
 App(

--- a/applications/main/archive/application.fam
+++ b/applications/main/archive/application.fam
@@ -7,5 +7,5 @@ App(
     requires=["gui"],
     stack_size=4 * 1024,
     icon="A_FileManager_14",
-    order=0,
+    order=10,
 )

--- a/applications/services/bt/application.fam
+++ b/applications/services/bt/application.fam
@@ -21,5 +21,5 @@ App(
     appid="bt_start",
     apptype=FlipperAppType.STARTUP,
     entry_point="bt_on_system_start",
-    order=70,
+    order=40,
 )

--- a/applications/services/cli/application.fam
+++ b/applications/services/cli/application.fam
@@ -21,7 +21,7 @@ App(
     apptype=FlipperAppType.SERVICE,
     entry_point="cli_vcp_srv",
     stack_size=1024,
-    order=40,
+    order=10,
     sdk_headers=["cli_vcp.h"],
     sources=["cli_vcp.c"],
 )

--- a/applications/services/crypto/application.fam
+++ b/applications/services/crypto/application.fam
@@ -2,5 +2,5 @@ App(
     appid="crypto_start",
     apptype=FlipperAppType.STARTUP,
     entry_point="crypto_on_system_start",
-    order=10,
+    order=20,
 )

--- a/applications/services/expansion/application.fam
+++ b/applications/services/expansion/application.fam
@@ -8,5 +8,5 @@ App(
     ],
     requires=["rpc_start"],
     provides=["expansion_settings"],
-    order=150,
+    order=100,
 )

--- a/applications/services/loader/application.fam
+++ b/applications/services/loader/application.fam
@@ -19,5 +19,5 @@ App(
     apptype=FlipperAppType.STARTUP,
     entry_point="loader_on_system_start",
     requires=["loader"],
-    order=90,
+    order=80,
 )

--- a/applications/services/locale/application.fam
+++ b/applications/services/locale/application.fam
@@ -4,6 +4,6 @@ App(
     apptype=FlipperAppType.STARTUP,
     entry_point="locale_on_system_start",
     cdefines=["SRV_LOCALE"],
-    order=90,
+    order=70,
     sdk_headers=["locale.h"],
 )

--- a/applications/services/power/application.fam
+++ b/applications/services/power/application.fam
@@ -22,5 +22,5 @@ App(
     apptype=FlipperAppType.STARTUP,
     entry_point="power_on_system_start",
     requires=["power"],
-    order=80,
+    order=50,
 )

--- a/applications/services/region/application.fam
+++ b/applications/services/region/application.fam
@@ -6,5 +6,5 @@ App(
     entry_point="region_on_system_start",
     cdefines=["SRV_REGION"],
     requires=["storage"],
-    order=170,
+    order=120,
 )

--- a/applications/services/storage/application.fam
+++ b/applications/services/storage/application.fam
@@ -16,5 +16,5 @@ App(
     apptype=FlipperAppType.STARTUP,
     entry_point="storage_on_system_start",
     requires=["storage"],
-    order=90,
+    order=60,
 )

--- a/applications/system/js_app/application.fam
+++ b/applications/system/js_app/application.fam
@@ -23,7 +23,7 @@ App(
     appid="js_app_start",
     apptype=FlipperAppType.STARTUP,
     entry_point="js_app_on_system_start",
-    order=160,
+    order=110,
     sources=["js_app.c"],
 )
 

--- a/applications/system/js_app/application.fam
+++ b/applications/system/js_app/application.fam
@@ -5,7 +5,7 @@ App(
     entry_point="js_app",
     stack_size=2 * 1024,
     resources="examples",
-    order=0,
+    order=10,
     provides=["js_app_start"],
     sources=[
         "js_app.c",

--- a/applications/system/updater/application.fam
+++ b/applications/system/updater/application.fam
@@ -27,7 +27,7 @@ App(
     provides=["updater_start"],
     entry_point="updater_srv",
     stack_size=2 * 1024,
-    order=10,
+    order=20,
 )
 
 App(

--- a/applications/system/updater/application.fam
+++ b/applications/system/updater/application.fam
@@ -35,5 +35,5 @@ App(
     apptype=FlipperAppType.STARTUP,
     entry_point="updater_on_system_start",
     requires=["updater_app"],
-    order=110,
+    order=90,
 )

--- a/scripts/fbt_tools/fbt_apps.py
+++ b/scripts/fbt_tools/fbt_apps.py
@@ -155,6 +155,15 @@ def DumpApplicationConfig(target, source, env):
                 fg.green(f"{apptype.value}:\n\t"),
                 ", ".join(app.appid for app in app_sublist),
             )
+        # Print a warning if any apps in the list have same .order value
+        unique_order_values = set(app.order for app in app_sublist)
+        if len(app_sublist) != len(unique_order_values) and max(unique_order_values):
+            print(
+                fg.yellow(
+                    "\tDuplicate .order values in group:\n\t"
+                    + ", ".join(f"{app.appid} ({app.order})" for app in app_sublist)
+                )
+            )
     if incompatible_ext_apps := env["APPBUILD"].get_incompatible_ext_apps():
         print(
             fg.blue("Incompatible apps (skipped):\n\t"),

--- a/scripts/fbt_tools/fbt_apps.py
+++ b/scripts/fbt_tools/fbt_apps.py
@@ -150,20 +150,22 @@ def DumpApplicationConfig(target, source, env):
     print(fg.boldgreen("Firmware modules configuration:"))
     for apptype in FlipperAppType:
         app_sublist = env["APPBUILD"].get_apps_of_type(apptype)
-        if app_sublist:
-            print(
-                fg.green(f"{apptype.value}:\n\t"),
-                ", ".join(app.appid for app in app_sublist),
-            )
         # Print a warning if any apps in the list have same .order value
         unique_order_values = set(app.order for app in app_sublist)
         if len(app_sublist) != len(unique_order_values) and max(unique_order_values):
             print(
-                fg.yellow(
-                    "\tDuplicate .order values in group:\n\t"
+                fg.red(f"{apptype.value}: ")
+                + fg.yellow(
+                    "Duplicate .order values in group:\n\t"
                     + ", ".join(f"{app.appid} ({app.order})" for app in app_sublist)
                 )
             )
+        elif app_sublist:
+            print(
+                fg.green(f"{apptype.value}:\n\t"),
+                ", ".join(app.appid for app in app_sublist),
+            )
+
     if incompatible_ext_apps := env["APPBUILD"].get_incompatible_ext_apps():
         print(
             fg.blue("Incompatible apps (skipped):\n\t"),


### PR DESCRIPTION
# What's new
  - Fixed startup order for CLI-adjacent `STARTUP` apps
  - Added warnings if multiple apps in same category have same .order value, leading to non-deterministic behaviour 

# Verification 
  - Confirm that unit tests do not deadlock

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
