### PR TITLE
string from file function for bad usb

### DIFF
--- a/applications/main/bad_usb/helpers/ducky_script_commands.c
+++ b/applications/main/bad_usb/helpers/ducky_script_commands.c
@@ -1,4 +1,6 @@
+#include <furi.h>
 #include <furi_hal.h>
+#include <storage/storage.h>
 #include <lib/toolbox/strint.h>
 #include "ducky_script.h"
 #include "ducky_script_i.h"
@@ -253,6 +255,28 @@ static int32_t ducky_fnc_mouse_move(BadUsbScript* bad_usb, const char* line, int
     return 0;
 }
 
+static int32_t ducky_fnc_string_from_file(BadUsbScript* bad_usb, const char* line, int32_t param) {
+    UNUSED(param);
+    char buffer[254];
+    size_t read_bytes;
+    Storage* storage = furi_record_open("storage");
+    File* file = storage_file_alloc(storage);
+
+    line = &line[ducky_get_command_len(line) + 1];
+    if (file) {
+        storage_file_open(file, line, FSAM_READ, FSOM_OPEN_EXISTING);
+        read_bytes = storage_file_read(file, buffer, sizeof(buffer) - 1);
+        buffer[read_bytes] = '\0'; // Null-terminate the string
+        furi_string_set_str(bad_usb->string_print, buffer);
+        storage_file_close(file);
+        bool state = ducky_string(bad_usb, furi_string_get_cstr(bad_usb->string_print));
+        if(!state) {
+            return ducky_error(bad_usb, "Invalid string %s", line);
+        }
+    }
+    return 0;
+}
+
 static const DuckyCmd ducky_commands[] = {
     {"REM", NULL, -1},
     {"ID", NULL, -1},
@@ -279,6 +303,7 @@ static const DuckyCmd ducky_commands[] = {
     {"MOUSE_MOVE", ducky_fnc_mouse_move, -1},
     {"MOUSESCROLL", ducky_fnc_mouse_scroll, -1},
     {"MOUSE_SCROLL", ducky_fnc_mouse_scroll, -1},
+    {"STRING_FROM_FILE", ducky_fnc_string_from_file, -1},
 };
 
 #define TAG "BadUsb"

--- a/documentation/file_formats/BadUsbScriptFormat.md
+++ b/documentation/file_formats/BadUsbScriptFormat.md
@@ -79,10 +79,11 @@ Up to 5 keys can be hold simultaneously.
 
 ## String
 
-| Command  | Parameters  | Notes                                      |
-| -------  | ----------- | -----------------                          |
-| STRING   | Text string | Print text string                          |
-| STRINGLN | Text string | Print text string and press enter after it |
+| Command          | Parameters  | Notes                                      |
+| ---------------- | ----------- | -----------------                          |
+| STRING           | Text string | Print text string                          |
+| STRINGLN         | Text string | Print text string and press enter after it |
+| STRING_FROM_FILE | File path   | Print text contained in a file             |
 
 ## String delay
 


### PR DESCRIPTION
# What's new
A badusb function to take the content of a file and print it.

![image](https://github.com/user-attachments/assets/0796ad80-7d57-47f8-9726-d3f9b5978973)

1. notepad to test badusb script
2. the badusb script
3. content of `/ext/abc.txt`

# Verification 
Here is a sample script to test the function:
```
STRING_FROM_FILE /ext/abc.txt
```
make sure to place a file named `abc.txt` at the root of an sdcard with text inside of it.
# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
