### PR TITLE
 Felica standard loading fix

### DIFF
--- a/lib/nfc/protocols/felica/felica.c
+++ b/lib/nfc/protocols/felica/felica.c
@@ -157,6 +157,8 @@ bool felica_load(FelicaData* data, FlipperFormat* ff, uint32_t version) {
     case FelicaStandard:
         uint32_t systems_total = 0;
         if(!flipper_format_read_uint32(ff, "System found", &systems_total, 1)) break;
+        if(systems_total == 0) break;
+
         simple_array_init(data->systems, systems_total);
 
         for(uint8_t sys_idx = 0; sys_idx < systems_total; sys_idx++) {
@@ -181,6 +183,8 @@ bool felica_load(FelicaData* data, FlipperFormat* ff, uint32_t version) {
             do {
                 uint32_t area_count = 0;
                 if(!flipper_format_read_uint32(ff, "Area found", &area_count, 1)) break;
+                if(area_count == 0) break;
+
                 simple_array_init(system->areas, area_count);
 
                 furi_string_reset(str_key_buffer);
@@ -207,6 +211,8 @@ bool felica_load(FelicaData* data, FlipperFormat* ff, uint32_t version) {
             do {
                 uint32_t service_count = 0;
                 if(!flipper_format_read_uint32(ff, "Service found", &service_count, 1)) break;
+                if(service_count == 0) break;
+
                 simple_array_init(system->services, service_count);
 
                 furi_string_reset(str_key_buffer);
@@ -237,6 +243,8 @@ bool felica_load(FelicaData* data, FlipperFormat* ff, uint32_t version) {
                 uint32_t public_block_count = 0;
                 if(!flipper_format_read_uint32(ff, "Public blocks read", &public_block_count, 1))
                     break;
+                if(public_block_count == 0) break;
+
                 simple_array_init(system->public_blocks, public_block_count);
                 for(uint16_t i = 0; i < public_block_count; i++) {
                     furi_string_printf(str_key_buffer, "Block %04X", i);


### PR DESCRIPTION
# What's new

- Fix Felica standard loading when reading 0 from nfc file

# Verification 

- Use empty felica standard card with 0 services on it
- Read and save this card
- Try to open nfc file. Previously this would result to `furi_check` in `simple_array_init` and crash
- Now it wouldn't crash

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
