### PR TITLE
ISSUE-4336: EventLoop receives callbacks one event late when setting FuriEventFlag from interrupts

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -90,6 +90,22 @@ Make sure your Flipper is on, and your firmware is functioning. Connect your Fli
 ./fbt flash_usb
 ```
 
+## Running unit tests
+
+Unit tests run on the device. Build firmware with tests enabled, flash it (and copy resources from `build/latest/resources` to the SD card), then in a CLI session run:
+
+```shell
+unit_tests
+```
+
+To run only the Furi tests (e.g. after changing event loop or event flag code):
+
+```shell
+unit_tests test_furi
+```
+
+See [Unit Tests](/documentation/UnitTests.md) for details and how to add tests.
+
 ## Documentation
 
 - [Flipper Build Tool](/documentation/fbt.md) - building, flashing, and debugging Flipper software

--- a/applications/debug/unit_tests/tests/furi/furi_event_loop_test.c
+++ b/applications/debug/unit_tests/tests/furi/furi_event_loop_test.c
@@ -495,6 +495,109 @@ void test_furi_event_loop_self_unsubscribe(void) {
     furi_event_loop_free(event_loop);
 }
 
+/*
+ * Regression test for issue #4336: event loop must receive the correct flag
+ * value when furi_event_flag_set() is called from ISR (no one-event delay).
+ * Uses a software-pending LPTIM2 interrupt to run the ISR path.
+ */
+#define EVENT_FLAG_ISR_TEST_BITS 3U
+#define EVENT_FLAG_ISR_TEST_MASK ((1U << EVENT_FLAG_ISR_TEST_BITS) - 1U)
+
+typedef struct {
+    FuriEventFlag* flag;
+    uint32_t bits_to_set;
+} EventFlagIsrTestIsrContext;
+
+typedef struct {
+    FuriEventFlag* flag;
+    FuriEventLoop* loop;
+    FuriSemaphore* ready;
+    FuriSemaphore* sync;
+    uint32_t bits_received;
+} EventFlagIsrTestContext;
+
+static void event_flag_isr_test_isr(void* context) {
+    EventFlagIsrTestIsrContext* ctx = context;
+    furi_event_flag_set(ctx->flag, ctx->bits_to_set);
+}
+
+static void event_flag_isr_test_callback(FuriEventLoopObject* object, void* context) {
+    EventFlagIsrTestContext* ctx = context;
+    ctx->bits_received =
+        furi_event_flag_wait((FuriEventFlag*)object, EVENT_FLAG_ISR_TEST_MASK, FuriFlagWaitAny, 0);
+    furi_semaphore_release(ctx->sync);
+}
+
+// The event loop is owned by this thread: every FuriEventLoop call except
+// furi_event_loop_stop() must run on the thread the loop was created in.
+static int32_t event_flag_isr_test_loop_thread(void* arg) {
+    EventFlagIsrTestContext* ctx = arg;
+
+    ctx->loop = furi_event_loop_alloc();
+    furi_event_loop_subscribe_event_flag(
+        ctx->loop, ctx->flag, FuriEventLoopEventIn, event_flag_isr_test_callback, ctx);
+
+    furi_semaphore_release(ctx->ready);
+    furi_event_loop_run(ctx->loop);
+
+    furi_event_loop_unsubscribe(ctx->loop, ctx->flag);
+    furi_event_loop_free(ctx->loop);
+
+    return 0;
+}
+
+void test_furi_event_loop_event_flag_from_isr(void) {
+    EventFlagIsrTestContext ctx = {
+        .flag = furi_event_flag_alloc(),
+        .loop = NULL,
+        .ready = furi_semaphore_alloc(1, 0),
+        .sync = furi_semaphore_alloc(1, 0),
+        .bits_received = 0,
+    };
+    EventFlagIsrTestIsrContext isr_ctx = {.flag = ctx.flag, .bits_to_set = 0};
+
+    FuriThread* loop_thread =
+        furi_thread_alloc_ex("event_flag_isr_loop", 1024, event_flag_isr_test_loop_thread, &ctx);
+    furi_thread_start(loop_thread);
+
+    // Only trigger the interrupt once the loop thread is subscribed, otherwise
+    // the flag would be set before anything is listening for it.
+    furi_check(furi_semaphore_acquire(ctx.ready, furi_ms_to_ticks(1000)) == FuriStatusOk);
+
+    furi_hal_interrupt_set_isr(FuriHalInterruptIdLpTim2, event_flag_isr_test_isr, &isr_ctx);
+
+    const uint32_t test_bits[] = {1U, 2U, 4U};
+    uint32_t bits_received[3] = {0};
+    bool timed_out = false;
+
+    for(size_t i = 0; i < sizeof(test_bits) / sizeof(test_bits[0]); i++) {
+        isr_ctx.bits_to_set = test_bits[i];
+        furi_hal_interrupt_trigger_pending(FuriHalInterruptIdLpTim2);
+
+        if(furi_semaphore_acquire(ctx.sync, furi_ms_to_ticks(500)) != FuriStatusOk) {
+            timed_out = true;
+            break;
+        }
+        bits_received[i] = ctx.bits_received;
+    }
+
+    // Tear down before asserting so a failure cannot leave the ISR registered
+    // against this function's stack.
+    furi_hal_interrupt_set_isr(FuriHalInterruptIdLpTim2, NULL, NULL);
+    furi_event_loop_stop(ctx.loop);
+    furi_thread_join(loop_thread);
+    furi_thread_free(loop_thread);
+
+    mu_assert(!timed_out, "timeout waiting for event flag callback");
+    for(size_t i = 0; i < sizeof(test_bits) / sizeof(test_bits[0]); i++) {
+        mu_assert_int_eq(bits_received[i], test_bits[i]);
+    }
+
+    furi_semaphore_free(ctx.sync);
+    furi_semaphore_free(ctx.ready);
+    furi_event_flag_free(ctx.flag);
+}
+
 void test_furi_event_loop(void) {
     TestFuriEventLoopData data = {};
 

--- a/applications/debug/unit_tests/tests/furi/furi_test.c
+++ b/applications/debug/unit_tests/tests/furi/furi_test.c
@@ -9,6 +9,7 @@ void test_furi_pubsub(void);
 void test_furi_memmgr(void);
 void test_furi_event_loop(void);
 void test_furi_event_loop_self_unsubscribe(void);
+void test_furi_event_loop_event_flag_from_isr(void);
 void test_errno_saving(void);
 void test_furi_primitives(void);
 void test_stdin(void);
@@ -51,6 +52,10 @@ MU_TEST(mu_test_furi_event_loop_self_unsubscribe) {
     test_furi_event_loop_self_unsubscribe();
 }
 
+MU_TEST(mu_test_furi_event_loop_event_flag_from_isr) {
+    test_furi_event_loop_event_flag_from_isr();
+}
+
 MU_TEST(mu_test_errno_saving) {
     test_errno_saving();
 }
@@ -74,6 +79,7 @@ MU_TEST_SUITE(test_suite) {
     MU_RUN_TEST(mu_test_furi_memmgr);
     MU_RUN_TEST(mu_test_furi_event_loop);
     MU_RUN_TEST(mu_test_furi_event_loop_self_unsubscribe);
+    MU_RUN_TEST(mu_test_furi_event_loop_event_flag_from_isr);
     MU_RUN_TEST(mu_test_stdio);
     MU_RUN_TEST(mu_test_errno_saving);
     MU_RUN_TEST(mu_test_furi_primitives);

--- a/applications/debug/unit_tests/unit_test_api_table_i.h
+++ b/applications/debug/unit_tests/unit_test_api_table_i.h
@@ -4,6 +4,7 @@
 #include <FreeRTOS.h>
 #include <FreeRTOS-Kernel/include/queue.h>
 #include <task.h>
+#include <furi_hal_interrupt.h>
 
 #include <rpc/rpc_i.h>
 #include <flipper.pb.h>
@@ -25,6 +26,7 @@ static constexpr auto unit_tests_api_table = sort(create_array_t<sym_entry>(
         BaseType_t,
         (TaskHandle_t, UBaseType_t, uint32_t, eNotifyAction, uint32_t*)),
     API_METHOD(xTaskGetCurrentTaskHandle, TaskHandle_t, ()),
+    API_METHOD(furi_hal_interrupt_trigger_pending, void, (FuriHalInterruptId)),
     API_METHOD(vQueueDelete, void, (QueueHandle_t)),
     API_METHOD(
         xQueueGenericCreateStatic,

--- a/documentation/FuriHalInterrupt.md
+++ b/documentation/FuriHalInterrupt.md
@@ -1,0 +1,33 @@
+# Furi HAL Interrupt API {#furi_hal_interrupt}
+
+The interrupt HAL provides a unified way to register and control interrupt service routines (ISRs) for various on-chip peripherals. It is used by the system and by apps that need timer, DMA, UART, or other hardware interrupts.
+
+**Header:** `furi_hal_interrupt.h` (target-specific, e.g. `targets/f7/furi_hal/furi_hal_interrupt.h`)
+
+## Initialization
+
+The interrupt subsystem must be initialized before use. The system does this at startup. User code typically only calls `furi_hal_interrupt_set_isr()` or `furi_hal_interrupt_set_isr_ex()` to register a handler.
+
+## Registering an ISR
+
+- **`furi_hal_interrupt_set_isr(index, isr, context)`** — Set the ISR for the given interrupt ID and enable the interrupt with default priority. Pass `NULL` as `isr` to clear and disable.
+- **`furi_hal_interrupt_set_isr_ex(index, priority, isr, context)`** — Same, but with an explicit priority.
+
+**Warning:** Interrupt flags are not cleared automatically. Ensure your peripheral status flags are cleared in the ISR or before enabling, as required by the hardware.
+
+## Interrupt IDs and priorities
+
+Interrupt IDs are defined in **`FuriHalInterruptId`** (e.g. `FuriHalInterruptIdTIM2`, `FuriHalInterruptIdLpTim2`, `FuriHalInterruptIdDma1Ch1`, `FuriHalInterruptIdUart1`). See the enum in the header for the full list.
+
+Priorities are in **`FuriHalInterruptPriority`**. Use one of the levels that allow ISR-safe OS primitives (e.g. `FuriHalInterruptPriorityNormal`) unless you have a reason to use a higher or lower level. The special level `FuriHalInterruptPriorityKamiSama` must not use any OS primitives; see the header and FreeRTOS `configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY` before using it.
+
+## Software-triggered pending interrupt (for tests)
+
+**`furi_hal_interrupt_trigger_pending(index)`** sets the given interrupt as pending so that the CPU will run the currently registered ISR without hardware firing. This is intended for **unit tests** that need to run code in interrupt context (e.g. to test `furi_event_flag_set()` from ISR). Not for use in production application logic.
+
+Example: the Furi event loop regression test uses `FuriHalInterruptIdLpTim2` and `furi_hal_interrupt_trigger_pending()` to trigger the ISR from software and assert that the event loop callback receives the correct flag values.
+
+## Other functions
+
+- **`furi_hal_interrupt_get_name(exception_number)`** — Return the interrupt name for a given exception number (e.g. from IPSR). Useful for debugging.
+- **`furi_hal_interrupt_get_time_in_isr_total()`** — Return total time (CPU clocks) spent in ISRs. Useful for profiling.

--- a/documentation/UnitTests.md
+++ b/documentation/UnitTests.md
@@ -20,6 +20,7 @@ To run the unit tests, follow these steps:
 3. Launch the CLI session and run the `unit_tests` command.
 
 **NOTE:** To run a particular test (and skip all others), specify its name as the command argument.
+For example, `unit_tests test_furi` runs only the Furi core tests.
 Test names match application names defined [here](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/applications/debug/unit_tests/application.fam).
 
 ## Adding unit tests

--- a/documentation/doxygen/system.dox
+++ b/documentation/doxygen/system.dox
@@ -6,6 +6,7 @@ Lower-level aspects of software development for Flipper Zero.
 - @subpage unit_tests — Automated testing, a crucial part of the development process
 - @subpage furi_check — Hard checks for exceptional situations
 - @subpage furi_hal_bus — Access the on-chip peripherals in a safe way
+- @subpage furi_hal_interrupt — Register and control interrupt service routines
 - @subpage furi_hal_debugging — Low-level debugging features
 - @subpage hardware_targets — Support for different hardware platforms
 - @subpage firmware_assets — Various files required for building the firmware

--- a/furi/core/event_flag.c
+++ b/furi/core/event_flag.c
@@ -4,6 +4,8 @@
 
 #include <FreeRTOS.h>
 #include <event_groups.h>
+#include <task.h>
+#include <timers.h>
 
 #include "event_loop_link_i.h"
 
@@ -18,6 +20,28 @@ struct FuriEventFlag {
 
 // IMPORTANT: container MUST be the FIRST struct member
 static_assert(offsetof(FuriEventFlag, container) == 0);
+
+/**
+ * Runs in timer daemon context. Sets the event group bits then notifies the
+ * event loop, so the loop sees the new bits when it runs (fixes ISR one-event-
+ * late delivery: see https://github.com/flipperdevices/flipperzero-firmware/issues/4336).
+ */
+static void
+    furi_event_flag_set_bits_and_notify_callback(void* pvParameter1, uint32_t ulParameter2) {
+    FuriEventFlag* instance = (FuriEventFlag*)pvParameter1;
+    EventBits_t bits = (EventBits_t)ulParameter2;
+
+    /* xEventGroupSetBits() ends in xTaskResumeAll(), which yields to any woken
+     * higher-priority task before returning. That task may free the instance
+     * (FuriApiLock is a FuriEventFlag), so notifying afterwards would touch
+     * freed memory. Suspending the scheduler here makes that inner resume
+     * nest instead of switching context, keeping the instance alive until we
+     * are done with it. */
+    vTaskSuspendAll();
+    (void)xEventGroupSetBits((EventGroupHandle_t)instance, bits);
+    furi_event_loop_link_notify(&instance->event_loop_link, FuriEventLoopEventIn);
+    (void)xTaskResumeAll();
+}
 
 FuriEventFlag* furi_event_flag_alloc(void) {
     furi_check(!FURI_IS_IRQ_MODE());
@@ -51,8 +75,15 @@ uint32_t furi_event_flag_set(FuriEventFlag* instance, uint32_t flags) {
     FURI_CRITICAL_ENTER();
 
     if(FURI_IS_IRQ_MODE()) {
+        /* Defer set + notify to timer daemon so bits are visible when the event
+         * loop runs (xEventGroupSetBitsFromISR defers only the set; we notify
+         * from our pended callback after the set). */
         yield = pdFALSE;
-        if(xEventGroupSetBitsFromISR(hEventGroup, (EventBits_t)flags, &yield) == pdFAIL) {
+        if(xTimerPendFunctionCallFromISR(
+               furi_event_flag_set_bits_and_notify_callback,
+               (void*)instance,
+               (uint32_t)flags,
+               &yield) != pdPASS) {
             rflags = (uint32_t)FuriFlagErrorResource;
         } else {
             rflags = flags;
@@ -60,10 +91,9 @@ uint32_t furi_event_flag_set(FuriEventFlag* instance, uint32_t flags) {
         }
     } else {
         rflags = xEventGroupSetBits(hEventGroup, (EventBits_t)flags);
-    }
-
-    if(rflags & flags) {
-        furi_event_loop_link_notify(&instance->event_loop_link, FuriEventLoopEventIn);
+        if(rflags & flags) {
+            furi_event_loop_link_notify(&instance->event_loop_link, FuriEventLoopEventIn);
+        }
     }
 
     FURI_CRITICAL_EXIT();

--- a/furi/core/event_flag.h
+++ b/furi/core/event_flag.h
@@ -26,6 +26,10 @@ void furi_event_flag_free(FuriEventFlag* instance);
 
 /** Set flags
  *
+ * Safe to call from interrupt context (ISR). When used with FuriEventLoop
+ * (furi_event_loop_subscribe_event_flag), events are delivered with the
+ * correct flag value; there is no one-event delay when setting from ISR.
+ *
  * @warning    result of this function can be flags that you've just asked to
  *             set or not if someone was waiting for them and asked to clear it.
  *             It is highly recommended to read this function and

--- a/furi/core/event_loop.h
+++ b/furi/core/event_loop.h
@@ -214,6 +214,9 @@ typedef struct FuriEventFlag FuriEventFlag;
 
 /** Subscribe to event flag events
  *
+ * Event flags set from interrupt context (furi_event_flag_set from ISR) are
+ * delivered to the callback with the correct flag value; no one-event delay.
+ *
  * @warning you can only have one subscription for one event type.
  *
  * @param      instance       The Event Loop instance
@@ -222,7 +225,6 @@ typedef struct FuriEventFlag FuriEventFlag;
  * @param[in]  callback       The callback to call on event
  * @param      context        The context for callback
  */
-
 void furi_event_loop_subscribe_event_flag(
     FuriEventLoop* instance,
     FuriEventFlag* event_flag,

--- a/targets/f18/api_symbols.csv
+++ b/targets/f18/api_symbols.csv
@@ -1343,6 +1343,7 @@ Function,+,furi_hal_interrupt_get_time_in_isr_total,uint32_t,
 Function,-,furi_hal_interrupt_init,void,
 Function,+,furi_hal_interrupt_set_isr,void,"FuriHalInterruptId, FuriHalInterruptISR, void*"
 Function,+,furi_hal_interrupt_set_isr_ex,void,"FuriHalInterruptId, FuriHalInterruptPriority, FuriHalInterruptISR, void*"
+Function,-,furi_hal_interrupt_trigger_pending,void,FuriHalInterruptId
 Function,+,furi_hal_light_blink_set_color,void,Light
 Function,+,furi_hal_light_blink_start,void,"Light, uint8_t, uint16_t, uint16_t"
 Function,+,furi_hal_light_blink_stop,void,

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1488,6 +1488,7 @@ Function,+,furi_hal_interrupt_get_time_in_isr_total,uint32_t,
 Function,-,furi_hal_interrupt_init,void,
 Function,+,furi_hal_interrupt_set_isr,void,"FuriHalInterruptId, FuriHalInterruptISR, void*"
 Function,+,furi_hal_interrupt_set_isr_ex,void,"FuriHalInterruptId, FuriHalInterruptPriority, FuriHalInterruptISR, void*"
+Function,-,furi_hal_interrupt_trigger_pending,void,FuriHalInterruptId
 Function,+,furi_hal_light_blink_set_color,void,Light
 Function,+,furi_hal_light_blink_start,void,"Light, uint8_t, uint16_t, uint16_t"
 Function,+,furi_hal_light_blink_stop,void,

--- a/targets/f7/furi_hal/furi_hal_interrupt.c
+++ b/targets/f7/furi_hal/furi_hal_interrupt.c
@@ -542,3 +542,8 @@ const char* furi_hal_interrupt_get_name(uint8_t exception_number) {
 uint32_t furi_hal_interrupt_get_time_in_isr_total(void) {
     return furi_hal_interrupt.counter_time_in_isr_total;
 }
+
+void furi_hal_interrupt_trigger_pending(FuriHalInterruptId index) {
+    furi_check(index < FuriHalInterruptIdMax);
+    NVIC_SetPendingIRQ(furi_hal_interrupt_irqn[index]);
+}

--- a/targets/f7/furi_hal/furi_hal_interrupt.h
+++ b/targets/f7/furi_hal/furi_hal_interrupt.h
@@ -127,6 +127,13 @@ const char* furi_hal_interrupt_get_name(uint8_t exception_number);
  */
 uint32_t furi_hal_interrupt_get_time_in_isr_total(void);
 
+/** Trigger interrupt from software (e.g. for unit tests).
+ * Sets the interrupt pending so the CPU will run the registered ISR.
+ *
+ * @param index interrupt ID (e.g. FuriHalInterruptIdLpTim2)
+ */
+void furi_hal_interrupt_trigger_pending(FuriHalInterruptId index);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
# What's New

**Problem (fixes #4336)**

When `furi_event_flag_set()` is called from interrupt context (e.g. a GPIO ISR) and the app subscribes via `furi_event_loop_subscribe_event_flag()`, the event loop sees events **one step late**: the first interrupt often does not trigger the callback at all, and later callbacks observe the **previous** flag value.

**Cause**

FreeRTOS's `xEventGroupSetBitsFromISR()` does not set the bits in the ISR — it is a thin wrapper around `xTimerPendFunctionCallFromISR()` that queues the set for the timer daemon. The old code then called `furi_event_loop_link_notify()` immediately, from the ISR. The event loop thread (priority 16) outranks the timer daemon (priority 2), so it woke **first**, read the flag level while the bits were still unset, found nothing, and dropped the item from its waiting list. The daemon then applied the bits with no further notification, so the event was lost entirely.

**Fix**

Notify only **after** the bits are actually set. The ISR path of `furi_event_flag_set()` now uses `xTimerPendFunctionCallFromISR()` to run a callback in the timer daemon that:

1. calls `xEventGroupSetBits()`
2. then calls `furi_event_loop_link_notify()`

By the time the event loop runs, the bits are set and the callback observes the correct value. The timer command queue is unchanged; if it is full, `FuriFlagErrorResource` is still returned. Task-context behaviour is unchanged.

The pended callback runs with the scheduler suspended (`vTaskSuspendAll()` / `xTaskResumeAll()`). `xEventGroupSetBits()` ends in its own `xTaskResumeAll()`, which would otherwise yield to a woken higher-priority task *before* our notify — and that task may legitimately free the object (`FuriApiLock` is a `FuriEventFlag`), leaving the notify to dereference freed memory. Suspending the scheduler makes the inner resume nest rather than switch context, so the instance stays alive across both calls.

**Scope note:** `furi_event_flag_clear()` has the same pre-existing defect on its ISR path (`xEventGroupClearBitsFromISR()` also only queues the clear, while the `FuriEventLoopEventOut` notify fires synchronously). It is deliberately **not** changed here: no in-tree caller invokes `furi_event_flag_clear()` from ISR context — the only callers are `applications/services/bt/bt_service/bt.c` and `api_lock_relock()` (`lib/toolbox/api_lock.h`), all task context — so its `FURI_IS_IRQ_MODE()` branch is unreachable in practice. Fixing it is a separable change; filed as #4417 and fixed by #4418.

# Regression test

`test_furi_event_loop_event_flag_from_isr()` in `applications/debug/unit_tests/tests/furi/furi_event_loop_test.c` uses a software-pending LPTIM2 interrupt to call `furi_event_flag_set()` from ISR context three times (bits 1, 2, 4) and asserts the event-loop callback receives each value, in order.

The event loop is allocated, subscribed, run, unsubscribed and freed entirely on the thread that owns it: `furi_event_loop_free()`, `_run()`, `_unsubscribe()` and the `subscribe_*` object APIs all assert `instance->thread_id == furi_thread_get_current_id()`. `furi_event_loop_stop()` is the one call the test makes cross-thread, which is safe by construction — it only posts a task notification to the owning thread via `furi_event_loop_notify()`. A semaphore handshake ensures the interrupt only fires once the loop thread has subscribed, and teardown happens before the assertions so a failure cannot leave the ISR registered against a dead stack.

Supporting HAL: `furi_hal_interrupt_trigger_pending(FuriHalInterruptId)` in `targets/f7/furi_hal/furi_hal_interrupt.c` sets an interrupt pending so tests can run code in ISR context.

# API surface

**No change to the public FAP API.** No `+` entry is added, removed or changed in either CSV — the public symbol count is unchanged from `dev` for both targets (`grep -cE '^(Function|Variable),\+,'` gives 2739 for f7 and 1937 for f18, same as `dev`) — and both `targets/f7/api_symbols.csv` and `targets/f18/api_symbols.csv` stay at version **88.0**, in lockstep with `dev`.

`furi_hal_interrupt_trigger_pending` is a test-only helper, so it is marked `-` in both CSVs (following the existing precedent of `furi_hal_interrupt_init` in the same header) and exposed to the `test_furi` plugin through the private `applications/debug/unit_tests/unit_test_api_table_i.h` instead. This avoids a permanent public-API commitment that could only be withdrawn later with a major version bump.

# Verification

Verified on physical hardware (Flipper Zero, `f7`) as an A/B against the same commit, gated on `firmware.commit.dirty` from `info device` to rule out a stale self-update:

| Build | `firmware.commit.dirty` | `unit_tests test_furi` |
|---|---|---|
| With the fix | `false` | **PASSED** |
| `event_flag.c` reverted to pre-fix | `true` | **FAILED** — `timeout waiting for event flag callback` |

The pre-fix run fails on the **first** trigger with a timeout rather than a wrong value, which is the expected signature: the event is lost outright, exactly as described under *Cause* above.

Also verified:

- Full `unit_tests` suite passes on the fixed build (`Failed tests: 0`, `Leaked: 0`) — this exercises the shared `FuriApiLock` path that `event_flag.c` sits under.
- `./fbt TARGET_HW=18 firmware_all` builds clean (f18 is built by CI and shares `furi_hal_interrupt.h`).
- `./fbt FIRMWARE_APP_SET=unit_tests firmware_all` and `... resources` build clean; the `test_furi.fal` plugin links and its imports resolve.
- `API version 88.0 is up to date` — fbt requires no version bump; device reports `firmware.api.major 88` / `firmware.api.minor 0`.

## Reproducing the A/B

```bash
# 1. Fixed build
./fbt FIRMWARE_APP_SET=unit_tests flash_usb_full
#    CLI: info device            -> firmware.commit.dirty : false
#    CLI: unit_tests test_furi   -> Status: PASSED

# 2. Revert just the fix and rebuild
git show c9ab2b68:furi/core/event_flag.c > furi/core/event_flag.c
./fbt FIRMWARE_APP_SET=unit_tests flash_usb_full
#    CLI: info device            -> firmware.commit.dirty : true   <- gate on this
#    CLI: unit_tests test_furi   -> Status: FAILED

git checkout furi/core/event_flag.c
```

`flash_usb_full` (not `flash_usb`) is required: the unit tests load as plugins from `/ext/apps_data/unit_tests/plugins`, and `flash_usb` installs firmware only. The device self-updates and reboots, so wait for it to return to the desktop before running the tests — `firmware.commit.dirty` is what confirms which build is actually running (the commit hash is identical either way, since the revert is uncommitted).

# Documentation

- **`documentation/FuriHalInterrupt.md`** — new HAL interrupt reference (init, set_isr, priorities, `furi_hal_interrupt_trigger_pending`, get_name, get_time_in_isr_total), with a `{#furi_hal_interrupt}` anchor and linked from `documentation/doxygen/system.dox`.
- **API comments** in `furi/core/event_flag.h` and `furi/core/event_loop.h` — state that `furi_event_flag_set()` is ISR-safe and that flags set from interrupt context are delivered with the correct value.
- **`ReadMe.md`** — new "Running unit tests" section.
- **`documentation/UnitTests.md`** — example of running a subset (`unit_tests test_furi`).

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
