### PR TITLE
Fix NULL dereference in CLI completions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,7 +23,7 @@
 /applications/main/u2f/ @DrZlo13 @hedger @gsurkov @nminaylov
 
 /applications/services/bt/ @DrZlo13 @hedger @gsurkov @gornekich
-/applications/services/cli/ @DrZlo13 @hedger @gsurkov @nminaylov
+/applications/services/cli/ @DrZlo13 @hedger @gsurkov @nminaylov @portasynthinca3
 /applications/services/crypto/ @DrZlo13 @hedger @gsurkov @nminaylov
 /applications/services/desktop/ @DrZlo13 @hedger @gsurkov @nminaylov
 /applications/services/dolphin/ @DrZlo13 @hedger @gsurkov @nminaylov
@@ -64,6 +64,8 @@
 /lib/nfc/ @DrZlo13 @hedger @gsurkov @gornekich
 /lib/one_wire/ @DrZlo13 @hedger @gsurkov
 /lib/subghz/ @DrZlo13 @hedger @gsurkov @Skorpionm
+/lib/toolbox/ @DrZlo13 @hedger @gsurkov
+/lib/toolbox/cli @DrZlo13 @hedger @gsurkov @portasynthinca3
 
 # CI/CD
 /.github/workflows/ @DrZlo13 @hedger @gsurkov

--- a/applications/services/cli/cli_main_commands.c
+++ b/applications/services/cli/cli_main_commands.c
@@ -506,7 +506,7 @@ void cli_main_commands_init(CliRegistry* registry) {
     cli_registry_add_command(registry, "top", CliCommandFlagParallelSafe, cli_command_top, NULL);
     cli_registry_add_command(registry, "free", CliCommandFlagParallelSafe, cli_command_free, NULL);
     cli_registry_add_command(
-        registry, "free_blocks", CliCommandFlagDefault, cli_command_free_blocks, NULL);
+        registry, "free_blocks", CliCommandFlagParallelSafe, cli_command_free_blocks, NULL);
     cli_registry_add_command(registry, "echo", CliCommandFlagParallelSafe, cli_command_echo, NULL);
 
     cli_registry_add_command(registry, "vibro", CliCommandFlagDefault, cli_command_vibro, NULL);

--- a/lib/toolbox/cli/shell/cli_shell_completions.c
+++ b/lib/toolbox/cli/shell/cli_shell_completions.c
@@ -265,6 +265,7 @@ void cli_shell_completions_render(
         }
 
     } else if(action == CliShellCompletionsActionSelectNoClose) {
+        if(!CommandCompletions_size(completions->variants)) return;
         // insert selection into prompt
         CliShellCompletionSegment segment = cli_shell_completions_segment(completions);
         FuriString* input = cli_shell_line_get_selected(completions->line);


### PR DESCRIPTION
# What's new
  - Fix NULL dereference in CLI completions menu
  - Marked `free_blocks` as parallel safe
  - Added myself to CODEOWNERS for the CLI subsystem

# Verification 
  - Call up a CLI completions menu with 0 options, e.g. by `vibro <TAB>`, or `nonexistentcommand<TAB>`
  - Press enter
  - Verify that flipper doesn't crash

# Checklist (For Reviewer)
  - [x] PR has description of feature/bug or link to Confluence/Jira task
  - [x] Description contains actions to verify feature/bugfix
  - [x] I've built this code, uploaded it to the device and verified feature/bugfix
