### PR TITLE
SubGhz: Add Security+2.0 433.92 MHz

### DIFF
--- a/applications/main/subghz/helpers/subghz_custom_event.h
+++ b/applications/main/subghz/helpers/subghz_custom_event.h
@@ -22,6 +22,7 @@ typedef enum {
     SubmenuIndexSecPlus_v2_310_00,
     SubmenuIndexSecPlus_v2_315_00,
     SubmenuIndexSecPlus_v2_390_00,
+    SubmenuIndexSecPlus_v2_433_92,
 
     //SubGhzCustomEvent
     SubGhzCustomEventSceneDeleteSuccess = 100,

--- a/applications/main/subghz/scenes/subghz_scene_set_type.c
+++ b/applications/main/subghz/scenes/subghz_scene_set_type.c
@@ -109,6 +109,12 @@ void subghz_scene_set_type_on_enter(void* context) {
         SubmenuIndexSecPlus_v2_390_00,
         subghz_scene_set_type_submenu_callback,
         subghz);
+    submenu_add_item(
+        subghz->submenu,
+        "Security+2.0_433",
+        SubmenuIndexSecPlus_v2_433_92,
+        subghz_scene_set_type_submenu_callback,
+        subghz);
 
     submenu_set_selected_item(
         subghz->submenu, scene_manager_get_scene_state(subghz->scene_manager, SubGhzSceneSetType));
@@ -211,6 +217,11 @@ bool subghz_scene_set_type_on_event(void* context, SceneManagerEvent event) {
             key = (key & 0x7FFFF3FC); // 850LM pairing
             generated_protocol = subghz_txrx_gen_secplus_v2_protocol(
                 subghz->txrx, "AM650", 390000000, key, 0x68, 0xE500000);
+            break;
+        case SubmenuIndexSecPlus_v2_433_92:
+            key = (key & 0x7FFFF3FC); // 850LM pairing
+            generated_protocol = subghz_txrx_gen_secplus_v2_protocol(
+                subghz->txrx, "AM650", 433920000, key, 0x68, 0xE500000);
             break;
         default:
             return false;


### PR DESCRIPTION
This is used by several Merlin (Chamberlain) garage door openers in Australia.

# What's new

- SubGhz: Add 433.92 MHz frequency profile for Security+2.0

# Verification 

- Tested with Merlin (Chamberlain) MT100EVO garage door opener

<img width="1447" height="1146" alt="image" src="https://github.com/user-attachments/assets/826a1c45-a459-4318-8d33-3d4c80d9ae0d" />

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
