### PR TITLE
FBT: Fix for Python 3.13

### DIFF
--- a/scripts/fbt/appmanifest.py
+++ b/scripts/fbt/appmanifest.py
@@ -158,7 +158,7 @@ class AppManager:
                     f"App {kw.get('appid')} cannot have fal_embedded set"
                 )
 
-        if apptype in AppBuildset.dist_app_types:
+        if apptype in AppBuildset.DIST_APP_TYPES:
             # For distributing .fap's resources, there's "fap_file_assets"
             for app_property in ("resources",):
                 if kw.get(app_property):
@@ -258,14 +258,12 @@ class AppBuildset:
         FlipperAppType.DEBUG: True,
         FlipperAppType.MENUEXTERNAL: False,
     }
-
-    @classmethod
-    @property
-    def dist_app_types(cls):
-        """Applications that are installed on SD card"""
-        return list(
-            entry[0] for entry in cls.EXTERNAL_APP_TYPES_MAP.items() if entry[1]
-        )
+    DIST_APP_TYPES = list(
+        # Applications that are installed on SD card
+        entry[0]
+        for entry in EXTERNAL_APP_TYPES_MAP.items()
+        if entry[1]
+    )
 
     @staticmethod
     def print_writer(message):


### PR DESCRIPTION
# What's new

- title
- `@classmethod` cannot be used with `@property` anymore
- also needed for https://github.com/flipperdevices/flipper-application-catalog/pull/688

# Verification 

- use app catalog's bundle script with this modified sdk and updated dependencies from other pr
- it should work on 3.13

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
