### PR TITLE
VSCode: Reduce file watcher resource usage

### DIFF
--- a/.vscode/example/settings.json.tmpl
+++ b/.vscode/example/settings.json.tmpl
@@ -19,5 +19,13 @@
         "--compile-commands-dir=${workspaceFolder}/build/latest",
         "--clang-tidy",
         "--header-insertion=never"
-    ]
+    ],
+    "files.watcherExclude": {
+        "**/.git/objects/**": true,
+        "**/.git/**/modules/**/objects/**": true,
+        "**/.git/**/subtree-cache/**": true,
+        "**/.git/**/rr-cache/**": true,
+        "build/**": true,
+        "toolchain/**": true
+    }
 }


### PR DESCRIPTION
# What's new

- For some reason VSCode still does not use gitignore to limit what files are watched for updates after 7 years, see Microsoft/vscode#62725
- Thus, many thousands of files are registered with the kernel to be watched for no reason at all, including every single commit object every created in any submodule and the repo itself
- This either causes a warning that not all files can be watched for updates on Linux, or if bypassed with a higher limit it causes high cpu usage at vscode startup to register all these useless files and higher memory usage thereafter
- This solution still watches git branches and logs to react to commits made outside vscode, and all source code files as expected, but ignored unnecessarily files that do not need to be watched for changes

# Verification 

- [ Describe how to verify changes ]

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
