### PR TITLE
CLI: Fix crash with unexpected plugin files

### DIFF
--- a/lib/toolbox/cli/cli_registry.c
+++ b/lib/toolbox/cli/cli_registry.c
@@ -136,9 +136,9 @@ void cli_registry_reload_external_commands(
             FURI_LOG_T(TAG, "Plugin: %s", plugin_filename);
             furi_string_set_str(plugin_name, plugin_filename);
 
-            furi_check(furi_string_end_with_str(plugin_name, ".fal"));
+            if(!furi_string_end_with_str(plugin_name, ".fal")) continue;
             furi_string_replace_all_str(plugin_name, ".fal", "");
-            furi_check(furi_string_start_with_str(plugin_name, config->fal_prefix));
+            if(!furi_string_start_with_str(plugin_name, config->fal_prefix)) continue;
             furi_string_replace_at(plugin_name, 0, strlen(config->fal_prefix), "");
 
             CliRegistryCommand command = {


### PR DESCRIPTION
# What's new

- simply ignores unexpected files in CLI plugins dir instead of crashing
- this is because some CFWs had their own CLI plugin system before with a different naming scheme, and some of those leftover plugin files caused people moving from CFW to OFW to crash when connecting to qFlipper / lab.flipper.net (sorry about that :sweat_smile:)

# Verification 

- put any file in `/ext/apps_data/cli/plugins/` that does not start with `cli_` or does not end with `.fal`
- flipper should ignore it when plugging into qFlipper / lab.flipper.net instead of crashing

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
