### PR TITLE
Fixed inverted logic condition in subghz chat cli

### DIFF
--- a/applications/main/subghz/subghz_cli.c
+++ b/applications/main/subghz/subghz_cli.c
@@ -1092,7 +1092,7 @@ static void subghz_cli_command_chat(PipeSide* pipe, FuriString* args) {
                 break;
             }
         }
-        if(!cli_is_pipe_broken_or_is_etx_next_char(pipe)) {
+        if(cli_is_pipe_broken_or_is_etx_next_char(pipe)) {
             printf("\r\n");
             chat_event.event = SubGhzChatEventUserExit;
             subghz_chat_worker_put_event_chat(subghz_chat, &chat_event);


### PR DESCRIPTION
# What's new

- Fixed problem that broke subghz chat cli. There was an error that reversed error handling logic, and make it close when you pressed any key.

# Verification 

- Open cli, type `subghz chat`, and use it

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
