### PR TITLE
Fix display_led_lock logic

### DIFF
--- a/applications/services/notification/notification_app.c
+++ b/applications/services/notification/notification_app.c
@@ -227,24 +227,19 @@ static void notification_process_notification_message(
             }
             break;
         case NotificationMessageTypeLedDisplayBacklightEnforceOn:
-            furi_check(app->display_led_lock < UINT8_MAX);
-            app->display_led_lock++;
-            if(app->display_led_lock == 1) {
+            if(!app->display_led_lock) {
+                app->display_led_lock = true;
                 notification_apply_internal_led_layer(
                     &app->display,
                     notification_message->data.led.value * display_brightness_setting);
             }
             break;
         case NotificationMessageTypeLedDisplayBacklightEnforceAuto:
-            if(app->display_led_lock > 0) {
-                app->display_led_lock--;
-                if(app->display_led_lock == 0) {
-                    notification_apply_internal_led_layer(
-                        &app->display,
-                        notification_message->data.led.value * display_brightness_setting);
-                }
-            } else {
-                FURI_LOG_E(TAG, "Incorrect BacklightEnforce use");
+            if(app->display_led_lock) {
+                app->display_led_lock = false;
+                notification_apply_internal_led_layer(
+                    &app->display,
+                    notification_message->data.led.value * display_brightness_setting);
             }
             break;
         case NotificationMessageTypeLedRed:

--- a/applications/services/notification/notification_app.h
+++ b/applications/services/notification/notification_app.h
@@ -53,7 +53,7 @@ struct NotificationApp {
 
     NotificationLedLayer display;
     NotificationLedLayer led[NOTIFICATION_LED_COUNT];
-    uint8_t display_led_lock;
+    bool display_led_lock;
 
     NotificationSettings settings;
 };


### PR DESCRIPTION
# What's new

- Make `display_led_lock` to bool instead of uint8 and remake logic to be simple
- Fix issue when enforceon event was called multiple times and enforce auto will be required to called same amount of times, while there's just one exec of internal layer func, both in enforce on and enforce auto
- Thanks @Dmitry422 for info about the issue

# Verification 

- Display enforce events should work correctly

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
