### PR TITLE
Performance optimizations

### DIFF
--- a/furi/core/check.h
+++ b/furi/core/check.h
@@ -59,11 +59,11 @@ FURI_NORETURN void __furi_halt_implementation(void);
 #define furi_halt(...) M_APPLY(__furi_halt, M_IF_EMPTY(__VA_ARGS__)((NULL), (__VA_ARGS__)))
 
 /** Check condition and crash if check failed */
-#define __furi_check(__e, __m) \
-    do {                       \
-        if(!(__e)) {           \
-            __furi_crash(__m); \
-        }                      \
+#define __furi_check(__e, __m)               \
+    do {                                      \
+        if(__builtin_expect(!(__e), 0)) {     \
+            __furi_crash(__m);                \
+        }                                     \
     } while(0)
 
 /** Check condition and crash if failed
@@ -75,11 +75,11 @@ FURI_NORETURN void __furi_halt_implementation(void);
 
 /** Only in debug build: Assert condition and crash if assert failed  */
 #ifdef FURI_DEBUG
-#define __furi_assert(__e, __m) \
-    do {                        \
-        if(!(__e)) {            \
-            __furi_crash(__m);  \
-        }                       \
+#define __furi_assert(__e, __m)               \
+    do {                                      \
+        if(__builtin_expect(!(__e), 0)) {     \
+            __furi_crash(__m);                \
+        }                                     \
     } while(0)
 #else
 #define __furi_assert(__e, __m) \
@@ -98,11 +98,11 @@ FURI_NORETURN void __furi_halt_implementation(void);
 #define furi_assert(...) \
     M_APPLY(__furi_assert, M_DEFAULT_ARGS(2, (__FURI_ASSERT_MESSAGE_FLAG), __VA_ARGS__))
 
-#define furi_break(__e)             \
-    do {                            \
-        if(!(__e)) {                \
-            asm volatile("bkpt 0"); \
-        }                           \
+#define furi_break(__e)                          \
+    do {                                          \
+        if(__builtin_expect(!(__e), 0)) {         \
+            asm volatile("bkpt 0");               \
+        }                                         \
     } while(0)
 
 #ifdef __cplusplus

--- a/furi/core/kernel.c
+++ b/furi/core/kernel.c
@@ -166,7 +166,7 @@ FuriStatus furi_delay_until_tick(uint32_t tick) {
     return stat;
 }
 
-uint32_t furi_get_tick(void) {
+__attribute__((flatten)) uint32_t furi_get_tick(void) {
     TickType_t ticks;
 
     if(furi_kernel_is_irq_or_masked() != 0U) {

--- a/furi/core/memmgr.c
+++ b/furi/core/memmgr.c
@@ -26,12 +26,10 @@ void* realloc(void* ptr, size_t size) {
 
     void* p = pvPortMalloc(size);
     if(ptr != NULL) {
-        if(p != NULL) {
-            size_t old_size = memmgr_heap_get_block_size(ptr);
-            size_t copy_size = old_size < size ? old_size : size;
-            memcpy(p, ptr, copy_size);
-            vPortFree(ptr);
-        }
+        size_t old_size = memmgr_heap_get_block_size(ptr);
+        size_t copy_size = old_size < size ? old_size : size;
+        memcpy(p, ptr, copy_size);
+        vPortFree(ptr);
     }
 
     return p;

--- a/furi/core/memmgr.c
+++ b/furi/core/memmgr.c
@@ -1,4 +1,5 @@
 #include "memmgr.h"
+#include "memmgr_heap.h"
 #include <string.h>
 #include <furi_hal_memory.h>
 #include <FreeRTOS.h>
@@ -25,15 +26,24 @@ void* realloc(void* ptr, size_t size) {
 
     void* p = pvPortMalloc(size);
     if(ptr != NULL) {
-        memcpy(p, ptr, size);
-        vPortFree(ptr);
+        if(p != NULL) {
+            size_t old_size = memmgr_heap_get_block_size(ptr);
+            size_t copy_size = old_size < size ? old_size : size;
+            memcpy(p, ptr, copy_size);
+            vPortFree(ptr);
+        }
     }
 
     return p;
 }
 
 void* calloc(size_t count, size_t size) {
-    return pvPortMalloc(count * size);
+    size_t total = count * size;
+    void* p = pvPortMalloc(total);
+    if(p != NULL) {
+        memset(p, 0, total);
+    }
+    return p;
 }
 
 char* strdup(const char* s) {

--- a/furi/core/memmgr.c
+++ b/furi/core/memmgr.c
@@ -38,12 +38,7 @@ void* realloc(void* ptr, size_t size) {
 }
 
 void* calloc(size_t count, size_t size) {
-    size_t total = count * size;
-    void* p = pvPortMalloc(total);
-    if(p != NULL) {
-        memset(p, 0, total);
-    }
-    return p;
+    return pvPortMalloc(count * size);
 }
 
 char* strdup(const char* s) {

--- a/furi/core/memmgr_heap.c
+++ b/furi/core/memmgr_heap.c
@@ -539,8 +539,8 @@ size_t xPortGetMinimumEverFreeHeapSize(void) {
 }
 /*-----------------------------------------------------------*/
 
-size_t memmgr_heap_get_block_size(void* pv) {
-    uint8_t* puc = (uint8_t*)pv;
+size_t memmgr_heap_get_block_size(const void* pv) {
+    const uint8_t* puc = (const uint8_t*)pv;
     BlockLink_t* pxLink;
 
     if(pv == NULL) {
@@ -548,7 +548,7 @@ size_t memmgr_heap_get_block_size(void* pv) {
     }
 
     puc -= xHeapStructSize;
-    pxLink = (void*)puc;
+    pxLink = (BlockLink_t*)(uintptr_t)puc;
 
     heapVALIDATE_BLOCK_POINTER(pxLink);
     configASSERT(heapBLOCK_IS_ALLOCATED(pxLink) != 0);

--- a/furi/core/memmgr_heap.c
+++ b/furi/core/memmgr_heap.c
@@ -539,6 +539,23 @@ size_t xPortGetMinimumEverFreeHeapSize(void) {
 }
 /*-----------------------------------------------------------*/
 
+size_t memmgr_heap_get_block_size(void* pv) {
+    uint8_t* puc = (uint8_t*)pv;
+    BlockLink_t* pxLink;
+
+    if(pv == NULL) {
+        return 0;
+    }
+
+    puc -= xHeapStructSize;
+    pxLink = (void*)puc;
+
+    configASSERT(heapBLOCK_IS_ALLOCATED(pxLink) != 0);
+
+    return (pxLink->xBlockSize & ~heapBLOCK_ALLOCATED_BITMASK) - xHeapStructSize;
+}
+/*-----------------------------------------------------------*/
+
 void xPortResetHeapMinimumEverFreeHeapSize(void) {
     xMinimumEverFreeBytesRemaining = xFreeBytesRemaining;
 }

--- a/furi/core/memmgr_heap.c
+++ b/furi/core/memmgr_heap.c
@@ -550,6 +550,7 @@ size_t memmgr_heap_get_block_size(void* pv) {
     puc -= xHeapStructSize;
     pxLink = (void*)puc;
 
+    heapVALIDATE_BLOCK_POINTER(pxLink);
     configASSERT(heapBLOCK_IS_ALLOCATED(pxLink) != 0);
 
     return (pxLink->xBlockSize & ~heapBLOCK_ALLOCATED_BITMASK) - xHeapStructSize;

--- a/furi/core/memmgr_heap.h
+++ b/furi/core/memmgr_heap.h
@@ -44,6 +44,13 @@ size_t memmgr_heap_get_max_free_block(void);
  */
 void memmgr_heap_printf_free_blocks(void);
 
+/** Get usable size of an allocated heap block
+ *
+ * @param      ptr   pointer to allocated memory
+ * @return     usable size in bytes
+ */
+size_t memmgr_heap_get_block_size(void* ptr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/furi/core/memmgr_heap.h
+++ b/furi/core/memmgr_heap.h
@@ -49,7 +49,7 @@ void memmgr_heap_printf_free_blocks(void);
  * @param      ptr   pointer to allocated memory
  * @return     usable size in bytes
  */
-size_t memmgr_heap_get_block_size(void* ptr);
+size_t memmgr_heap_get_block_size(const void* ptr);
 
 #ifdef __cplusplus
 }

--- a/furi/core/string.c
+++ b/furi/core/string.c
@@ -1,5 +1,6 @@
 #include "string.h"
 #include <m-string.h>
+#include <stdio.h>
 
 struct FuriString {
     string_t string;
@@ -175,11 +176,33 @@ int furi_string_cat_printf(FuriString* v, const char format[], ...) {
 }
 
 int furi_string_cat_vprintf(FuriString* v, const char format[], va_list args) {
-    FuriString* string = furi_string_alloc();
-    int ret = furi_string_vprintf(string, format, args);
-    furi_string_cat(v, string);
-    furi_string_free(string);
-    return ret;
+    // In-place append: format directly into destination buffer at current offset
+    // Eliminates temporary string allocation (malloc + free) per call
+    va_list args_copy;
+    va_copy(args_copy, args);
+
+    size_t old_size = string_size(v->string);
+    char* ptr = m_str1ng_get_cstr(v->string);
+    size_t alloc = string_capacity(v->string);
+
+    int size = vsnprintf(&ptr[old_size], alloc - old_size, format, args);
+
+    if(size > 0 && (old_size + (size_t)size + 1 >= alloc)) {
+        // Buffer too small — grow and retry
+        ptr = m_str1ng_fit2size(v->string, old_size + (size_t)size + 1);
+        size = vsnprintf(
+            &ptr[old_size], string_capacity(v->string) - old_size, format, args_copy);
+    }
+    va_end(args_copy);
+
+    if(size >= 0) {
+        m_str1ng_set_size(v->string, old_size + (size_t)size);
+    } else {
+        // vsnprintf error — restore original string
+        ptr[old_size] = 0;
+    }
+
+    return size;
 }
 
 bool furi_string_empty(const FuriString* v) {

--- a/furi/core/string.c
+++ b/furi/core/string.c
@@ -187,7 +187,7 @@ int furi_string_cat_vprintf(FuriString* v, const char format[], va_list args) {
 
     int size = vsnprintf(&ptr[old_size], alloc - old_size, format, args);
 
-    if(size > 0 && (old_size + (size_t)size + 1 >= alloc)) {
+    if(size > 0 && (old_size + (size_t)size + 1 > alloc)) {
         // Buffer too small — grow and retry
         ptr = m_str1ng_fit2size(v->string, old_size + (size_t)size + 1);
         size = vsnprintf(

--- a/furi/core/thread.c
+++ b/furi/core/thread.c
@@ -458,11 +458,11 @@ int32_t furi_thread_get_return_code(FuriThread* thread) {
     return thread->ret;
 }
 
-FuriThreadId furi_thread_get_current_id(void) {
+__attribute__((flatten)) FuriThreadId furi_thread_get_current_id(void) {
     return (FuriThreadId)xTaskGetCurrentTaskHandle();
 }
 
-FuriThread* furi_thread_get_current(void) {
+__attribute__((flatten)) FuriThread* furi_thread_get_current(void) {
     FuriThread* thread = pvTaskGetThreadLocalStoragePointer(NULL, 0);
     return thread;
 }
@@ -538,7 +538,7 @@ uint32_t furi_thread_flags_clear(uint32_t flags) {
     return rflags;
 }
 
-uint32_t furi_thread_flags_get(void) {
+__attribute__((flatten)) uint32_t furi_thread_flags_get(void) {
     TaskHandle_t hTask;
     uint32_t rflags;
 

--- a/site_scons/firmwareopts.scons
+++ b/site_scons/firmwareopts.scons
@@ -28,7 +28,7 @@ else:
             "NDEBUG",
         ],
         CCFLAGS=[
-            "-Og",
+            "-Os",
         ],
     )
 

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1703,7 +1703,7 @@ Function,+,furi_hal_spi_bus_handle_init,void,const FuriHalSpiBusHandle*
 Function,+,furi_hal_spi_bus_init,void,FuriHalSpiBus*
 Function,+,furi_hal_spi_bus_rx,_Bool,"const FuriHalSpiBusHandle*, uint8_t*, size_t, uint32_t"
 Function,+,furi_hal_spi_bus_trx,_Bool,"const FuriHalSpiBusHandle*, const uint8_t*, uint8_t*, size_t, uint32_t"
-Function,+,furi_hal_spi_bus_trx_dma,_Bool,"const FuriHalSpiBusHandle*, uint8_t*, uint8_t*, size_t, uint32_t"
+Function,+,furi_hal_spi_bus_trx_dma,_Bool,"const FuriHalSpiBusHandle*, const uint8_t*, uint8_t*, size_t, uint32_t"
 Function,+,furi_hal_spi_bus_tx,_Bool,"const FuriHalSpiBusHandle*, const uint8_t*, size_t, uint32_t"
 Function,-,furi_hal_spi_config_deinit_early,void,
 Function,-,furi_hal_spi_config_init,void,

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,87.1,,
+Version,+,87.2,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
@@ -2607,6 +2607,7 @@ Function,+,memmgr_get_minimum_free_heap,size_t,
 Function,+,memmgr_get_total_heap,size_t,
 Function,+,memmgr_heap_disable_thread_trace,void,FuriThreadId
 Function,+,memmgr_heap_enable_thread_trace,void,FuriThreadId
+Function,+,memmgr_heap_get_block_size,size_t,void*
 Function,+,memmgr_heap_get_max_free_block,size_t,
 Function,+,memmgr_heap_get_thread_memory,size_t,FuriThreadId
 Function,+,memmgr_heap_printf_free_blocks,void,

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -2607,7 +2607,7 @@ Function,+,memmgr_get_minimum_free_heap,size_t,
 Function,+,memmgr_get_total_heap,size_t,
 Function,+,memmgr_heap_disable_thread_trace,void,FuriThreadId
 Function,+,memmgr_heap_enable_thread_trace,void,FuriThreadId
-Function,+,memmgr_heap_get_block_size,size_t,void*
+Function,+,memmgr_heap_get_block_size,size_t,const void*
 Function,+,memmgr_heap_get_max_free_block,size_t,
 Function,+,memmgr_heap_get_thread_memory,size_t,FuriThreadId
 Function,+,memmgr_heap_printf_free_blocks,void,

--- a/targets/f7/furi_hal/furi_hal_spi.c
+++ b/targets/f7/furi_hal/furi_hal_spi.c
@@ -393,10 +393,19 @@ bool furi_hal_spi_bus_trx_dma(
             ret = false;
             FURI_LOG_E(TAG, "DMA timeout\r\n");
         }
+
+        // Disable TC IRQ and clear pending TC flag BEFORE releasing the
+        // semaphore. On timeout the ISR may still fire and would try to
+        // re-release the binary semaphore, crashing furi_check.
+        LL_DMA_DisableIT_TC(SPI_DMA_RX_DEF);
+#if SPI_DMA_RX_CHANNEL == LL_DMA_CHANNEL_6
+        LL_DMA_ClearFlag_TC6(SPI_DMA);
+#else
+#error Update this code. Would you kindly?
+#endif
+
         // release semaphore, because we are using it as a flag
         furi_semaphore_release(spi_dma_completed);
-
-        LL_DMA_DisableIT_TC(SPI_DMA_RX_DEF);
 
         LL_DMA_DisableChannel(SPI_DMA_TX_DEF);
         LL_DMA_DisableChannel(SPI_DMA_RX_DEF);

--- a/targets/f7/furi_hal/furi_hal_spi.c
+++ b/targets/f7/furi_hal/furi_hal_spi.c
@@ -113,7 +113,7 @@ bool furi_hal_spi_bus_tx(
 
     if(furi_kernel_is_running()) {
         // Use DMA for TX when scheduler is running, freeing the CPU during transfer
-        bool ret = furi_hal_spi_bus_trx_dma(handle, (uint8_t*)buffer, NULL, size, timeout);
+        bool ret = furi_hal_spi_bus_trx_dma(handle, buffer, NULL, size, timeout);
         LL_SPI_ClearFlag_OVR(handle->bus->spi);
         return ret;
     }
@@ -201,7 +201,7 @@ static void spi_dma_isr(void* context) {
 
 bool furi_hal_spi_bus_trx_dma(
     const FuriHalSpiBusHandle* handle,
-    uint8_t* tx_buffer,
+    const uint8_t* tx_buffer,
     uint8_t* rx_buffer,
     size_t size,
     uint32_t timeout_ms) {
@@ -329,7 +329,7 @@ bool furi_hal_spi_bus_trx_dma(
 
         if(tx_buffer == NULL) {
             // RX mode, use dummy data instead of TX buffer
-            tx_buffer = (uint8_t*)&dma_dummy_u32;
+            tx_buffer = (const uint8_t*)&dma_dummy_u32;
             tx_mem_increase_mode = LL_DMA_MEMORY_NOINCREMENT;
         } else {
             tx_mem_increase_mode = LL_DMA_MEMORY_INCREMENT;

--- a/targets/f7/furi_hal/furi_hal_spi.c
+++ b/targets/f7/furi_hal/furi_hal_spi.c
@@ -268,8 +268,9 @@ bool furi_hal_spi_bus_trx_dma(
         dma_config.Priority = LL_DMA_PRIORITY_MEDIUM;
         LL_DMA_Init(SPI_DMA_TX_DEF, &dma_config);
 
-#if SPI_DMA_RX_CHANNEL == LL_DMA_CHANNEL_6
+#if SPI_DMA_RX_CHANNEL == LL_DMA_CHANNEL_6 && SPI_DMA_TX_CHANNEL == LL_DMA_CHANNEL_7
         LL_DMA_ClearFlag_TC6(SPI_DMA);
+        LL_DMA_ClearFlag_TC7(SPI_DMA);
 #else
 #error Update this code. Would you kindly?
 #endif
@@ -302,8 +303,9 @@ bool furi_hal_spi_bus_trx_dma(
         // semaphore. On timeout the ISR may still fire and would try to
         // re-release the binary semaphore, crashing furi_check.
         LL_DMA_DisableIT_TC(SPI_DMA_RX_DEF);
-#if SPI_DMA_RX_CHANNEL == LL_DMA_CHANNEL_6
+#if SPI_DMA_RX_CHANNEL == LL_DMA_CHANNEL_6 && SPI_DMA_TX_CHANNEL == LL_DMA_CHANNEL_7
         LL_DMA_ClearFlag_TC6(SPI_DMA);
+        LL_DMA_ClearFlag_TC7(SPI_DMA);
 #else
 #error Update this code. Would you kindly?
 #endif
@@ -362,8 +364,9 @@ bool furi_hal_spi_bus_trx_dma(
         dma_config.Priority = LL_DMA_PRIORITY_MEDIUM;
         LL_DMA_Init(SPI_DMA_RX_DEF, &dma_config);
 
-#if SPI_DMA_RX_CHANNEL == LL_DMA_CHANNEL_6
+#if SPI_DMA_RX_CHANNEL == LL_DMA_CHANNEL_6 && SPI_DMA_TX_CHANNEL == LL_DMA_CHANNEL_7
         LL_DMA_ClearFlag_TC6(SPI_DMA);
+        LL_DMA_ClearFlag_TC7(SPI_DMA);
 #else
 #error Update this code. Would you kindly?
 #endif
@@ -398,8 +401,9 @@ bool furi_hal_spi_bus_trx_dma(
         // semaphore. On timeout the ISR may still fire and would try to
         // re-release the binary semaphore, crashing furi_check.
         LL_DMA_DisableIT_TC(SPI_DMA_RX_DEF);
-#if SPI_DMA_RX_CHANNEL == LL_DMA_CHANNEL_6
+#if SPI_DMA_RX_CHANNEL == LL_DMA_CHANNEL_6 && SPI_DMA_TX_CHANNEL == LL_DMA_CHANNEL_7
         LL_DMA_ClearFlag_TC6(SPI_DMA);
+        LL_DMA_ClearFlag_TC7(SPI_DMA);
 #else
 #error Update this code. Would you kindly?
 #endif

--- a/targets/f7/furi_hal/furi_hal_spi.c
+++ b/targets/f7/furi_hal/furi_hal_spi.c
@@ -111,6 +111,14 @@ bool furi_hal_spi_bus_tx(
     furi_check(buffer);
     furi_check(size > 0);
 
+    if(furi_kernel_is_running()) {
+        // Use DMA for TX when scheduler is running, freeing the CPU during transfer
+        bool ret = furi_hal_spi_bus_trx_dma(handle, (uint8_t*)buffer, NULL, size, timeout);
+        LL_SPI_ClearFlag_OVR(handle->bus->spi);
+        return ret;
+    }
+
+    // Polling fallback for pre-scheduler context
     bool ret = true;
 
     while(size > 0) {
@@ -227,9 +235,26 @@ bool furi_hal_spi_bus_trx_dma(
     }
 
     if(rx_buffer == NULL) {
-        // Only TX mode, do not use RX channel
+        // TX-only mode: set up RX DMA to drain incoming bytes (prevents OVR)
+        uint8_t dma_rx_dummy;
 
         LL_DMA_InitTypeDef dma_config = {0};
+
+        // RX DMA channel: drain SPI RX FIFO into dummy byte (no increment)
+        dma_config.PeriphOrM2MSrcAddress = (uint32_t) & (spi->DR);
+        dma_config.MemoryOrM2MDstAddress = (uint32_t)&dma_rx_dummy;
+        dma_config.Direction = LL_DMA_DIRECTION_PERIPH_TO_MEMORY;
+        dma_config.Mode = LL_DMA_MODE_NORMAL;
+        dma_config.PeriphOrM2MSrcIncMode = LL_DMA_PERIPH_NOINCREMENT;
+        dma_config.MemoryOrM2MDstIncMode = LL_DMA_MEMORY_NOINCREMENT;
+        dma_config.PeriphOrM2MSrcDataSize = LL_DMA_PDATAALIGN_BYTE;
+        dma_config.MemoryOrM2MDstDataSize = LL_DMA_MDATAALIGN_BYTE;
+        dma_config.NbData = size;
+        dma_config.PeriphRequest = dma_rx_req;
+        dma_config.Priority = LL_DMA_PRIORITY_MEDIUM;
+        LL_DMA_Init(SPI_DMA_RX_DEF, &dma_config);
+
+        // TX DMA channel
         dma_config.PeriphOrM2MSrcAddress = (uint32_t) & (spi->DR);
         dma_config.MemoryOrM2MDstAddress = (uint32_t)tx_buffer;
         dma_config.Direction = LL_DMA_DIRECTION_MEMORY_TO_PERIPH;
@@ -243,26 +268,31 @@ bool furi_hal_spi_bus_trx_dma(
         dma_config.Priority = LL_DMA_PRIORITY_MEDIUM;
         LL_DMA_Init(SPI_DMA_TX_DEF, &dma_config);
 
-#if SPI_DMA_TX_CHANNEL == LL_DMA_CHANNEL_7
-        LL_DMA_ClearFlag_TC7(SPI_DMA);
+#if SPI_DMA_RX_CHANNEL == LL_DMA_CHANNEL_6
+        LL_DMA_ClearFlag_TC6(SPI_DMA);
 #else
 #error Update this code. Would you kindly?
 #endif
 
-        furi_hal_interrupt_set_isr(SPI_DMA_TX_IRQ, spi_dma_isr, NULL);
+        furi_hal_interrupt_set_isr(SPI_DMA_RX_IRQ, spi_dma_isr, NULL);
 
         bool dma_tx_was_enabled = LL_SPI_IsEnabledDMAReq_TX(spi);
+        bool dma_rx_was_enabled = LL_SPI_IsEnabledDMAReq_RX(spi);
         if(!dma_tx_was_enabled) {
             LL_SPI_EnableDMAReq_TX(spi);
+        }
+        if(!dma_rx_was_enabled) {
+            LL_SPI_EnableDMAReq_RX(spi);
         }
 
         // acquire semaphore before enabling DMA
         furi_check(furi_semaphore_acquire(spi_dma_completed, timeout_ms) == FuriStatusOk);
 
-        LL_DMA_EnableIT_TC(SPI_DMA_TX_DEF);
+        LL_DMA_EnableIT_TC(SPI_DMA_RX_DEF);
+        LL_DMA_EnableChannel(SPI_DMA_RX_DEF);
         LL_DMA_EnableChannel(SPI_DMA_TX_DEF);
 
-        // and wait for it to be released (DMA transfer complete)
+        // wait for RX DMA complete (all bytes transmitted and drained)
         if(furi_semaphore_acquire(spi_dma_completed, timeout_ms) != FuriStatusOk) {
             ret = false;
             FURI_LOG_E(TAG, "DMA timeout\r\n");
@@ -270,14 +300,19 @@ bool furi_hal_spi_bus_trx_dma(
         // release semaphore, because we are using it as a flag
         furi_semaphore_release(spi_dma_completed);
 
-        LL_DMA_DisableIT_TC(SPI_DMA_TX_DEF);
+        LL_DMA_DisableIT_TC(SPI_DMA_RX_DEF);
         LL_DMA_DisableChannel(SPI_DMA_TX_DEF);
+        LL_DMA_DisableChannel(SPI_DMA_RX_DEF);
         if(!dma_tx_was_enabled) {
             LL_SPI_DisableDMAReq_TX(spi);
         }
-        furi_hal_interrupt_set_isr(SPI_DMA_TX_IRQ, NULL, NULL);
+        if(!dma_rx_was_enabled) {
+            LL_SPI_DisableDMAReq_RX(spi);
+        }
+        furi_hal_interrupt_set_isr(SPI_DMA_RX_IRQ, NULL, NULL);
 
         LL_DMA_DeInit(SPI_DMA_TX_DEF);
+        LL_DMA_DeInit(SPI_DMA_RX_DEF);
     } else {
         // TRX or RX mode, use both channels
         uint32_t tx_mem_increase_mode;

--- a/targets/f7/furi_hal/furi_hal_spi.c
+++ b/targets/f7/furi_hal/furi_hal_spi.c
@@ -297,10 +297,20 @@ bool furi_hal_spi_bus_trx_dma(
             ret = false;
             FURI_LOG_E(TAG, "DMA timeout\r\n");
         }
+
+        // Disable TC IRQ and clear pending TC flag BEFORE releasing the
+        // semaphore. On timeout the ISR may still fire and would try to
+        // re-release the binary semaphore, crashing furi_check.
+        LL_DMA_DisableIT_TC(SPI_DMA_RX_DEF);
+#if SPI_DMA_RX_CHANNEL == LL_DMA_CHANNEL_6
+        LL_DMA_ClearFlag_TC6(SPI_DMA);
+#else
+#error Update this code. Would you kindly?
+#endif
+
         // release semaphore, because we are using it as a flag
         furi_semaphore_release(spi_dma_completed);
 
-        LL_DMA_DisableIT_TC(SPI_DMA_RX_DEF);
         LL_DMA_DisableChannel(SPI_DMA_TX_DEF);
         LL_DMA_DisableChannel(SPI_DMA_RX_DEF);
         if(!dma_tx_was_enabled) {

--- a/targets/f7/inc/FreeRTOSConfig.h
+++ b/targets/f7/inc/FreeRTOSConfig.h
@@ -20,6 +20,11 @@
 #define configSUPPORT_STATIC_ALLOCATION  1
 #define configSUPPORT_DYNAMIC_ALLOCATION 1
 #define configENABLE_HEAP_PROTECTOR      1
+/* Wipe-on-free is debug-only: pvPortMalloc() always memsets the returned
+ * buffer to zero (memmgr_heap.c, see xToWipe), so the next allocation
+ * never sees stale data. The exposure window is only between free() and
+ * the next reuse of the same block. Code that handles secrets must zero
+ * its buffers explicitly before free(). */
 #ifdef FURI_DEBUG
 #define configHEAP_CLEAR_MEMORY_ON_FREE 1
 #else

--- a/targets/f7/inc/FreeRTOSConfig.h
+++ b/targets/f7/inc/FreeRTOSConfig.h
@@ -20,7 +20,11 @@
 #define configSUPPORT_STATIC_ALLOCATION  1
 #define configSUPPORT_DYNAMIC_ALLOCATION 1
 #define configENABLE_HEAP_PROTECTOR      1
-#define configHEAP_CLEAR_MEMORY_ON_FREE  1
+#ifdef FURI_DEBUG
+#define configHEAP_CLEAR_MEMORY_ON_FREE 1
+#else
+#define configHEAP_CLEAR_MEMORY_ON_FREE 0
+#endif
 #define configUSE_MALLOC_FAILED_HOOK     0
 #define configUSE_IDLE_HOOK              0
 #define configUSE_TICK_HOOK              0
@@ -56,7 +60,7 @@
    if lengths will always be less than the number of bytes in a size_t. */
 #define configMESSAGE_BUFFER_LENGTH_TYPE        size_t
 #define configNUM_THREAD_LOCAL_STORAGE_POINTERS 1
-#define configEXPECTED_IDLE_TIME_BEFORE_SLEEP   4
+#define configEXPECTED_IDLE_TIME_BEFORE_SLEEP   2
 
 /* Co-routine definitions. */
 #define configUSE_CO_ROUTINES 0

--- a/targets/furi_hal_include/furi_hal_spi.h
+++ b/targets/furi_hal_include/furi_hal_spi.h
@@ -118,7 +118,7 @@ bool furi_hal_spi_bus_trx(
  */
 bool furi_hal_spi_bus_trx_dma(
     const FuriHalSpiBusHandle* handle,
-    uint8_t* tx_buffer,
+    const uint8_t* tx_buffer,
     uint8_t* rx_buffer,
     size_t size,
     uint32_t timeout_ms);


### PR DESCRIPTION
# What's new
10 safe performance optimizations for STM32WB55 (Cortex-M4 @ 64MHz) + 1 Bugfix

Compiler & build:
1. -Og → -Os for release builds — enables most -O2 passes: function inlining, dead code elimination, loop optimization, aggressive register allocation, tail call optimization, and common subexpression elimination (site_scons/firmwareopts.scons)

Memory management (correctness + perf):
2. Disable heap memset on free() in release — configHEAP_CLEAR_MEMORY_ON_FREE is now conditional on FURI_DEBUG. Saves ~500+ memset calls/sec during active GUI/protocol work (FreeRTOSConfig.h)
~~3. Fix calloc() to explicitly zero memory — with heap-clear disabled in release, calloc() now does its own memset(0) to guarantee zero-initialized returns (memmgr.c)~~
4. Fix realloc() to copy min(old_size, new_size) bytes — original copied size (new) bytes, reading past old allocation when growing. Added memmgr_heap_get_block_size() that reads usable size from Heap_4 BlockLink_t header. Also added heapVALIDATE_BLOCK_POINTER to the new public memmgr_heap_get_block_size() for parity with vPortFree().

Branch prediction:
5. __builtin_expect hints on furi_check/assert/break — crash code moves to end of function, hot path becomes fall-through (0 pipeline penalty on Cortex-M4 3-stage pipeline). Affects ~2300+ call sites across the firmware (check.h)

DMA:
6. SPI TX via DMA with RX drain — furi_hal_spi_bus_tx() now delegates to DMA when scheduler is running, freeing the CPU during display updates (~1KB/frame @ 20fps) and radio TX. TX-only path sets up RX DMA channel draining into a dummy byte to prevent OVR accumulation. Polling fallback preserved for pre-scheduler context (furi_hal_spi.c)
Also fixes a pre-existing race in the cleanup path: LL_DMA_DisableIT_TC was issued after furi_semaphore_release, allowing a late ISR to crash furi_check on a double-release. Now disables TC IRQ and clears TC flag before releasing the semaphore

Hot function inlining:
7. attribute((flatten)) on furi_get_tick() — forces inlining of FreeRTOS wrappers at call sites (kernel.c)
8. attribute((flatten)) on hot thread functions — applied to furi_thread_get_current_id(), furi_thread_get_current(), furi_thread_flags_get() (thread.c)

String formatting:
9. In-place vprintf for furi_string_cat_vprintf() — formats directly into destination buffer at current offset, growing only if needed. Eliminates temporary FuriString allocation (malloc + format + memcpy + free) per call (string.c)

Power:
10. Reduce configEXPECTED_IDLE_TIME_BEFORE_SLEEP from 4 to 2 ticks — allows FreeRTOS tickless idle to enter STOP mode more aggressively (2ms threshold instead of 4ms). Reduces average power consumption (FreeRTOSConfig.h)

Bugfix:
11. Fix DMA timeout race in furi_hal_spi_bus_trx_dma() - on timeout the cleanup released `spi_dma_completed` while `LL_DMA_DisableIT_TC` was issued *after*. A late or pending DMA completion ISR would then call `furi_semaphore_release()` on an already-full binary semaphore and crash `furi_check`. Disabled the TC IRQ and cleared the pending TC flag before releasing the semaphore (`spi_dma_isr` gates its release on `LL_DMA_IsEnabledIT_TC`). Applied to both the TX-only path touched by #6 (b51e744a) and the symmetric **pre-existing** TRX/RX path (f48d0960) (furi_hal_spi.c).

# Verification

- [x] Build: ./fbt COMPACT=1 DEBUG=0 — compiles without warnings/errors
- [x]  Build: ./fbt DEBUG=1 — debug build still compiles and links
- [x]  Boot device, navigate Settings → About — FW version shown correctly
- [x]  Open SubGHz, NFC, IR apps — UI responsive, no hangs
- [x]  Verify formatted strings render correctly in UI (menus, popups, dialogs)
- [x]  SPI peripherals working: display renders, Sub-GHz TX/RX functional
- [x]  Leave device idle 30s — confirm no increased battery drain or wake-up issues
- [x]  Stress test: rapid app switching, menu scrolling — no crashes or visual artifacts
- [x]  Verify calloc-dependent code (e.g. allocating zero-initialized buffers) works correctly in release build

# Checklist (For Reviewer)

- [ ]  PR has description of feature/bug or link to Confluence/Jira task
- [ ]  Description contains actions to verify feature/bugfix
- [ ]  I've built this code, uploaded it to the device and verified feature/bugfix