### PR TITLE
ISSUE-4332: Fix boot-path stack overflow risk and reduce update stack footprint

### DIFF
--- a/targets/f7/src/update.c
+++ b/targets/f7/src/update.c
@@ -15,13 +15,6 @@
 
 static FATFS* pfs = NULL;
 
-#define CHECK_FRESULT(result)   \
-    {                           \
-        if((result) != FR_OK) { \
-            return 0;           \
-        }                       \
-    }
-
 static bool flipper_update_mount_sd(void) {
     for(int i = 0; i < furi_hal_sd_max_mount_retry_count(); ++i) {
         if(furi_hal_sd_init((i % 2) == 0) != FuriStatusOk) {
@@ -60,31 +53,43 @@ static bool flipper_update_init(void) {
     return flipper_update_mount_sd();
 }
 
+/**
+ * Load and verify boot loader stage from manifest
+ * 
+ * FatFS structures (FIL, FILINFO) are heap-allocated to keep this frame off
+ * the boot stack: -fstack-usage measured 928 bytes for the stack-allocated
+ * version. See issue #4332 for stack overflow analysis.
+ */
 static bool flipper_update_load_stage(const FuriString* work_dir, UpdateManifest* manifest) {
-    FIL file;
-    FILINFO stat;
+    /* NB: furi malloc never returns NULL - it furi_checks on OOM
+     * (see memmgr_heap.c), so allocations here are not NULL-checked,
+     * matching the rest of the codebase. */
+    FIL* file = (FIL*)malloc(sizeof(FIL)); // 600 bytes - MUST be heap-allocated
+    FILINFO* stat = (FILINFO*)malloc(sizeof(FILINFO)); // 288 bytes (LFN fname[256] dominates)
 
     FuriString* loader_img_path;
     loader_img_path = furi_string_alloc_set(work_dir);
     path_append(loader_img_path, furi_string_get_cstr(manifest->staged_loader_file));
 
-    if((f_stat(furi_string_get_cstr(loader_img_path), &stat) != FR_OK) ||
-       (f_open(&file, furi_string_get_cstr(loader_img_path), FA_OPEN_EXISTING | FA_READ) !=
+    if((f_stat(furi_string_get_cstr(loader_img_path), stat) != FR_OK) ||
+       (f_open(file, furi_string_get_cstr(loader_img_path), FA_OPEN_EXISTING | FA_READ) !=
         FR_OK) ||
-       (stat.fsize == 0)) {
+       (stat->fsize == 0)) {
         furi_string_free(loader_img_path);
+        free(file);
+        free(stat);
         return false;
     }
     furi_string_free(loader_img_path);
 
-    void* img = malloc(stat.fsize);
+    void* img = malloc(stat->fsize);
     uint32_t read_total = 0;
     uint16_t read_current = 0;
     const uint16_t MAX_READ = 0xFFFF;
 
     uint32_t crc = 0;
     do {
-        if(f_read(&file, img + read_total, MAX_READ, &read_current) != FR_OK) { //-V769
+        if(f_read(file, img + read_total, MAX_READ, &read_current) != FR_OK) { //-V769
             break;
         }
         crc = crc32_calc_buffer(crc, img + read_total, read_current);
@@ -92,7 +97,7 @@ static bool flipper_update_load_stage(const FuriString* work_dir, UpdateManifest
     } while(read_current == MAX_READ);
 
     do {
-        if((read_total != stat.fsize) || (crc != manifest->staged_loader_crc)) {
+        if((read_total != stat->fsize) || (crc != manifest->staged_loader_crc)) {
             break;
         }
 
@@ -107,7 +112,7 @@ static bool flipper_update_load_stage(const FuriString* work_dir, UpdateManifest
          */
         __disable_irq();
 
-        memmove((void*)(SRAM1_BASE), img, stat.fsize);
+        memmove((void*)(SRAM1_BASE), img, stat->fsize);
         LL_SYSCFG_SetRemapMemory(LL_SYSCFG_REMAP_SRAM);
         furi_hal_switch(0x0);
         return true;
@@ -115,68 +120,100 @@ static bool flipper_update_load_stage(const FuriString* work_dir, UpdateManifest
     } while(false);
 
     free(img);
+    free(file);
+    free(stat);
     return false;
 }
 
+/**
+ * Read manifest path from SD card boot pointer file
+ * 
+ * FatFS structures and path buffer are heap-allocated: -fstack-usage measured
+ * 1160 bytes for the stack-allocated version - by itself exceeding the
+ * original 1024-byte main stack. This was the deepest frame in the boot
+ * update path. See issue #4332.
+ */
 static bool flipper_update_get_manifest_path(FuriString* out_path) {
-    FIL file;
-    FILINFO stat;
+    FIL* file = (FIL*)malloc(sizeof(FIL)); // 600 bytes
+    FILINFO* stat = (FILINFO*)malloc(sizeof(FILINFO)); // 288 bytes (LFN fname[256] dominates)
+    char* manifest_name_buf = (char*)malloc(UPDATE_OPERATION_MAX_MANIFEST_PATH_LEN); // 255 bytes
     uint16_t size_read = 0;
-    char manifest_name_buf[UPDATE_OPERATION_MAX_MANIFEST_PATH_LEN] = {0};
 
+    memset(manifest_name_buf, 0, UPDATE_OPERATION_MAX_MANIFEST_PATH_LEN);
     furi_string_reset(out_path);
-    CHECK_FRESULT(f_stat(UPDATE_POINTER_FILE_PATH, &stat));
-    CHECK_FRESULT(f_open(&file, UPDATE_POINTER_FILE_PATH, FA_OPEN_EXISTING | FA_READ));
-    do {
-        if(f_read(&file, manifest_name_buf, UPDATE_OPERATION_MAX_MANIFEST_PATH_LEN, &size_read) !=
-           FR_OK) {
-            break;
-        }
 
-        if((size_read == 0) || (size_read == UPDATE_OPERATION_MAX_MANIFEST_PATH_LEN)) {
-            break;
-        }
-        furi_string_set(out_path, manifest_name_buf);
-        furi_string_right(out_path, strlen(STORAGE_EXT_PATH_PREFIX));
-    } while(0);
-    f_close(&file);
+    /* f_close only when f_open succeeded; short-circuit skips it on f_stat failure.
+     * All heap buffers are freed on every path (the structs now outlive the stack
+     * frame, so an early return would leak them). */
+    if((f_stat(UPDATE_POINTER_FILE_PATH, stat) == FR_OK) &&
+       (f_open(file, UPDATE_POINTER_FILE_PATH, FA_OPEN_EXISTING | FA_READ) == FR_OK)) {
+        do {
+            if(f_read(
+                   file, manifest_name_buf, UPDATE_OPERATION_MAX_MANIFEST_PATH_LEN, &size_read) !=
+               FR_OK) {
+                break;
+            }
+
+            if((size_read == 0) || (size_read == UPDATE_OPERATION_MAX_MANIFEST_PATH_LEN)) {
+                break;
+            }
+            furi_string_set(out_path, manifest_name_buf);
+            furi_string_right(out_path, strlen(STORAGE_EXT_PATH_PREFIX));
+        } while(0);
+        f_close(file);
+    }
+
+    free(file);
+    free(stat);
+    free(manifest_name_buf);
     return !furi_string_empty(out_path);
 }
 
+/**
+ * Parse and validate firmware update manifest
+ * 
+ * FatFS structures are heap-allocated: -fstack-usage measured 920 bytes for
+ * the stack-allocated version. With all three helpers heap-based, the whole
+ * update path inlines into flipper_boot_update_exec at 56 bytes of stack.
+ * See issue #4332.
+ */
 static UpdateManifest* flipper_update_process_manifest(const FuriString* manifest_path) {
-    FIL file;
-    FILINFO stat;
-
-    CHECK_FRESULT(f_stat(furi_string_get_cstr(manifest_path), &stat));
-    CHECK_FRESULT(f_open(&file, furi_string_get_cstr(manifest_path), FA_OPEN_EXISTING | FA_READ));
-
-    uint8_t* manifest_data = malloc(stat.fsize);
-    uint32_t bytes_read = 0;
-    const uint16_t MAX_READ = 0xFFFF;
-
-    do {
-        uint16_t size_read = 0;
-        if(f_read(&file, manifest_data + bytes_read, MAX_READ, &size_read) != FR_OK) { //-V769
-            break;
-        }
-        bytes_read += size_read;
-    } while(bytes_read == MAX_READ);
+    FIL* file = (FIL*)malloc(sizeof(FIL)); // 600 bytes
+    FILINFO* stat = (FILINFO*)malloc(sizeof(FILINFO)); // 288 bytes (LFN fname[256] dominates)
 
     UpdateManifest* manifest = NULL;
-    do {
-        if(bytes_read != stat.fsize) {
-            break;
-        }
 
-        manifest = update_manifest_alloc();
-        if(!update_manifest_init_mem(manifest, manifest_data, bytes_read)) {
-            update_manifest_free(manifest);
-            manifest = NULL;
-        }
-    } while(false);
+    /* f_close only when f_open succeeded; short-circuit skips it on f_stat failure.
+     * file/stat are freed on every path (they now outlive the stack frame, so an
+     * early return would leak them). */
+    if((f_stat(furi_string_get_cstr(manifest_path), stat) == FR_OK) &&
+       (stat->fsize != 0) && /* malloc(0) triggers furi_check; empty manifest is invalid anyway */
+       (f_open(file, furi_string_get_cstr(manifest_path), FA_OPEN_EXISTING | FA_READ) == FR_OK)) {
+        uint8_t* manifest_data = malloc(stat->fsize);
+        uint32_t bytes_read = 0;
+        const uint16_t MAX_READ = 0xFFFF;
 
-    f_close(&file);
-    free(manifest_data);
+        do {
+            uint16_t size_read = 0;
+            if(f_read(file, manifest_data + bytes_read, MAX_READ, &size_read) != FR_OK) { //-V769
+                break;
+            }
+            bytes_read += size_read;
+        } while(bytes_read == MAX_READ);
+
+        if(bytes_read == stat->fsize) {
+            manifest = update_manifest_alloc();
+            if(!update_manifest_init_mem(manifest, manifest_data, bytes_read)) {
+                update_manifest_free(manifest);
+                manifest = NULL;
+            }
+        }
+        free(manifest_data);
+        f_close(file);
+    }
+
+    free(file);
+    free(stat);
     return manifest;
 }
 

--- a/targets/f7/stm32wb55xx_flash.ld
+++ b/targets/f7/stm32wb55xx_flash.ld
@@ -3,7 +3,7 @@ ENTRY(Reset_Handler)
 /* Highest address of the user mode stack */
 _stack_end = 0x20030000;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
-_stack_size = 0x400; /* required amount of stack */
+_stack_size = 0x800; /* required amount of stack */
 
 MEMORY {
     FLASH (rx)  : ORIGIN = 0x08000000, LENGTH = 1024K

--- a/targets/f7/stm32wb55xx_ram_fw.ld
+++ b/targets/f7/stm32wb55xx_ram_fw.ld
@@ -3,7 +3,7 @@ ENTRY(Reset_Handler)
 /* Highest address of the user mode stack */
 _stack_end = 0x20030000;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
-_stack_size = 0x400; /* required amount of stack */
+_stack_size = 0x800; /* required amount of stack */
 
 MEMORY {
     FLASH (rx)  : ORIGIN = 0x08000000, LENGTH = 1024K


### PR DESCRIPTION
## Summary
Resolves the boot-path stack overflow in issue #4332. The core fix is the **heap refactor**: the update path's FatFS structures (`FIL`, `FILINFO`, and the manifest path buffer) were large stack locals; moving them to the heap removes the overflow at its root. A main-thread stack increase (`0x400`→`0x800`) is kept as defense-in-depth.

Validated on real hardware — see **Validation Performed**.

## Problem
The boot update path (`flipper_boot_update_exec`, entered on `FuriHalRtcBootModeUpdate`) runs on the 1024-byte main-thread stack. Measured `-fstack-usage` frames for the three helper functions (stack-allocated, `-Os`, cortex-m4):

| Function | Own frame |
|---|---|
| `flipper_update_get_manifest_path` | 1160 B |
| `flipper_update_load_stage` | 928 B |
| `flipper_update_process_manifest` | 920 B |

The helpers are called sequentially from `flipper_boot_update_exec`, so peak stack was ~1184 B of the path's own frames — already over the 1024 B stack **before** the FatFS callees (`f_open`/`f_read`/`f_stat`) push it deeper. `sizeof(FIL)` = 600 B and `sizeof(FILINFO)` = 288 B on this target (`_MAX_SS=512`, `_FS_TINY=0`) dominate those frames.

## What Changed

### 1) Heap refactor — the root-cause fix (`update.c`)
Moves the large FatFS structures off the stack. With all three helpers heap-based, the optimizer inlines the whole path into `flipper_boot_update_exec` at **56 bytes** of stack (measured) — a ~1100 B reduction that fits under even the original 1024 B stack.

On the boot-path heap dependency raised in review:
- This path **already** depended on the heap before this PR (`pfs`, `img`, `manifest_data` were already `malloc`-ed), so the refactor crosses no new line.
- furi `malloc` never returns `NULL` — it `furi_check`s on OOM (`memmgr_heap.c`). NULL-checks after `malloc` are therefore dead code. This PR **removes** the dead checks (matching the rest of the tree) and instead guards the real latent hazard — `malloc(0)`, which is also a `furi_check` and is reachable from a zero-length manifest.
- Removes the `CHECK_FRESULT` macro, whose bare early-`return` leaked the now-heap-allocated structs; both helpers use single-exit cleanup.

### 2) Main-thread stack increase — defense-in-depth (linker scripts)
`_stack_size` `0x400`→`0x800` in `stm32wb55xx_flash.ld` and `stm32wb55xx_ram_fw.ld`. Not strictly required once the refactor lands (the path fits in 56 B), but 1 KB of SRAM is negligible on the STM32WB55 and leaves headroom for the FatFS callee frames and future growth.

## Addressing the review
- **Are both fixes needed, or is one belt-and-braces?** Either resolves the overflow alone. The heap refactor is the real fix (it removes the 1000+ B frames); the stack bump is intentional defense-in-depth. Kept both by design.
- **`img`/`manifest_data` not checked for allocation failure.** furi `malloc` cannot return `NULL` (it `furi_check`s on OOM), so `if(!img)`/`if(!manifest_data)` would be dead code. The actual hazard on those lines is `malloc(0)`, now guarded (`load_stage` was already covered by its `fsize == 0` early return; `process_manifest` gains an explicit `stat->fsize != 0` guard).

## Validation Performed
On-device, two full `flash_usb_full` self-update cycles on real hardware (STM32WB55):
- **Cycle 1** installed this build (the *prior* firmware's boot code performed the install).
- **Cycle 2** — with this build now running, **this PR's modified `flipper_boot_update_exec` performed the update**. It completed a full firmware + radio + resources update and rebooted healthy. Confirmed via the update pointer file `/ext/.fupdate` being disarmed (removed only on successful completion), no stored fault data, and stable heap across samples.
- Static: measured `-fstack-usage` numbers above (1160 / 928 / 920 B → 56 B).
- Full `f7` firmware + updater build green via `fbt`.

## Risk / Impact
- SRAM impact from the stack increase is negligible relative to STM32WB55 capacity.
- The refactor adds no new failure surface (the path was already heap-dependent; `malloc` can't return `NULL`), and removes a latent `malloc(0)` crash and an early-return leak.
- Net effect: a safer boot update path with the stack frames reduced from ~1184 B to 56 B.

## Related Issue
- Fixes #4332

---

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
