### PR TITLE
ISSUE-4281: Add ECDH source to static library build

### DIFF
--- a/lib/mbedtls.scons
+++ b/lib/mbedtls.scons
@@ -41,6 +41,7 @@ sources = [
     File("mbedtls/library/aes.c"),
     File("mbedtls/library/bignum.c"),
     File("mbedtls/library/bignum_core.c"),
+    File("mbedtls/library/ecdh.c"),
     File("mbedtls/library/ecdsa.c"),
     File("mbedtls/library/ecp.c"),
     File("mbedtls/library/ecp_curves.c"),


### PR DESCRIPTION
# Summary:

This PR enables mbedTLS ECDH at link time by compiling the ECDH implementation into the static library.
`MBEDTLS_ECDH_C` and the SDK header are already present, but `ecdh.c` was not included in the build sources.  This resolves ISSUE #4281.

# What Changed?:

- Added mbedtls/library/ecdh.c to the mbedTLS source list in [mbedtls.scons](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

# Validation:

- Ran `./fbt firmware_all` successfully.
- Build log includes `CC lib/mbedtls/library/ecdh.c`.
- Firmware link and package steps complete successfully.