### PR TITLE
github: fail submit_sdk on catalog api error

### DIFF
--- a/.github/actions/submit_sdk/action.yml
+++ b/.github/actions/submit_sdk/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: Submit SDK
       shell: bash
       run: |
-        curl -sX 'GET' \
+        curl --fail -sX 'GET' \
           '${{ inputs.catalog-url }}/api/v0/0/sdk?length=500' \
           -H 'Accept: application/json' > sdk_versions.json
         if jq -r -e ".[] | select((.api == \"${{ inputs.firmware-api }}\") and .target == \"${{ inputs.firmware-target }}\")" sdk_versions.json > found_sdk.json ; then
@@ -61,7 +61,7 @@ runs:
           if ! echo "${{ inputs.firmware-version }}" | grep -q -- "-rc" ; then
             SDK_ID=$(jq -r ._id found_sdk.json)
             echo "Marking SDK $SDK_ID as released"
-            curl -X 'POST' \
+            curl --fail-with-body -X 'POST' \
               "${{ inputs.catalog-url }}/api/v0/0/sdk/${SDK_ID}/release" \
               -H 'Accept: application/json' \
               -H 'Authorization: Bearer ${{ inputs.catalog-api-token }}' \
@@ -69,7 +69,7 @@ runs:
           fi
         else
           echo "API version ${{ inputs.firmware-api }} doesn't exist in catalog, adding"
-          curl -X 'POST' \
+          curl --fail-with-body -X 'POST' \
             '${{ inputs.catalog-url }}/api/v0/0/sdk' \
             -H 'Accept: application/json' \
             -H 'Authorization: Bearer ${{ inputs.catalog-api-token }}' \


### PR DESCRIPTION
# What's new

- Fail SDK submit job when catalog API raises an error

# Verification 

- [ Describe how to verify changes ]

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
