### PR TITLE
feat: accept `const` pointer in `furi_hal_rtc_set_datetime`

### DIFF
--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,87.1,,
+Version,v,87.2,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
@@ -1638,7 +1638,7 @@ Function,+,furi_hal_rtc_reset_registers,void,
 Function,-,furi_hal_rtc_set_alarm,void,"const DateTime*, _Bool"
 Function,-,furi_hal_rtc_set_alarm_callback,void,"FuriHalRtcAlarmCallback, void*"
 Function,+,furi_hal_rtc_set_boot_mode,void,FuriHalRtcBootMode
-Function,+,furi_hal_rtc_set_datetime,void,DateTime*
+Function,?,furi_hal_rtc_set_datetime,void,const DateTime*
 Function,+,furi_hal_rtc_set_fault_data,void,uint32_t
 Function,+,furi_hal_rtc_set_flag,void,FuriHalRtcFlag
 Function,+,furi_hal_rtc_set_heap_track_mode,void,FuriHalRtcHeapTrackMode

--- a/targets/f7/furi_hal/furi_hal_rtc.c
+++ b/targets/f7/furi_hal/furi_hal_rtc.c
@@ -392,7 +392,7 @@ FuriHalRtcLocaleDateFormat furi_hal_rtc_get_locale_dateformat(void) {
     return data->locale_dateformat;
 }
 
-void furi_hal_rtc_set_datetime(DateTime* datetime) {
+void furi_hal_rtc_set_datetime(const DateTime* datetime) {
     furi_check(!FURI_IS_IRQ_MODE());
     furi_check(datetime);
 

--- a/targets/f7/furi_hal/furi_hal_rtc.h
+++ b/targets/f7/furi_hal/furi_hal_rtc.h
@@ -247,7 +247,7 @@ FuriHalRtcLocaleDateFormat furi_hal_rtc_get_locale_dateformat(void);
  *
  * @param      datetime  The date time to set
  */
-void furi_hal_rtc_set_datetime(DateTime* datetime);
+void furi_hal_rtc_set_datetime(const DateTime* datetime);
 
 /** Get RTC Date Time
  *


### PR DESCRIPTION
# What's new

- `furi_hal_rtc_set_datetime` now accepts `const` pointer to `DateTime` since it only reads from it

# Verification 

- Ensure that the API still builds (since strictly more clients are now allowed and the ABI is not affected).

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
