### PR TITLE
NFC: Add Write NDEF Tag action for NTAG21x

### DIFF
--- a/applications/main/nfc/helpers/mf_ultralight_ndef.c
+++ b/applications/main/nfc/helpers/mf_ultralight_ndef.c
@@ -1,0 +1,151 @@
+#include "mf_ultralight_ndef.h"
+
+#include <string.h>
+#include <furi.h>
+#include <nfc/protocols/mf_ultralight/mf_ultralight.h>
+
+// NTAG21x parameters per NXP datasheets.
+typedef struct {
+    MfUltralightType ul_type;
+    const char* name;
+    uint8_t total_pages; // including config pages
+    uint8_t cc_size; // value of CC byte 2 (data area / 8)
+    uint8_t storage_size; // GET_VERSION storage_size byte
+    uint16_t user_capacity_bytes; // usable bytes for the NDEF TLV blob
+} NtagParams;
+
+static const NtagParams ntag_params[] = {
+    [NdefNtagTypeNTAG213] = {MfUltralightTypeNTAG213, "NTAG213", 45, 0x12, 0x0F, 144},
+    [NdefNtagTypeNTAG215] = {MfUltralightTypeNTAG215, "NTAG215", 135, 0x3E, 0x11, 504},
+    [NdefNtagTypeNTAG216] = {MfUltralightTypeNTAG216, "NTAG216", 231, 0x6D, 0x13, 888},
+};
+
+// NTAG21x GET_VERSION response (fixed prefix; storage_size differs per variant).
+static const uint8_t ntag21x_version_prefix[] = {
+    0x00, // header
+    0x04, // vendor (NXP)
+    0x04, // type (NTAG)
+    0x02, // subtype
+    0x01, // major version
+    0x00, // minor version
+    // storage_size at byte 6 — filled per variant
+    // protocol_type at byte 7
+};
+
+const char* mf_ultralight_ndef_ntag_name(NdefNtagType ntag) {
+    if(ntag > NdefNtagTypeNTAG216) return "?";
+    return ntag_params[ntag].name;
+}
+
+size_t mf_ultralight_ndef_user_capacity(NdefNtagType ntag) {
+    if(ntag > NdefNtagTypeNTAG216) return 0;
+    return ntag_params[ntag].user_capacity_bytes;
+}
+
+bool mf_ultralight_ndef_fill_device(
+    NfcDevice* nfc_device,
+    NdefNtagType ntag,
+    const uint8_t* ndef_blob,
+    size_t ndef_size) {
+    furi_assert(nfc_device);
+    furi_assert(ndef_blob);
+    if(ntag > NdefNtagTypeNTAG216) return false;
+    const NtagParams* p = &ntag_params[ntag];
+    if(ndef_size > p->user_capacity_bytes) return false;
+
+    MfUltralightData* data = mf_ultralight_alloc();
+    data->type = p->ul_type;
+    data->pages_total = p->total_pages;
+    data->pages_read = p->total_pages;
+
+    // GET_VERSION
+    data->version.header = ntag21x_version_prefix[0];
+    data->version.vendor_id = ntag21x_version_prefix[1];
+    data->version.prod_type = ntag21x_version_prefix[2];
+    data->version.prod_subtype = ntag21x_version_prefix[3];
+    data->version.prod_ver_major = ntag21x_version_prefix[4];
+    data->version.prod_ver_minor = ntag21x_version_prefix[5];
+    data->version.storage_size = p->storage_size;
+    data->version.protocol_type = 0x03;
+
+    // ISO14443-3A identification: NTAGs respond with ATQA=0x0044, SAK=0x00, 7-byte UID.
+    Iso14443_3aData* iso = data->iso14443_3a_data;
+    iso->atqa[0] = 0x44;
+    iso->atqa[1] = 0x00;
+    iso->sak = 0x00;
+    iso->uid_len = 7;
+    // Arbitrary but plausible UID — pages 0-2 are read-only on real cards and the
+    // poller never writes to them anyway, so the values here don't reach the tag.
+    static const uint8_t default_uid[7] = {0x04, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+    memcpy(iso->uid, default_uid, 7);
+
+    // Mirror the UID into pages 0-1 + BCC bytes (so render/debug paths see sane data).
+    // Page 0: UID0..UID2 + BCC0 (CT XOR UID0 XOR UID1 XOR UID2)
+    data->page[0].data[0] = default_uid[0];
+    data->page[0].data[1] = default_uid[1];
+    data->page[0].data[2] = default_uid[2];
+    data->page[0].data[3] = 0x88 ^ default_uid[0] ^ default_uid[1] ^ default_uid[2];
+    // Page 1: UID3..UID6
+    data->page[1].data[0] = default_uid[3];
+    data->page[1].data[1] = default_uid[4];
+    data->page[1].data[2] = default_uid[5];
+    data->page[1].data[3] = default_uid[6];
+    // Page 2: BCC1, internal, lock0, lock1 — keep locks zero (poller refuses to write
+    // if static-lock bits are set).
+    data->page[2].data[0] = default_uid[3] ^ default_uid[4] ^ default_uid[5] ^ default_uid[6];
+    data->page[2].data[1] = 0x48; // Internal byte (NTAG default)
+    data->page[2].data[2] = 0x00;
+    data->page[2].data[3] = 0x00;
+
+    // Page 3: Capability Container (E1 10 <size/8> 00)
+    data->page[3].data[0] = 0xE1;
+    data->page[3].data[1] = 0x10;
+    data->page[3].data[2] = p->cc_size;
+    data->page[3].data[3] = 0x00;
+
+    // Pages 4..config_page-1 = user memory. Clear, then write NDEF TLV blob.
+    uint8_t config_page = p->total_pages - 4;
+    for(uint8_t pg = 4; pg < config_page; pg++) {
+        memset(data->page[pg].data, 0, 4);
+    }
+    // Copy NDEF blob into user memory, page-aligned starting at page 4.
+    for(size_t i = 0; i < ndef_size; i++) {
+        size_t byte_offset = i;
+        uint8_t pg = 4 + (byte_offset / 4);
+        uint8_t off = byte_offset % 4;
+        data->page[pg].data[off] = ndef_blob[i];
+    }
+
+    // Config pages (replicate NXP factory defaults so the poller's lock/dynlock
+    // checks pass and the auth handler can use the default password).
+    // Page config_page+0: STRG_MOD_EN | RFUI | RFUI | AUTH0
+    data->page[config_page].data[0] = 0x04;
+    data->page[config_page].data[1] = 0x00;
+    data->page[config_page].data[2] = 0x00;
+    data->page[config_page].data[3] = 0xFF; // AUTH0 = no password protection
+    // Page config_page+1: ACCESS | VCTID | RFUI | RFUI
+    data->page[config_page + 1].data[0] = 0x00;
+    data->page[config_page + 1].data[1] = 0x05;
+    data->page[config_page + 1].data[2] = 0x00;
+    data->page[config_page + 1].data[3] = 0x00;
+    // Page config_page+2: PWD (default 0xFFFFFFFF)
+    memset(data->page[config_page + 2].data, 0xFF, 4);
+    // Page config_page+3: PACK (default 0x0000) + RFUI
+    data->page[config_page + 3].data[0] = 0x00;
+    data->page[config_page + 3].data[1] = 0x00;
+    data->page[config_page + 3].data[2] = 0x00;
+    data->page[config_page + 3].data[3] = 0x00;
+
+    // Dynamic lock byte page sits just before the config page block. Leave zero
+    // so the poller's pre-write check passes.
+    if(config_page > 0) {
+        data->page[config_page - 1].data[0] = 0x00;
+        data->page[config_page - 1].data[1] = 0x00;
+        data->page[config_page - 1].data[2] = 0x00;
+        data->page[config_page - 1].data[3] = 0xBD; // default tearing flag pattern
+    }
+
+    nfc_device_set_data(nfc_device, NfcProtocolMfUltralight, data);
+    mf_ultralight_free(data);
+    return true;
+}

--- a/applications/main/nfc/helpers/mf_ultralight_ndef.h
+++ b/applications/main/nfc/helpers/mf_ultralight_ndef.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <nfc/nfc_device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    NdefNtagTypeNTAG213 = 0,
+    NdefNtagTypeNTAG215 = 1,
+    NdefNtagTypeNTAG216 = 2,
+} NdefNtagType;
+
+/**
+ * Populate `nfc_device` with a freshly-built NTAG21x dump (default UID/version/CC)
+ * whose user memory starts with the provided NDEF Message TLV blob.
+ *
+ * The poller's write flow starts at page 4, so we leave pages 0-3 with sane
+ * defaults (UID + CC) — only user pages (4..config_page-1) carry the NDEF data.
+ *
+ * @return false if the blob doesn't fit in the chosen NTAG's user memory.
+ */
+bool mf_ultralight_ndef_fill_device(
+    NfcDevice* nfc_device,
+    NdefNtagType ntag,
+    const uint8_t* ndef_blob,
+    size_t ndef_size);
+
+/** Human-readable name, e.g. "NTAG215". */
+const char* mf_ultralight_ndef_ntag_name(NdefNtagType ntag);
+
+/** User-memory capacity in bytes for the given NTAG (the NDEF TLV blob must fit here). */
+size_t mf_ultralight_ndef_user_capacity(NdefNtagType ntag);
+
+#ifdef __cplusplus
+}
+#endif

--- a/applications/main/nfc/helpers/ndef_builder.c
+++ b/applications/main/nfc/helpers/ndef_builder.c
@@ -41,14 +41,14 @@ static const struct {
 };
 
 // NDEF record header flag bits
-#define NDEF_MB 0x80 // Message Begin
-#define NDEF_ME 0x40 // Message End
-#define NDEF_SR 0x10 // Short Record (1-byte payload length)
+#define NDEF_MB             0x80 // Message Begin
+#define NDEF_ME             0x40 // Message End
+#define NDEF_SR             0x10 // Short Record (1-byte payload length)
 #define NDEF_TNF_WELL_KNOWN 0x01
 #define NDEF_TNF_MIME_MEDIA 0x02
 
 // TLV markers
-#define NDEF_TLV_MESSAGE 0x03
+#define NDEF_TLV_MESSAGE    0x03
 #define NDEF_TLV_TERMINATOR 0xFE
 
 static uint8_t ndef_uri_match_prefix(const char** uri_io) {
@@ -97,11 +97,7 @@ static bool ndef_tlv_wrap(
     return true;
 }
 
-bool ndef_builder_build_uri(
-    const char* uri,
-    uint8_t* out,
-    size_t out_capacity,
-    size_t* out_size) {
+bool ndef_builder_build_uri(const char* uri, uint8_t* out, size_t out_capacity, size_t* out_size) {
     if(!uri || !out || !out_size) return false;
 
     const char* uri_body = uri;
@@ -130,11 +126,7 @@ bool ndef_builder_build_uri(
     return ndef_tlv_wrap(out, out_capacity, body_start, record_len, out_size);
 }
 
-bool ndef_builder_build_text(
-    const char* text,
-    uint8_t* out,
-    size_t out_capacity,
-    size_t* out_size) {
+bool ndef_builder_build_text(const char* text, uint8_t* out, size_t out_capacity, size_t* out_size) {
     if(!text || !out || !out_size) return false;
 
     static const char lang[] = "en";
@@ -163,16 +155,16 @@ bool ndef_builder_build_text(
 }
 
 // WPS attribute IDs (big-endian on the wire)
-#define WPS_ATTR_CREDENTIAL       0x100E
-#define WPS_ATTR_NETWORK_INDEX    0x1026
-#define WPS_ATTR_SSID             0x1045
-#define WPS_ATTR_AUTH_TYPE        0x1003
-#define WPS_ATTR_ENCRYPT_TYPE     0x100F
-#define WPS_ATTR_NETWORK_KEY      0x1027
-#define WPS_ATTR_MAC_ADDRESS      0x1020
+#define WPS_ATTR_CREDENTIAL    0x100E
+#define WPS_ATTR_NETWORK_INDEX 0x1026
+#define WPS_ATTR_SSID          0x1045
+#define WPS_ATTR_AUTH_TYPE     0x1003
+#define WPS_ATTR_ENCRYPT_TYPE  0x100F
+#define WPS_ATTR_NETWORK_KEY   0x1027
+#define WPS_ATTR_MAC_ADDRESS   0x1020
 
-#define WPS_AUTH_WPA2_PSK         0x0020
-#define WPS_ENCRYPT_AES           0x0008
+#define WPS_AUTH_WPA2_PSK 0x0020
+#define WPS_ENCRYPT_AES   0x0008
 
 static uint8_t* wps_put_u8(uint8_t* p, uint16_t attr, uint8_t value) {
     *p++ = (uint8_t)(attr >> 8);

--- a/applications/main/nfc/helpers/ndef_builder.c
+++ b/applications/main/nfc/helpers/ndef_builder.c
@@ -1,0 +1,259 @@
+#include "ndef_builder.h"
+
+#include <string.h>
+
+// NFC Forum URI RTD prefix table. Index = identifier code; entry = prefix string.
+// Order matters: when matching a URI we walk the table top-to-bottom and prefer the
+// first match. Putting "https://www." before "https://" yields shorter encodings.
+static const struct {
+    uint8_t code;
+    const char* prefix;
+} ndef_uri_prefixes[] = {
+    {0x01, "http://www."},
+    {0x02, "https://www."},
+    {0x03, "http://"},
+    {0x04, "https://"},
+    {0x05, "tel:"},
+    {0x06, "mailto:"},
+    {0x07, "ftp://anonymous:anonymous@"},
+    {0x08, "ftp://ftp."},
+    {0x09, "ftps://"},
+    {0x0A, "sftp://"},
+    {0x0B, "smb://"},
+    {0x0C, "nfs://"},
+    {0x0D, "ftp://"},
+    {0x0E, "dav://"},
+    {0x0F, "news:"},
+    {0x10, "telnet://"},
+    {0x11, "imap:"},
+    {0x12, "rtsp://"},
+    {0x13, "urn:"},
+    {0x14, "pop:"},
+    {0x15, "sip:"},
+    {0x16, "sips:"},
+    {0x17, "tftp:"},
+    {0x18, "btspp://"},
+    {0x19, "btl2cap://"},
+    {0x1A, "btgoep://"},
+    {0x1B, "tcpobex://"},
+    {0x1C, "irdaobex://"},
+    {0x1D, "file://"},
+};
+
+// NDEF record header flag bits
+#define NDEF_MB 0x80 // Message Begin
+#define NDEF_ME 0x40 // Message End
+#define NDEF_SR 0x10 // Short Record (1-byte payload length)
+#define NDEF_TNF_WELL_KNOWN 0x01
+#define NDEF_TNF_MIME_MEDIA 0x02
+
+// TLV markers
+#define NDEF_TLV_MESSAGE 0x03
+#define NDEF_TLV_TERMINATOR 0xFE
+
+static uint8_t ndef_uri_match_prefix(const char** uri_io) {
+    const char* uri = *uri_io;
+    for(size_t i = 0; i < sizeof(ndef_uri_prefixes) / sizeof(ndef_uri_prefixes[0]); i++) {
+        size_t plen = strlen(ndef_uri_prefixes[i].prefix);
+        if(strncmp(uri, ndef_uri_prefixes[i].prefix, plen) == 0) {
+            *uri_io = uri + plen;
+            return ndef_uri_prefixes[i].code;
+        }
+    }
+    return 0x00; // No prefix; URI is written verbatim
+}
+
+// Wrap a built NDEF message body (header + record bytes) with the TLV envelope
+// (0x03, length, body, 0xFE). For length < 0xFF we use the short form (1 byte);
+// otherwise the long form (0xFF + 2 bytes big-endian).
+//
+// `body` already lives in `out` at offset `body_start`. We shift it forward as
+// needed and write the TLV header/terminator around it. Returns total size.
+static bool ndef_tlv_wrap(
+    uint8_t* out,
+    size_t out_capacity,
+    size_t body_start,
+    size_t body_len,
+    size_t* out_size) {
+    size_t header_len = (body_len < 0xFF) ? 2 : 4;
+    size_t total = header_len + body_len + 1; // +1 terminator
+    if(total > out_capacity) return false;
+
+    // If body isn't already at header_len, shift it.
+    if(body_start != header_len) {
+        memmove(out + header_len, out + body_start, body_len);
+    }
+
+    out[0] = NDEF_TLV_MESSAGE;
+    if(body_len < 0xFF) {
+        out[1] = (uint8_t)body_len;
+    } else {
+        out[1] = 0xFF;
+        out[2] = (uint8_t)(body_len >> 8);
+        out[3] = (uint8_t)(body_len & 0xFF);
+    }
+    out[header_len + body_len] = NDEF_TLV_TERMINATOR;
+    *out_size = total;
+    return true;
+}
+
+bool ndef_builder_build_uri(
+    const char* uri,
+    uint8_t* out,
+    size_t out_capacity,
+    size_t* out_size) {
+    if(!uri || !out || !out_size) return false;
+
+    const char* uri_body = uri;
+    uint8_t prefix_code = ndef_uri_match_prefix(&uri_body);
+    size_t uri_body_len = strlen(uri_body);
+    size_t payload_len = 1 + uri_body_len; // 1 byte prefix code + URI string
+
+    // Record layout: [hdr][type_len][payload_len][type='U'][prefix_code][uri_body]
+    // = 4 header bytes + 1 type + payload_len
+    size_t record_len = 4 + 1 + payload_len;
+
+    // Reserve space at the start for the TLV header (worst case 4 bytes).
+    // We always write the body starting at offset 4 and let tlv_wrap shift it
+    // down to offset 2 for the short-form case.
+    const size_t body_start = 4;
+    if(body_start + record_len + 1 > out_capacity) return false;
+
+    uint8_t* p = out + body_start;
+    *p++ = NDEF_MB | NDEF_ME | NDEF_SR | NDEF_TNF_WELL_KNOWN;
+    *p++ = 1; // Type length
+    *p++ = (uint8_t)payload_len;
+    *p++ = 'U';
+    *p++ = prefix_code;
+    memcpy(p, uri_body, uri_body_len);
+
+    return ndef_tlv_wrap(out, out_capacity, body_start, record_len, out_size);
+}
+
+bool ndef_builder_build_text(
+    const char* text,
+    uint8_t* out,
+    size_t out_capacity,
+    size_t* out_size) {
+    if(!text || !out || !out_size) return false;
+
+    static const char lang[] = "en";
+    const size_t lang_len = sizeof(lang) - 1;
+    const size_t text_len = strlen(text);
+    // Payload: [status_byte][lang_code][text]
+    // status_byte: bit7=0 (UTF-8), low 6 bits = lang code length
+    const size_t payload_len = 1 + lang_len + text_len;
+    if(payload_len > 0xFF) return false; // We only support short records
+
+    const size_t record_len = 4 + 1 + payload_len; // header + 'T' + payload
+    const size_t body_start = 4;
+    if(body_start + record_len + 1 > out_capacity) return false;
+
+    uint8_t* p = out + body_start;
+    *p++ = NDEF_MB | NDEF_ME | NDEF_SR | NDEF_TNF_WELL_KNOWN;
+    *p++ = 1; // Type length
+    *p++ = (uint8_t)payload_len;
+    *p++ = 'T';
+    *p++ = (uint8_t)lang_len; // status byte (UTF-8, lang length)
+    memcpy(p, lang, lang_len);
+    p += lang_len;
+    memcpy(p, text, text_len);
+
+    return ndef_tlv_wrap(out, out_capacity, body_start, record_len, out_size);
+}
+
+// WPS attribute IDs (big-endian on the wire)
+#define WPS_ATTR_CREDENTIAL       0x100E
+#define WPS_ATTR_NETWORK_INDEX    0x1026
+#define WPS_ATTR_SSID             0x1045
+#define WPS_ATTR_AUTH_TYPE        0x1003
+#define WPS_ATTR_ENCRYPT_TYPE     0x100F
+#define WPS_ATTR_NETWORK_KEY      0x1027
+#define WPS_ATTR_MAC_ADDRESS      0x1020
+
+#define WPS_AUTH_WPA2_PSK         0x0020
+#define WPS_ENCRYPT_AES           0x0008
+
+static uint8_t* wps_put_u8(uint8_t* p, uint16_t attr, uint8_t value) {
+    *p++ = (uint8_t)(attr >> 8);
+    *p++ = (uint8_t)(attr & 0xFF);
+    *p++ = 0x00;
+    *p++ = 0x01;
+    *p++ = value;
+    return p;
+}
+
+static uint8_t* wps_put_u16(uint8_t* p, uint16_t attr, uint16_t value) {
+    *p++ = (uint8_t)(attr >> 8);
+    *p++ = (uint8_t)(attr & 0xFF);
+    *p++ = 0x00;
+    *p++ = 0x02;
+    *p++ = (uint8_t)(value >> 8);
+    *p++ = (uint8_t)(value & 0xFF);
+    return p;
+}
+
+static uint8_t* wps_put_bytes(uint8_t* p, uint16_t attr, const uint8_t* data, uint16_t len) {
+    *p++ = (uint8_t)(attr >> 8);
+    *p++ = (uint8_t)(attr & 0xFF);
+    *p++ = (uint8_t)(len >> 8);
+    *p++ = (uint8_t)(len & 0xFF);
+    memcpy(p, data, len);
+    return p + len;
+}
+
+bool ndef_builder_build_wifi_wpa2(
+    const char* ssid,
+    const char* password,
+    uint8_t* out,
+    size_t out_capacity,
+    size_t* out_size) {
+    if(!ssid || !password || !out || !out_size) return false;
+
+    size_t ssid_len = strlen(ssid);
+    size_t pass_len = strlen(password);
+    if(ssid_len == 0 || ssid_len > 32) return false;
+    if(pass_len == 0 || pass_len > 63) return false;
+
+    // Inner credential payload size:
+    // Network Index TLV (5) + SSID TLV (4 + ssid_len) +
+    // Auth Type TLV (6) + Encrypt Type TLV (6) + Network Key TLV (4 + pass_len) +
+    // MAC Address TLV (4 + 6) = 35 + ssid_len + pass_len
+    size_t cred_len = 5 + (4 + ssid_len) + 6 + 6 + (4 + pass_len) + (4 + 6);
+
+    // Outer Credential TLV: 4 byte header + cred_len
+    size_t payload_len = 4 + cred_len;
+    if(payload_len > 0xFF) return false;
+
+    static const char mime[] = "application/vnd.wfa.wsc";
+    const size_t mime_len = sizeof(mime) - 1;
+
+    // Record layout: [hdr][type_len][payload_len][mime...][payload]
+    size_t record_len = 1 + 1 + 1 + mime_len + payload_len;
+
+    const size_t body_start = 4;
+    if(body_start + record_len + 1 > out_capacity) return false;
+
+    uint8_t* p = out + body_start;
+    *p++ = NDEF_MB | NDEF_ME | NDEF_SR | NDEF_TNF_MIME_MEDIA;
+    *p++ = (uint8_t)mime_len;
+    *p++ = (uint8_t)payload_len;
+    memcpy(p, mime, mime_len);
+    p += mime_len;
+
+    // Outer Credential TLV header
+    *p++ = (uint8_t)(WPS_ATTR_CREDENTIAL >> 8);
+    *p++ = (uint8_t)(WPS_ATTR_CREDENTIAL & 0xFF);
+    *p++ = (uint8_t)(cred_len >> 8);
+    *p++ = (uint8_t)(cred_len & 0xFF);
+
+    p = wps_put_u8(p, WPS_ATTR_NETWORK_INDEX, 0x01);
+    p = wps_put_bytes(p, WPS_ATTR_SSID, (const uint8_t*)ssid, (uint16_t)ssid_len);
+    p = wps_put_u16(p, WPS_ATTR_AUTH_TYPE, WPS_AUTH_WPA2_PSK);
+    p = wps_put_u16(p, WPS_ATTR_ENCRYPT_TYPE, WPS_ENCRYPT_AES);
+    p = wps_put_bytes(p, WPS_ATTR_NETWORK_KEY, (const uint8_t*)password, (uint16_t)pass_len);
+    static const uint8_t bcast_mac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+    p = wps_put_bytes(p, WPS_ATTR_MAC_ADDRESS, bcast_mac, 6);
+
+    return ndef_tlv_wrap(out, out_capacity, body_start, record_len, out_size);
+}

--- a/applications/main/nfc/helpers/ndef_builder.c
+++ b/applications/main/nfc/helpers/ndef_builder.c
@@ -105,9 +105,9 @@ bool ndef_builder_build_uri(const char* uri, uint8_t* out, size_t out_capacity, 
     size_t uri_body_len = strlen(uri_body);
     size_t payload_len = 1 + uri_body_len; // 1 byte prefix code + URI string
 
-    // Record layout: [hdr][type_len][payload_len][type='U'][prefix_code][uri_body]
-    // = 4 header bytes + 1 type + payload_len
-    size_t record_len = 4 + 1 + payload_len;
+    // Record layout: [flags][type_len][payload_len][type='U'][prefix_code][uri_body]
+    // = 3 header bytes (SR record, no ID) + 1 type byte + payload_len bytes
+    size_t record_len = 3 + 1 + payload_len;
 
     // Reserve space at the start for the TLV header (worst case 4 bytes).
     // We always write the body starting at offset 4 and let tlv_wrap shift it
@@ -137,7 +137,7 @@ bool ndef_builder_build_text(const char* text, uint8_t* out, size_t out_capacity
     const size_t payload_len = 1 + lang_len + text_len;
     if(payload_len > 0xFF) return false; // We only support short records
 
-    const size_t record_len = 4 + 1 + payload_len; // header + 'T' + payload
+    const size_t record_len = 3 + 1 + payload_len; // 3 hdr bytes + 'T' + payload
     const size_t body_start = 4;
     if(body_start + record_len + 1 > out_capacity) return false;
 

--- a/applications/main/nfc/helpers/ndef_builder.h
+++ b/applications/main/nfc/helpers/ndef_builder.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Maximum NDEF blob size we will produce — fits comfortably in NTAG216 (888 user bytes). */
+#define NDEF_BUILDER_MAX_SIZE 800
+
+/**
+ * Build a complete NDEF Message TLV (0x03 .. 0xFE terminator) for a URI/URL record.
+ *
+ * Common prefixes (http://, https://, tel:, mailto: …) are encoded as a one-byte
+ * URI identifier code per the NFC Forum URI RTD, so they don't take payload space.
+ *
+ * @param uri               null-terminated input string
+ * @param out               destination buffer
+ * @param out_capacity      destination capacity in bytes
+ * @param out_size          on success, set to the number of bytes written
+ * @return                  true if the blob fit; false otherwise
+ */
+bool ndef_builder_build_uri(
+    const char* uri,
+    uint8_t* out,
+    size_t out_capacity,
+    size_t* out_size);
+
+/**
+ * Build a complete NDEF Message TLV for a plain Text record (UTF-8, language code "en").
+ */
+bool ndef_builder_build_text(
+    const char* text,
+    uint8_t* out,
+    size_t out_capacity,
+    size_t* out_size);
+
+/**
+ * Build a complete NDEF Message TLV for a Wi-Fi Simple Configuration credential
+ * (WPS Credential, application/vnd.wfa.wsc) using WPA2-PSK / AES.
+ *
+ * @param ssid       null-terminated SSID
+ * @param password   null-terminated passphrase (8..63 chars typical)
+ */
+bool ndef_builder_build_wifi_wpa2(
+    const char* ssid,
+    const char* password,
+    uint8_t* out,
+    size_t out_capacity,
+    size_t* out_size);
+
+#ifdef __cplusplus
+}
+#endif

--- a/applications/main/nfc/helpers/ndef_builder.h
+++ b/applications/main/nfc/helpers/ndef_builder.h
@@ -23,20 +23,12 @@ extern "C" {
  * @param out_size          on success, set to the number of bytes written
  * @return                  true if the blob fit; false otherwise
  */
-bool ndef_builder_build_uri(
-    const char* uri,
-    uint8_t* out,
-    size_t out_capacity,
-    size_t* out_size);
+bool ndef_builder_build_uri(const char* uri, uint8_t* out, size_t out_capacity, size_t* out_size);
 
 /**
  * Build a complete NDEF Message TLV for a plain Text record (UTF-8, language code "en").
  */
-bool ndef_builder_build_text(
-    const char* text,
-    uint8_t* out,
-    size_t out_capacity,
-    size_t* out_size);
+bool ndef_builder_build_text(const char* text, uint8_t* out, size_t out_capacity, size_t* out_size);
 
 /**
  * Build a complete NDEF Message TLV for a Wi-Fi Simple Configuration credential

--- a/applications/main/nfc/nfc_app.c
+++ b/applications/main/nfc/nfc_app.c
@@ -97,6 +97,13 @@ NfcApp* nfc_app_alloc(void) {
     view_dispatcher_add_view(
         instance->view_dispatcher, NfcViewTextInput, text_input_get_view(instance->text_input));
 
+    // NDEF Text Input (extended keyboard with punctuation)
+    instance->ndef_text_input = ndef_text_input_alloc();
+    view_dispatcher_add_view(
+        instance->view_dispatcher,
+        NfcViewNdefTextInput,
+        ndef_text_input_get_view(instance->ndef_text_input));
+
     // Byte Input
     instance->byte_input = byte_input_alloc();
     view_dispatcher_add_view(
@@ -128,6 +135,9 @@ NfcApp* nfc_app_alloc(void) {
     instance->iso14443_3a_edit_data = iso14443_3a_alloc();
     instance->file_path = furi_string_alloc_set(NFC_APP_FOLDER);
     instance->file_name = furi_string_alloc();
+
+    instance->ndef_write.primary = furi_string_alloc();
+    instance->ndef_write.secondary = furi_string_alloc();
 
     return instance;
 }
@@ -172,6 +182,10 @@ void nfc_app_free(NfcApp* instance) {
     view_dispatcher_remove_view(instance->view_dispatcher, NfcViewTextInput);
     text_input_free(instance->text_input);
 
+    // NDEF Text Input
+    view_dispatcher_remove_view(instance->view_dispatcher, NfcViewNdefTextInput);
+    ndef_text_input_free(instance->ndef_text_input);
+
     // ByteInput
     view_dispatcher_remove_view(instance->view_dispatcher, NfcViewByteInput);
     byte_input_free(instance->byte_input);
@@ -211,6 +225,9 @@ void nfc_app_free(NfcApp* instance) {
     iso14443_3a_free(instance->iso14443_3a_edit_data);
     furi_string_free(instance->file_path);
     furi_string_free(instance->file_name);
+
+    furi_string_free(instance->ndef_write.primary);
+    furi_string_free(instance->ndef_write.secondary);
 
     free(instance);
 }

--- a/applications/main/nfc/nfc_app_i.h
+++ b/applications/main/nfc/nfc_app_i.h
@@ -23,6 +23,7 @@
 #include "views/dict_attack.h"
 #include "views/detect_reader.h"
 #include "views/dict_attack.h"
+#include "views/ndef_text_input.h"
 
 #include <nfc/scenes/nfc_scene.h>
 #include "helpers/nfc_detected_protocols.h"
@@ -34,6 +35,7 @@
 #include "helpers/nfc_supported_cards.h"
 #include "helpers/felica_auth.h"
 #include "helpers/slix_unlock.h"
+#include "helpers/mf_ultralight_ndef.h"
 
 #include <loader/loader.h>
 #include <dialogs/dialogs.h>
@@ -120,6 +122,27 @@ typedef struct {
     size_t dict_keys_current;
 } NfcMfUltralightCDictContext;
 
+typedef enum {
+    NdefWriteRecordTypeUri,
+    NdefWriteRecordTypeEmail,
+    NdefWriteRecordTypePhone,
+    NdefWriteRecordTypeText,
+    NdefWriteRecordTypeWifi,
+} NdefWriteRecordType;
+
+typedef enum {
+    NdefWriteInputStepPrimary, // URL / Text / SSID
+    NdefWriteInputStepSecondary, // Wi-Fi password
+} NdefWriteInputStep;
+
+typedef struct {
+    NdefWriteRecordType record_type;
+    NdefWriteInputStep input_step;
+    NdefNtagType ntag_type;
+    FuriString* primary; // URL, Text, or SSID depending on record_type
+    FuriString* secondary; // Wi-Fi password (unused for URI/Text)
+} NdefWriteContext;
+
 struct NfcApp {
     DialogsApp* dialogs;
     Storage* storage;
@@ -143,6 +166,7 @@ struct NfcApp {
     Popup* popup;
     Loading* loading;
     TextInput* text_input;
+    NdefTextInput* ndef_text_input;
     ByteInput* byte_input;
     TextBox* text_box;
     Widget* widget;
@@ -169,6 +193,8 @@ struct NfcApp {
     FuriString* file_path;
     FuriString* file_name;
     FuriTimer* timer;
+
+    NdefWriteContext ndef_write;
 };
 
 typedef enum {
@@ -182,6 +208,7 @@ typedef enum {
     NfcViewWidget,
     NfcViewDictAttack,
     NfcViewDetectReader,
+    NfcViewNdefTextInput,
 } NfcView;
 
 typedef enum {

--- a/applications/main/nfc/scenes/nfc_scene_config.h
+++ b/applications/main/nfc/scenes/nfc_scene_config.h
@@ -25,6 +25,11 @@ ADD_SCENE(nfc, retry_confirm, RetryConfirm)
 ADD_SCENE(nfc, exit_confirm, ExitConfirm)
 ADD_SCENE(nfc, save_confirm, SaveConfirm)
 
+ADD_SCENE(nfc, write_ndef_type, WriteNdefType)
+ADD_SCENE(nfc, write_ndef_input, WriteNdefInput)
+ADD_SCENE(nfc, write_ndef_tag, WriteNdefTag)
+ADD_SCENE(nfc, write_ndef, WriteNdef)
+
 ADD_SCENE(nfc, mf_ultralight_c_dict_attack, MfUltralightCDictAttack)
 ADD_SCENE(nfc, mf_ultralight_write, MfUltralightWrite)
 ADD_SCENE(nfc, mf_ultralight_write_success, MfUltralightWriteSuccess)

--- a/applications/main/nfc/scenes/nfc_scene_extra_actions.c
+++ b/applications/main/nfc/scenes/nfc_scene_extra_actions.c
@@ -6,6 +6,7 @@ enum SubmenuIndex {
     SubmenuIndexMfUltralightCKeys,
     SubmenuIndexMfUltralightUnlock,
     SubmenuIndexSlixUnlock,
+    SubmenuIndexWriteNdef,
 };
 
 void nfc_scene_extra_actions_submenu_callback(void* context, uint32_t index) {
@@ -48,6 +49,12 @@ void nfc_scene_extra_actions_on_enter(void* context) {
         SubmenuIndexSlixUnlock,
         nfc_scene_extra_actions_submenu_callback,
         instance);
+    submenu_add_item(
+        submenu,
+        "Write NDEF Tag",
+        SubmenuIndexWriteNdef,
+        nfc_scene_extra_actions_submenu_callback,
+        instance);
     submenu_set_selected_item(
         submenu, scene_manager_get_scene_state(instance->scene_manager, NfcSceneExtraActions));
     view_dispatcher_switch_to_view(instance->view_dispatcher, NfcViewMenu);
@@ -73,6 +80,9 @@ bool nfc_scene_extra_actions_on_event(void* context, SceneManagerEvent event) {
             consumed = true;
         } else if(event.event == SubmenuIndexSlixUnlock) {
             scene_manager_next_scene(instance->scene_manager, NfcSceneSlixUnlockMenu);
+            consumed = true;
+        } else if(event.event == SubmenuIndexWriteNdef) {
+            scene_manager_next_scene(instance->scene_manager, NfcSceneWriteNdefType);
             consumed = true;
         }
         scene_manager_set_scene_state(instance->scene_manager, NfcSceneExtraActions, event.event);

--- a/applications/main/nfc/scenes/nfc_scene_write_ndef.c
+++ b/applications/main/nfc/scenes/nfc_scene_write_ndef.c
@@ -1,0 +1,220 @@
+#include "../nfc_app_i.h"
+#include "../helpers/ndef_builder.h"
+
+#include <nfc/protocols/mf_ultralight/mf_ultralight_poller.h>
+
+typedef enum {
+    NfcSceneWriteNdefStateSearch,
+    NfcSceneWriteNdefStateWriting,
+    NfcSceneWriteNdefStateSuccess,
+    NfcSceneWriteNdefStateFail,
+    NfcSceneWriteNdefStateWrongCard,
+} NfcSceneWriteNdefState;
+
+static NfcCommand nfc_scene_write_ndef_worker_callback(NfcGenericEvent event, void* context) {
+    furi_assert(context);
+    furi_assert(event.event_data);
+    furi_assert(event.protocol == NfcProtocolMfUltralight);
+
+    NfcCommand command = NfcCommandContinue;
+    NfcApp* instance = context;
+    MfUltralightPollerEvent* mfu_event = event.event_data;
+
+    if(mfu_event->type == MfUltralightPollerEventTypeRequestMode) {
+        mfu_event->data->poller_mode = MfUltralightPollerModeWrite;
+        view_dispatcher_send_custom_event(instance->view_dispatcher, NfcCustomEventCardDetected);
+    } else if(mfu_event->type == MfUltralightPollerEventTypeAuthRequest) {
+        mfu_event->data->auth_context.skip_auth = true;
+    } else if(mfu_event->type == MfUltralightPollerEventTypeRequestWriteData) {
+        mfu_event->data->write_data =
+            nfc_device_get_data(instance->nfc_device, NfcProtocolMfUltralight);
+    } else if(mfu_event->type == MfUltralightPollerEventTypeCardMismatch) {
+        view_dispatcher_send_custom_event(instance->view_dispatcher, NfcCustomEventWrongCard);
+        command = NfcCommandStop;
+    } else if(mfu_event->type == MfUltralightPollerEventTypeCardLocked) {
+        view_dispatcher_send_custom_event(instance->view_dispatcher, NfcCustomEventPollerFailure);
+        command = NfcCommandStop;
+    } else if(mfu_event->type == MfUltralightPollerEventTypeWriteFail) {
+        view_dispatcher_send_custom_event(instance->view_dispatcher, NfcCustomEventPollerFailure);
+        command = NfcCommandStop;
+    } else if(mfu_event->type == MfUltralightPollerEventTypeWriteSuccess) {
+        view_dispatcher_send_custom_event(instance->view_dispatcher, NfcCustomEventPollerSuccess);
+        command = NfcCommandStop;
+    }
+    return command;
+}
+
+static void nfc_scene_write_ndef_popup_callback(void* context) {
+    NfcApp* instance = context;
+    view_dispatcher_send_custom_event(instance->view_dispatcher, NfcCustomEventViewExit);
+}
+
+static void nfc_scene_write_ndef_setup_view(NfcApp* instance) {
+    Popup* popup = instance->popup;
+    popup_reset(popup);
+    uint32_t state = scene_manager_get_scene_state(instance->scene_manager, NfcSceneWriteNdef);
+
+    if(state == NfcSceneWriteNdefStateSearch) {
+        popup_set_header(popup, "Writing", 95, 20, AlignCenter, AlignCenter);
+        popup_set_text(popup, "Apply the\ntarget tag", 95, 38, AlignCenter, AlignCenter);
+        popup_set_icon(popup, 0, 8, &I_NFC_manual_60x50);
+    } else if(state == NfcSceneWriteNdefStateWriting) {
+        popup_set_header(popup, "Writing\nDon't move...", 52, 32, AlignLeft, AlignCenter);
+        popup_set_icon(popup, 12, 23, &A_Loading_24);
+    } else if(state == NfcSceneWriteNdefStateSuccess) {
+        notification_message(instance->notifications, &sequence_success);
+        popup_set_icon(popup, 48, 6, &I_DolphinDone_80x58);
+        popup_set_header(popup, "Successfully\nwritten", 5, 22, AlignLeft, AlignBottom);
+        popup_set_timeout(popup, 1500);
+        popup_set_context(popup, instance);
+        popup_set_callback(popup, nfc_scene_write_ndef_popup_callback);
+        popup_enable_timeout(popup);
+    } else if(state == NfcSceneWriteNdefStateFail) {
+        notification_message(instance->notifications, &sequence_error);
+        popup_set_icon(popup, 72, 17, &I_WarningDolphinFlip_45x42);
+        popup_set_header(popup, "Write failed", 64, 4, AlignCenter, AlignTop);
+        popup_set_text(
+            popup,
+            "Tag may be\nlocked or moved",
+            8,
+            22,
+            AlignLeft,
+            AlignTop);
+        popup_set_timeout(popup, 2000);
+        popup_set_context(popup, instance);
+        popup_set_callback(popup, nfc_scene_write_ndef_popup_callback);
+        popup_enable_timeout(popup);
+    } else if(state == NfcSceneWriteNdefStateWrongCard) {
+        notification_message(instance->notifications, &sequence_error);
+        popup_set_icon(popup, 72, 17, &I_WarningDolphinFlip_45x42);
+        popup_set_header(popup, "Wrong tag type", 64, 4, AlignCenter, AlignTop);
+        popup_set_text(
+            popup,
+            "Use selected\nNTAG variant",
+            8,
+            22,
+            AlignLeft,
+            AlignTop);
+        popup_set_timeout(popup, 2000);
+        popup_set_context(popup, instance);
+        popup_set_callback(popup, nfc_scene_write_ndef_popup_callback);
+        popup_enable_timeout(popup);
+    }
+
+    view_dispatcher_switch_to_view(instance->view_dispatcher, NfcViewPopup);
+}
+
+static bool nfc_scene_write_ndef_build_payload(NfcApp* instance) {
+    NdefWriteContext* ctx = &instance->ndef_write;
+    uint8_t blob[NDEF_BUILDER_MAX_SIZE];
+    size_t blob_size = 0;
+    bool built = false;
+
+    switch(ctx->record_type) {
+    case NdefWriteRecordTypeUri:
+        built = ndef_builder_build_uri(
+            furi_string_get_cstr(ctx->primary), blob, sizeof(blob), &blob_size);
+        break;
+    case NdefWriteRecordTypeEmail: {
+        // mailto: prefix is in the URI prefix table (code 0x06), so the builder
+        // strips it from the on-tag payload automatically.
+        FuriString* uri = furi_string_alloc_printf(
+            "mailto:%s", furi_string_get_cstr(ctx->primary));
+        built = ndef_builder_build_uri(furi_string_get_cstr(uri), blob, sizeof(blob), &blob_size);
+        furi_string_free(uri);
+        break;
+    }
+    case NdefWriteRecordTypePhone: {
+        // tel: prefix is in the URI prefix table (code 0x05).
+        FuriString* uri = furi_string_alloc_printf(
+            "tel:%s", furi_string_get_cstr(ctx->primary));
+        built = ndef_builder_build_uri(furi_string_get_cstr(uri), blob, sizeof(blob), &blob_size);
+        furi_string_free(uri);
+        break;
+    }
+    case NdefWriteRecordTypeText:
+        built = ndef_builder_build_text(
+            furi_string_get_cstr(ctx->primary), blob, sizeof(blob), &blob_size);
+        break;
+    case NdefWriteRecordTypeWifi:
+        built = ndef_builder_build_wifi_wpa2(
+            furi_string_get_cstr(ctx->primary),
+            furi_string_get_cstr(ctx->secondary),
+            blob,
+            sizeof(blob),
+            &blob_size);
+        break;
+    }
+
+    if(!built) return false;
+    return mf_ultralight_ndef_fill_device(instance->nfc_device, ctx->ntag_type, blob, blob_size);
+}
+
+void nfc_scene_write_ndef_on_enter(void* context) {
+    NfcApp* instance = context;
+    dolphin_deed(DolphinDeedNfcEmulate);
+
+    if(!nfc_scene_write_ndef_build_payload(instance)) {
+        scene_manager_set_scene_state(
+            instance->scene_manager, NfcSceneWriteNdef, NfcSceneWriteNdefStateFail);
+        nfc_scene_write_ndef_setup_view(instance);
+        return;
+    }
+
+    scene_manager_set_scene_state(
+        instance->scene_manager, NfcSceneWriteNdef, NfcSceneWriteNdefStateSearch);
+    nfc_scene_write_ndef_setup_view(instance);
+
+    instance->poller = nfc_poller_alloc(instance->nfc, NfcProtocolMfUltralight);
+    nfc_poller_start(instance->poller, nfc_scene_write_ndef_worker_callback, instance);
+
+    nfc_blink_emulate_start(instance);
+}
+
+bool nfc_scene_write_ndef_on_event(void* context, SceneManagerEvent event) {
+    NfcApp* instance = context;
+    bool consumed = false;
+
+    if(event.type == SceneManagerEventTypeCustom) {
+        if(event.event == NfcCustomEventCardDetected) {
+            scene_manager_set_scene_state(
+                instance->scene_manager, NfcSceneWriteNdef, NfcSceneWriteNdefStateWriting);
+            nfc_scene_write_ndef_setup_view(instance);
+            consumed = true;
+        } else if(event.event == NfcCustomEventWrongCard) {
+            scene_manager_set_scene_state(
+                instance->scene_manager, NfcSceneWriteNdef, NfcSceneWriteNdefStateWrongCard);
+            nfc_scene_write_ndef_setup_view(instance);
+            consumed = true;
+        } else if(event.event == NfcCustomEventPollerSuccess) {
+            scene_manager_set_scene_state(
+                instance->scene_manager, NfcSceneWriteNdef, NfcSceneWriteNdefStateSuccess);
+            nfc_scene_write_ndef_setup_view(instance);
+            consumed = true;
+        } else if(event.event == NfcCustomEventPollerFailure) {
+            scene_manager_set_scene_state(
+                instance->scene_manager, NfcSceneWriteNdef, NfcSceneWriteNdefStateFail);
+            nfc_scene_write_ndef_setup_view(instance);
+            consumed = true;
+        } else if(event.event == NfcCustomEventViewExit) {
+            consumed = scene_manager_search_and_switch_to_previous_scene(
+                instance->scene_manager, NfcSceneStart);
+        }
+    }
+    return consumed;
+}
+
+void nfc_scene_write_ndef_on_exit(void* context) {
+    NfcApp* instance = context;
+
+    if(instance->poller) {
+        nfc_poller_stop(instance->poller);
+        nfc_poller_free(instance->poller);
+        instance->poller = NULL;
+    }
+
+    scene_manager_set_scene_state(
+        instance->scene_manager, NfcSceneWriteNdef, NfcSceneWriteNdefStateSearch);
+    popup_reset(instance->popup);
+    nfc_blink_stop(instance);
+}

--- a/applications/main/nfc/scenes/nfc_scene_write_ndef.c
+++ b/applications/main/nfc/scenes/nfc_scene_write_ndef.c
@@ -154,6 +154,10 @@ void nfc_scene_write_ndef_on_enter(void* context) {
     NfcApp* instance = context;
     dolphin_deed(DolphinDeedNfcEmulate);
 
+    // Clear any stale poller pointer left by a previous scene so on_exit can
+    // tell whether *this* scene allocated one.
+    instance->poller = NULL;
+
     if(!nfc_scene_write_ndef_build_payload(instance)) {
         scene_manager_set_scene_state(
             instance->scene_manager, NfcSceneWriteNdef, NfcSceneWriteNdefStateFail);

--- a/applications/main/nfc/scenes/nfc_scene_write_ndef.c
+++ b/applications/main/nfc/scenes/nfc_scene_write_ndef.c
@@ -73,13 +73,7 @@ static void nfc_scene_write_ndef_setup_view(NfcApp* instance) {
         notification_message(instance->notifications, &sequence_error);
         popup_set_icon(popup, 72, 17, &I_WarningDolphinFlip_45x42);
         popup_set_header(popup, "Write failed", 64, 4, AlignCenter, AlignTop);
-        popup_set_text(
-            popup,
-            "Tag may be\nlocked or moved",
-            8,
-            22,
-            AlignLeft,
-            AlignTop);
+        popup_set_text(popup, "Tag may be\nlocked or moved", 8, 22, AlignLeft, AlignTop);
         popup_set_timeout(popup, 2000);
         popup_set_context(popup, instance);
         popup_set_callback(popup, nfc_scene_write_ndef_popup_callback);
@@ -88,13 +82,7 @@ static void nfc_scene_write_ndef_setup_view(NfcApp* instance) {
         notification_message(instance->notifications, &sequence_error);
         popup_set_icon(popup, 72, 17, &I_WarningDolphinFlip_45x42);
         popup_set_header(popup, "Wrong tag type", 64, 4, AlignCenter, AlignTop);
-        popup_set_text(
-            popup,
-            "Use selected\nNTAG variant",
-            8,
-            22,
-            AlignLeft,
-            AlignTop);
+        popup_set_text(popup, "Use selected\nNTAG variant", 8, 22, AlignLeft, AlignTop);
         popup_set_timeout(popup, 2000);
         popup_set_context(popup, instance);
         popup_set_callback(popup, nfc_scene_write_ndef_popup_callback);
@@ -118,16 +106,15 @@ static bool nfc_scene_write_ndef_build_payload(NfcApp* instance) {
     case NdefWriteRecordTypeEmail: {
         // mailto: prefix is in the URI prefix table (code 0x06), so the builder
         // strips it from the on-tag payload automatically.
-        FuriString* uri = furi_string_alloc_printf(
-            "mailto:%s", furi_string_get_cstr(ctx->primary));
+        FuriString* uri =
+            furi_string_alloc_printf("mailto:%s", furi_string_get_cstr(ctx->primary));
         built = ndef_builder_build_uri(furi_string_get_cstr(uri), blob, sizeof(blob), &blob_size);
         furi_string_free(uri);
         break;
     }
     case NdefWriteRecordTypePhone: {
         // tel: prefix is in the URI prefix table (code 0x05).
-        FuriString* uri = furi_string_alloc_printf(
-            "tel:%s", furi_string_get_cstr(ctx->primary));
+        FuriString* uri = furi_string_alloc_printf("tel:%s", furi_string_get_cstr(ctx->primary));
         built = ndef_builder_build_uri(furi_string_get_cstr(uri), blob, sizeof(blob), &blob_size);
         furi_string_free(uri);
         break;

--- a/applications/main/nfc/scenes/nfc_scene_write_ndef_input.c
+++ b/applications/main/nfc/scenes/nfc_scene_write_ndef_input.c
@@ -38,10 +38,9 @@ void nfc_scene_write_ndef_input_on_enter(void* context) {
 
     // Seed buffer with prior value (if any) or scheme hint
     memset(instance->text_store, 0, sizeof(instance->text_store));
-    const char* prior =
-        (instance->ndef_write.input_step == NdefWriteInputStepPrimary) ?
-            furi_string_get_cstr(instance->ndef_write.primary) :
-            furi_string_get_cstr(instance->ndef_write.secondary);
+    const char* prior = (instance->ndef_write.input_step == NdefWriteInputStepPrimary) ?
+                            furi_string_get_cstr(instance->ndef_write.primary) :
+                            furi_string_get_cstr(instance->ndef_write.secondary);
     if(prior && prior[0] != '\0') {
         strlcpy(instance->text_store, prior, sizeof(instance->text_store));
     } else if(seed) {
@@ -72,11 +71,9 @@ bool nfc_scene_write_ndef_input_on_event(void* context, SceneManagerEvent event)
                 if(ctx->record_type == NdefWriteRecordTypeWifi) {
                     // Wi-Fi needs a second prompt for the password.
                     ctx->input_step = NdefWriteInputStepSecondary;
-                    scene_manager_next_scene(
-                        instance->scene_manager, NfcSceneWriteNdefInput);
+                    scene_manager_next_scene(instance->scene_manager, NfcSceneWriteNdefInput);
                 } else {
-                    scene_manager_next_scene(
-                        instance->scene_manager, NfcSceneWriteNdefTag);
+                    scene_manager_next_scene(instance->scene_manager, NfcSceneWriteNdefTag);
                 }
             } else {
                 furi_string_set(ctx->secondary, instance->text_store);

--- a/applications/main/nfc/scenes/nfc_scene_write_ndef_input.c
+++ b/applications/main/nfc/scenes/nfc_scene_write_ndef_input.c
@@ -1,0 +1,94 @@
+#include "../nfc_app_i.h"
+
+static void nfc_scene_write_ndef_input_callback(void* context) {
+    NfcApp* instance = context;
+    view_dispatcher_send_custom_event(instance->view_dispatcher, NfcCustomEventTextInputDone);
+}
+
+void nfc_scene_write_ndef_input_on_enter(void* context) {
+    NfcApp* instance = context;
+    NdefTextInput* text_input = instance->ndef_text_input;
+
+    const char* header = "Enter value";
+    const char* seed = NULL;
+
+    if(instance->ndef_write.input_step == NdefWriteInputStepPrimary) {
+        switch(instance->ndef_write.record_type) {
+        case NdefWriteRecordTypeUri:
+            header = "Enter URL";
+            seed = "https://";
+            break;
+        case NdefWriteRecordTypeEmail:
+            header = "Enter email address";
+            break;
+        case NdefWriteRecordTypePhone:
+            header = "Enter phone number";
+            seed = "+";
+            break;
+        case NdefWriteRecordTypeText:
+            header = "Enter text";
+            break;
+        case NdefWriteRecordTypeWifi:
+            header = "Enter Wi-Fi SSID";
+            break;
+        }
+    } else {
+        header = "Enter Wi-Fi password";
+    }
+
+    // Seed buffer with prior value (if any) or scheme hint
+    memset(instance->text_store, 0, sizeof(instance->text_store));
+    const char* prior =
+        (instance->ndef_write.input_step == NdefWriteInputStepPrimary) ?
+            furi_string_get_cstr(instance->ndef_write.primary) :
+            furi_string_get_cstr(instance->ndef_write.secondary);
+    if(prior && prior[0] != '\0') {
+        strlcpy(instance->text_store, prior, sizeof(instance->text_store));
+    } else if(seed) {
+        strlcpy(instance->text_store, seed, sizeof(instance->text_store));
+    }
+
+    ndef_text_input_set_header_text(text_input, header);
+    ndef_text_input_set_result_callback(
+        text_input,
+        nfc_scene_write_ndef_input_callback,
+        instance,
+        instance->text_store,
+        sizeof(instance->text_store),
+        false);
+
+    view_dispatcher_switch_to_view(instance->view_dispatcher, NfcViewNdefTextInput);
+}
+
+bool nfc_scene_write_ndef_input_on_event(void* context, SceneManagerEvent event) {
+    NfcApp* instance = context;
+    bool consumed = false;
+
+    if(event.type == SceneManagerEventTypeCustom) {
+        if(event.event == NfcCustomEventTextInputDone) {
+            NdefWriteContext* ctx = &instance->ndef_write;
+            if(ctx->input_step == NdefWriteInputStepPrimary) {
+                furi_string_set(ctx->primary, instance->text_store);
+                if(ctx->record_type == NdefWriteRecordTypeWifi) {
+                    // Wi-Fi needs a second prompt for the password.
+                    ctx->input_step = NdefWriteInputStepSecondary;
+                    scene_manager_next_scene(
+                        instance->scene_manager, NfcSceneWriteNdefInput);
+                } else {
+                    scene_manager_next_scene(
+                        instance->scene_manager, NfcSceneWriteNdefTag);
+                }
+            } else {
+                furi_string_set(ctx->secondary, instance->text_store);
+                scene_manager_next_scene(instance->scene_manager, NfcSceneWriteNdefTag);
+            }
+            consumed = true;
+        }
+    }
+    return consumed;
+}
+
+void nfc_scene_write_ndef_input_on_exit(void* context) {
+    NfcApp* instance = context;
+    ndef_text_input_reset(instance->ndef_text_input);
+}

--- a/applications/main/nfc/scenes/nfc_scene_write_ndef_tag.c
+++ b/applications/main/nfc/scenes/nfc_scene_write_ndef_tag.c
@@ -17,14 +17,23 @@ void nfc_scene_write_ndef_tag_on_enter(void* context) {
 
     submenu_set_header(submenu, "Target tag type");
     submenu_add_item(
-        submenu, "NTAG213 (144 B)", SubmenuIndexNtag213,
-        nfc_scene_write_ndef_tag_submenu_callback, instance);
+        submenu,
+        "NTAG213 (144 B)",
+        SubmenuIndexNtag213,
+        nfc_scene_write_ndef_tag_submenu_callback,
+        instance);
     submenu_add_item(
-        submenu, "NTAG215 (504 B)", SubmenuIndexNtag215,
-        nfc_scene_write_ndef_tag_submenu_callback, instance);
+        submenu,
+        "NTAG215 (504 B)",
+        SubmenuIndexNtag215,
+        nfc_scene_write_ndef_tag_submenu_callback,
+        instance);
     submenu_add_item(
-        submenu, "NTAG216 (888 B)", SubmenuIndexNtag216,
-        nfc_scene_write_ndef_tag_submenu_callback, instance);
+        submenu,
+        "NTAG216 (888 B)",
+        SubmenuIndexNtag216,
+        nfc_scene_write_ndef_tag_submenu_callback,
+        instance);
 
     // Default selection: NTAG215
     uint32_t state = scene_manager_get_scene_state(instance->scene_manager, NfcSceneWriteNdefTag);
@@ -39,8 +48,7 @@ bool nfc_scene_write_ndef_tag_on_event(void* context, SceneManagerEvent event) {
 
     if(event.type == SceneManagerEventTypeCustom) {
         instance->ndef_write.ntag_type = (NdefNtagType)event.event;
-        scene_manager_set_scene_state(
-            instance->scene_manager, NfcSceneWriteNdefTag, event.event);
+        scene_manager_set_scene_state(instance->scene_manager, NfcSceneWriteNdefTag, event.event);
         scene_manager_next_scene(instance->scene_manager, NfcSceneWriteNdef);
         consumed = true;
     }

--- a/applications/main/nfc/scenes/nfc_scene_write_ndef_tag.c
+++ b/applications/main/nfc/scenes/nfc_scene_write_ndef_tag.c
@@ -1,0 +1,53 @@
+#include "../nfc_app_i.h"
+
+enum SubmenuIndex {
+    SubmenuIndexNtag213 = NdefNtagTypeNTAG213,
+    SubmenuIndexNtag215 = NdefNtagTypeNTAG215,
+    SubmenuIndexNtag216 = NdefNtagTypeNTAG216,
+};
+
+static void nfc_scene_write_ndef_tag_submenu_callback(void* context, uint32_t index) {
+    NfcApp* instance = context;
+    view_dispatcher_send_custom_event(instance->view_dispatcher, index);
+}
+
+void nfc_scene_write_ndef_tag_on_enter(void* context) {
+    NfcApp* instance = context;
+    Submenu* submenu = instance->submenu;
+
+    submenu_set_header(submenu, "Target tag type");
+    submenu_add_item(
+        submenu, "NTAG213 (144 B)", SubmenuIndexNtag213,
+        nfc_scene_write_ndef_tag_submenu_callback, instance);
+    submenu_add_item(
+        submenu, "NTAG215 (504 B)", SubmenuIndexNtag215,
+        nfc_scene_write_ndef_tag_submenu_callback, instance);
+    submenu_add_item(
+        submenu, "NTAG216 (888 B)", SubmenuIndexNtag216,
+        nfc_scene_write_ndef_tag_submenu_callback, instance);
+
+    // Default selection: NTAG215
+    uint32_t state = scene_manager_get_scene_state(instance->scene_manager, NfcSceneWriteNdefTag);
+    if(state == 0) state = SubmenuIndexNtag215;
+    submenu_set_selected_item(submenu, state);
+    view_dispatcher_switch_to_view(instance->view_dispatcher, NfcViewMenu);
+}
+
+bool nfc_scene_write_ndef_tag_on_event(void* context, SceneManagerEvent event) {
+    NfcApp* instance = context;
+    bool consumed = false;
+
+    if(event.type == SceneManagerEventTypeCustom) {
+        instance->ndef_write.ntag_type = (NdefNtagType)event.event;
+        scene_manager_set_scene_state(
+            instance->scene_manager, NfcSceneWriteNdefTag, event.event);
+        scene_manager_next_scene(instance->scene_manager, NfcSceneWriteNdef);
+        consumed = true;
+    }
+    return consumed;
+}
+
+void nfc_scene_write_ndef_tag_on_exit(void* context) {
+    NfcApp* instance = context;
+    submenu_reset(instance->submenu);
+}

--- a/applications/main/nfc/scenes/nfc_scene_write_ndef_type.c
+++ b/applications/main/nfc/scenes/nfc_scene_write_ndef_type.c
@@ -20,17 +20,9 @@ void nfc_scene_write_ndef_type_on_enter(void* context) {
     submenu_add_item(
         submenu, "URL", SubmenuIndexUri, nfc_scene_write_ndef_type_submenu_callback, instance);
     submenu_add_item(
-        submenu,
-        "Email",
-        SubmenuIndexEmail,
-        nfc_scene_write_ndef_type_submenu_callback,
-        instance);
+        submenu, "Email", SubmenuIndexEmail, nfc_scene_write_ndef_type_submenu_callback, instance);
     submenu_add_item(
-        submenu,
-        "Phone",
-        SubmenuIndexPhone,
-        nfc_scene_write_ndef_type_submenu_callback,
-        instance);
+        submenu, "Phone", SubmenuIndexPhone, nfc_scene_write_ndef_type_submenu_callback, instance);
     submenu_add_item(
         submenu, "Text", SubmenuIndexText, nfc_scene_write_ndef_type_submenu_callback, instance);
     submenu_add_item(
@@ -54,8 +46,7 @@ bool nfc_scene_write_ndef_type_on_event(void* context, SceneManagerEvent event) 
         instance->ndef_write.input_step = NdefWriteInputStepPrimary;
         furi_string_reset(instance->ndef_write.primary);
         furi_string_reset(instance->ndef_write.secondary);
-        scene_manager_set_scene_state(
-            instance->scene_manager, NfcSceneWriteNdefType, event.event);
+        scene_manager_set_scene_state(instance->scene_manager, NfcSceneWriteNdefType, event.event);
         scene_manager_next_scene(instance->scene_manager, NfcSceneWriteNdefInput);
         consumed = true;
     }

--- a/applications/main/nfc/scenes/nfc_scene_write_ndef_type.c
+++ b/applications/main/nfc/scenes/nfc_scene_write_ndef_type.c
@@ -1,0 +1,69 @@
+#include "../nfc_app_i.h"
+
+enum SubmenuIndex {
+    SubmenuIndexUri = NdefWriteRecordTypeUri,
+    SubmenuIndexEmail = NdefWriteRecordTypeEmail,
+    SubmenuIndexPhone = NdefWriteRecordTypePhone,
+    SubmenuIndexText = NdefWriteRecordTypeText,
+    SubmenuIndexWifi = NdefWriteRecordTypeWifi,
+};
+
+static void nfc_scene_write_ndef_type_submenu_callback(void* context, uint32_t index) {
+    NfcApp* instance = context;
+    view_dispatcher_send_custom_event(instance->view_dispatcher, index);
+}
+
+void nfc_scene_write_ndef_type_on_enter(void* context) {
+    NfcApp* instance = context;
+    Submenu* submenu = instance->submenu;
+
+    submenu_add_item(
+        submenu, "URL", SubmenuIndexUri, nfc_scene_write_ndef_type_submenu_callback, instance);
+    submenu_add_item(
+        submenu,
+        "Email",
+        SubmenuIndexEmail,
+        nfc_scene_write_ndef_type_submenu_callback,
+        instance);
+    submenu_add_item(
+        submenu,
+        "Phone",
+        SubmenuIndexPhone,
+        nfc_scene_write_ndef_type_submenu_callback,
+        instance);
+    submenu_add_item(
+        submenu, "Text", SubmenuIndexText, nfc_scene_write_ndef_type_submenu_callback, instance);
+    submenu_add_item(
+        submenu,
+        "Wi-Fi (WPA2)",
+        SubmenuIndexWifi,
+        nfc_scene_write_ndef_type_submenu_callback,
+        instance);
+
+    submenu_set_selected_item(
+        submenu, scene_manager_get_scene_state(instance->scene_manager, NfcSceneWriteNdefType));
+    view_dispatcher_switch_to_view(instance->view_dispatcher, NfcViewMenu);
+}
+
+bool nfc_scene_write_ndef_type_on_event(void* context, SceneManagerEvent event) {
+    NfcApp* instance = context;
+    bool consumed = false;
+
+    if(event.type == SceneManagerEventTypeCustom) {
+        instance->ndef_write.record_type = (NdefWriteRecordType)event.event;
+        instance->ndef_write.input_step = NdefWriteInputStepPrimary;
+        furi_string_reset(instance->ndef_write.primary);
+        furi_string_reset(instance->ndef_write.secondary);
+        scene_manager_set_scene_state(
+            instance->scene_manager, NfcSceneWriteNdefType, event.event);
+        scene_manager_next_scene(instance->scene_manager, NfcSceneWriteNdefInput);
+        consumed = true;
+    }
+
+    return consumed;
+}
+
+void nfc_scene_write_ndef_type_on_exit(void* context) {
+    NfcApp* instance = context;
+    submenu_reset(instance->submenu);
+}

--- a/applications/main/nfc/views/ndef_text_input.c
+++ b/applications/main/nfc/views/ndef_text_input.c
@@ -45,61 +45,129 @@ static const uint8_t keyboard_row_count = 3;
 // Letter layout: identical to stock text_input except `_` is replaced with SHIFT.
 // `_` is reachable via the symbol layout (symbols_row_2[0]).
 static const NdefTextInputKey letters_row_1[] = {
-    {'q', 1, 8},  {'w', 10, 8}, {'e', 19, 8},  {'r', 28, 8},  {'t', 37, 8},
-    {'y', 46, 8}, {'u', 55, 8}, {'i', 64, 8},  {'o', 73, 8},  {'p', 82, 8},
-    {'0', 91, 8}, {'1', 100, 8},{'2', 110, 8}, {'3', 120, 8},
+    {'q', 1, 8},
+    {'w', 10, 8},
+    {'e', 19, 8},
+    {'r', 28, 8},
+    {'t', 37, 8},
+    {'y', 46, 8},
+    {'u', 55, 8},
+    {'i', 64, 8},
+    {'o', 73, 8},
+    {'p', 82, 8},
+    {'0', 91, 8},
+    {'1', 100, 8},
+    {'2', 110, 8},
+    {'3', 120, 8},
 };
 static const NdefTextInputKey letters_row_2[] = {
-    {'a', 1, 20}, {'s', 10, 20}, {'d', 19, 20}, {'f', 28, 20}, {'g', 37, 20},
-    {'h', 46, 20},{'j', 55, 20}, {'k', 64, 20}, {'l', 73, 20},
+    {'a', 1, 20},
+    {'s', 10, 20},
+    {'d', 19, 20},
+    {'f', 28, 20},
+    {'g', 37, 20},
+    {'h', 46, 20},
+    {'j', 55, 20},
+    {'k', 64, 20},
+    {'l', 73, 20},
     {BACKSPACE_KEY, 82, 12},
-    {'4', 100, 20}, {'5', 110, 20}, {'6', 120, 20},
+    {'4', 100, 20},
+    {'5', 110, 20},
+    {'6', 120, 20},
 };
 static const NdefTextInputKey letters_row_3[] = {
-    {'z', 1, 32},  {'x', 10, 32}, {'c', 19, 32}, {'v', 28, 32}, {'b', 37, 32},
-    {'n', 46, 32}, {'m', 55, 32},
+    {'z', 1, 32},
+    {'x', 10, 32},
+    {'c', 19, 32},
+    {'v', 28, 32},
+    {'b', 37, 32},
+    {'n', 46, 32},
+    {'m', 55, 32},
     {SHIFT_KEY, 64, 32},
     {ENTER_KEY, 74, 23},
-    {'7', 100, 32}, {'8', 110, 32}, {'9', 120, 32},
+    {'7', 100, 32},
+    {'8', 110, 32},
+    {'9', 120, 32},
 };
 
 // Symbol layout: same key counts and positions as letters; punctuation in
 // place of the letters. The shift key keeps the same slot so muscle memory
 // works across modes.
 static const NdefTextInputKey symbols_row_1[] = {
-    {'.', 1, 8},  {'/', 10, 8}, {':', 19, 8},  {'-', 28, 8},  {'?', 37, 8},
-    {'=', 46, 8}, {'&', 55, 8}, {'#', 64, 8},  {'@', 73, 8},  {'+', 82, 8},
-    {'0', 91, 8}, {'1', 100, 8},{'2', 110, 8}, {'3', 120, 8},
+    {'.', 1, 8},
+    {'/', 10, 8},
+    {':', 19, 8},
+    {'-', 28, 8},
+    {'?', 37, 8},
+    {'=', 46, 8},
+    {'&', 55, 8},
+    {'#', 64, 8},
+    {'@', 73, 8},
+    {'+', 82, 8},
+    {'0', 91, 8},
+    {'1', 100, 8},
+    {'2', 110, 8},
+    {'3', 120, 8},
 };
 static const NdefTextInputKey symbols_row_2[] = {
-    {'_', 1, 20}, {'!', 10, 20}, {'~', 19, 20}, {',', 28, 20}, {'*', 37, 20},
-    {';', 46, 20},{'(', 55, 20}, {')', 64, 20}, {'\'', 73, 20},
+    {'_', 1, 20},
+    {'!', 10, 20},
+    {'~', 19, 20},
+    {',', 28, 20},
+    {'*', 37, 20},
+    {';', 46, 20},
+    {'(', 55, 20},
+    {')', 64, 20},
+    {'\'', 73, 20},
     {BACKSPACE_KEY, 82, 12},
-    {'4', 100, 20}, {'5', 110, 20}, {'6', 120, 20},
+    {'4', 100, 20},
+    {'5', 110, 20},
+    {'6', 120, 20},
 };
 static const NdefTextInputKey symbols_row_3[] = {
-    {'<', 1, 32}, {'>', 10, 32}, {'"', 19, 32}, {'%', 28, 32}, {'$', 37, 32},
-    {'[', 46, 32},{']', 55, 32},
+    {'<', 1, 32},
+    {'>', 10, 32},
+    {'"', 19, 32},
+    {'%', 28, 32},
+    {'$', 37, 32},
+    {'[', 46, 32},
+    {']', 55, 32},
     {SHIFT_KEY, 64, 32},
     {ENTER_KEY, 74, 23},
-    {'7', 100, 32}, {'8', 110, 32}, {'9', 120, 32},
+    {'7', 100, 32},
+    {'8', 110, 32},
+    {'9', 120, 32},
 };
 
 static uint8_t get_row_size(const NdefTextInputModel* model, uint8_t row_index) {
     uint8_t row_size = 0;
     if(model->symbol_mode) {
         switch(row_index + 1) {
-        case 1: row_size = COUNT_OF(symbols_row_1); break;
-        case 2: row_size = COUNT_OF(symbols_row_2); break;
-        case 3: row_size = COUNT_OF(symbols_row_3); break;
-        default: furi_crash();
+        case 1:
+            row_size = COUNT_OF(symbols_row_1);
+            break;
+        case 2:
+            row_size = COUNT_OF(symbols_row_2);
+            break;
+        case 3:
+            row_size = COUNT_OF(symbols_row_3);
+            break;
+        default:
+            furi_crash();
         }
     } else {
         switch(row_index + 1) {
-        case 1: row_size = COUNT_OF(letters_row_1); break;
-        case 2: row_size = COUNT_OF(letters_row_2); break;
-        case 3: row_size = COUNT_OF(letters_row_3); break;
-        default: furi_crash();
+        case 1:
+            row_size = COUNT_OF(letters_row_1);
+            break;
+        case 2:
+            row_size = COUNT_OF(letters_row_2);
+            break;
+        case 3:
+            row_size = COUNT_OF(letters_row_3);
+            break;
+        default:
+            furi_crash();
         }
     }
     return row_size;
@@ -109,17 +177,31 @@ static const NdefTextInputKey* get_row(const NdefTextInputModel* model, uint8_t 
     const NdefTextInputKey* row = NULL;
     if(model->symbol_mode) {
         switch(row_index + 1) {
-        case 1: row = symbols_row_1; break;
-        case 2: row = symbols_row_2; break;
-        case 3: row = symbols_row_3; break;
-        default: furi_crash();
+        case 1:
+            row = symbols_row_1;
+            break;
+        case 2:
+            row = symbols_row_2;
+            break;
+        case 3:
+            row = symbols_row_3;
+            break;
+        default:
+            furi_crash();
         }
     } else {
         switch(row_index + 1) {
-        case 1: row = letters_row_1; break;
-        case 2: row = letters_row_2; break;
-        case 3: row = letters_row_3; break;
-        default: furi_crash();
+        case 1:
+            row = letters_row_1;
+            break;
+        case 2:
+            row = letters_row_2;
+            break;
+        case 3:
+            row = letters_row_3;
+            break;
+        default:
+            furi_crash();
         }
     }
     return row;
@@ -216,10 +298,7 @@ static void ndef_text_input_view_draw_callback(Canvas* canvas, void* _model) {
             if(keys[column].text == ENTER_KEY) {
                 canvas_set_color(canvas, ColorBlack);
                 canvas_draw_icon(
-                    canvas,
-                    key_x,
-                    key_y,
-                    selected ? &I_KeySaveSelected_24x11 : &I_KeySave_24x11);
+                    canvas, key_x, key_y, selected ? &I_KeySaveSelected_24x11 : &I_KeySave_24x11);
             } else if(keys[column].text == BACKSPACE_KEY) {
                 canvas_set_color(canvas, ColorBlack);
                 canvas_draw_icon(
@@ -243,8 +322,7 @@ static void ndef_text_input_view_draw_callback(Canvas* canvas, void* _model) {
                 if((model->clear_default_text ||
                     (text_length == 0 && char_is_lowercase(keys[column].text))) &&
                    !model->symbol_mode) {
-                    canvas_draw_glyph(
-                        canvas, key_x, key_y, char_to_uppercase(keys[column].text));
+                    canvas_draw_glyph(canvas, key_x, key_y, char_to_uppercase(keys[column].text));
                 } else {
                     canvas_draw_glyph(canvas, key_x, key_y, keys[column].text);
                 }
@@ -356,33 +434,71 @@ static bool ndef_text_input_view_input_callback(InputEvent* event, void* context
     } else if(event->type == InputTypeShort) {
         consumed = true;
         switch(event->key) {
-        case InputKeyUp: ndef_text_input_handle_up(text_input, model); break;
-        case InputKeyDown: ndef_text_input_handle_down(text_input, model); break;
-        case InputKeyLeft: ndef_text_input_handle_left(text_input, model); break;
-        case InputKeyRight: ndef_text_input_handle_right(text_input, model); break;
-        case InputKeyOk: ndef_text_input_handle_ok(text_input, model, false); break;
-        default: consumed = false; break;
+        case InputKeyUp:
+            ndef_text_input_handle_up(text_input, model);
+            break;
+        case InputKeyDown:
+            ndef_text_input_handle_down(text_input, model);
+            break;
+        case InputKeyLeft:
+            ndef_text_input_handle_left(text_input, model);
+            break;
+        case InputKeyRight:
+            ndef_text_input_handle_right(text_input, model);
+            break;
+        case InputKeyOk:
+            ndef_text_input_handle_ok(text_input, model, false);
+            break;
+        default:
+            consumed = false;
+            break;
         }
     } else if(event->type == InputTypeLong) {
         consumed = true;
         switch(event->key) {
-        case InputKeyUp: ndef_text_input_handle_up(text_input, model); break;
-        case InputKeyDown: ndef_text_input_handle_down(text_input, model); break;
-        case InputKeyLeft: ndef_text_input_handle_left(text_input, model); break;
-        case InputKeyRight: ndef_text_input_handle_right(text_input, model); break;
-        case InputKeyOk: ndef_text_input_handle_ok(text_input, model, true); break;
-        case InputKeyBack: ndef_text_input_backspace_cb(model); break;
-        default: consumed = false; break;
+        case InputKeyUp:
+            ndef_text_input_handle_up(text_input, model);
+            break;
+        case InputKeyDown:
+            ndef_text_input_handle_down(text_input, model);
+            break;
+        case InputKeyLeft:
+            ndef_text_input_handle_left(text_input, model);
+            break;
+        case InputKeyRight:
+            ndef_text_input_handle_right(text_input, model);
+            break;
+        case InputKeyOk:
+            ndef_text_input_handle_ok(text_input, model, true);
+            break;
+        case InputKeyBack:
+            ndef_text_input_backspace_cb(model);
+            break;
+        default:
+            consumed = false;
+            break;
         }
     } else if(event->type == InputTypeRepeat) {
         consumed = true;
         switch(event->key) {
-        case InputKeyUp: ndef_text_input_handle_up(text_input, model); break;
-        case InputKeyDown: ndef_text_input_handle_down(text_input, model); break;
-        case InputKeyLeft: ndef_text_input_handle_left(text_input, model); break;
-        case InputKeyRight: ndef_text_input_handle_right(text_input, model); break;
-        case InputKeyBack: ndef_text_input_backspace_cb(model); break;
-        default: consumed = false; break;
+        case InputKeyUp:
+            ndef_text_input_handle_up(text_input, model);
+            break;
+        case InputKeyDown:
+            ndef_text_input_handle_down(text_input, model);
+            break;
+        case InputKeyLeft:
+            ndef_text_input_handle_left(text_input, model);
+            break;
+        case InputKeyRight:
+            ndef_text_input_handle_right(text_input, model);
+            break;
+        case InputKeyBack:
+            ndef_text_input_backspace_cb(model);
+            break;
+        default:
+            consumed = false;
+            break;
         }
     }
 
@@ -536,6 +652,5 @@ void* ndef_text_input_get_validator_callback_context(NdefTextInput* text_input) 
 
 void ndef_text_input_set_header_text(NdefTextInput* text_input, const char* text) {
     furi_check(text_input);
-    with_view_model(
-        text_input->view, NdefTextInputModel * model, { model->header = text; }, true);
+    with_view_model(text_input->view, NdefTextInputModel * model, { model->header = text; }, true);
 }

--- a/applications/main/nfc/views/ndef_text_input.c
+++ b/applications/main/nfc/views/ndef_text_input.c
@@ -1,0 +1,541 @@
+#include "ndef_text_input.h"
+#include <gui/elements.h>
+#include <assets_icons.h>
+#include <furi.h>
+
+struct NdefTextInput {
+    View* view;
+    FuriTimer* timer;
+};
+
+typedef struct {
+    const char text;
+    const uint8_t x;
+    const uint8_t y;
+} NdefTextInputKey;
+
+typedef struct {
+    const char* header;
+    char* text_buffer;
+    size_t text_buffer_size;
+    size_t minimum_length;
+    bool clear_default_text;
+    bool symbol_mode;
+
+    NdefTextInputCallback callback;
+    void* callback_context;
+
+    uint8_t selected_row;
+    uint8_t selected_column;
+
+    NdefTextInputValidatorCallback validator_callback;
+    void* validator_callback_context;
+    FuriString* validator_text;
+    bool validator_message_visible;
+} NdefTextInputModel;
+
+static const uint8_t keyboard_origin_x = 1;
+static const uint8_t keyboard_origin_y = 29;
+static const uint8_t keyboard_row_count = 3;
+
+#define ENTER_KEY     '\r'
+#define BACKSPACE_KEY '\b'
+#define SHIFT_KEY     '\x01'
+
+// Letter layout: identical to stock text_input except `_` is replaced with SHIFT.
+// `_` is reachable via the symbol layout (symbols_row_2[0]).
+static const NdefTextInputKey letters_row_1[] = {
+    {'q', 1, 8},  {'w', 10, 8}, {'e', 19, 8},  {'r', 28, 8},  {'t', 37, 8},
+    {'y', 46, 8}, {'u', 55, 8}, {'i', 64, 8},  {'o', 73, 8},  {'p', 82, 8},
+    {'0', 91, 8}, {'1', 100, 8},{'2', 110, 8}, {'3', 120, 8},
+};
+static const NdefTextInputKey letters_row_2[] = {
+    {'a', 1, 20}, {'s', 10, 20}, {'d', 19, 20}, {'f', 28, 20}, {'g', 37, 20},
+    {'h', 46, 20},{'j', 55, 20}, {'k', 64, 20}, {'l', 73, 20},
+    {BACKSPACE_KEY, 82, 12},
+    {'4', 100, 20}, {'5', 110, 20}, {'6', 120, 20},
+};
+static const NdefTextInputKey letters_row_3[] = {
+    {'z', 1, 32},  {'x', 10, 32}, {'c', 19, 32}, {'v', 28, 32}, {'b', 37, 32},
+    {'n', 46, 32}, {'m', 55, 32},
+    {SHIFT_KEY, 64, 32},
+    {ENTER_KEY, 74, 23},
+    {'7', 100, 32}, {'8', 110, 32}, {'9', 120, 32},
+};
+
+// Symbol layout: same key counts and positions as letters; punctuation in
+// place of the letters. The shift key keeps the same slot so muscle memory
+// works across modes.
+static const NdefTextInputKey symbols_row_1[] = {
+    {'.', 1, 8},  {'/', 10, 8}, {':', 19, 8},  {'-', 28, 8},  {'?', 37, 8},
+    {'=', 46, 8}, {'&', 55, 8}, {'#', 64, 8},  {'@', 73, 8},  {'+', 82, 8},
+    {'0', 91, 8}, {'1', 100, 8},{'2', 110, 8}, {'3', 120, 8},
+};
+static const NdefTextInputKey symbols_row_2[] = {
+    {'_', 1, 20}, {'!', 10, 20}, {'~', 19, 20}, {',', 28, 20}, {'*', 37, 20},
+    {';', 46, 20},{'(', 55, 20}, {')', 64, 20}, {'\'', 73, 20},
+    {BACKSPACE_KEY, 82, 12},
+    {'4', 100, 20}, {'5', 110, 20}, {'6', 120, 20},
+};
+static const NdefTextInputKey symbols_row_3[] = {
+    {'<', 1, 32}, {'>', 10, 32}, {'"', 19, 32}, {'%', 28, 32}, {'$', 37, 32},
+    {'[', 46, 32},{']', 55, 32},
+    {SHIFT_KEY, 64, 32},
+    {ENTER_KEY, 74, 23},
+    {'7', 100, 32}, {'8', 110, 32}, {'9', 120, 32},
+};
+
+static uint8_t get_row_size(const NdefTextInputModel* model, uint8_t row_index) {
+    uint8_t row_size = 0;
+    if(model->symbol_mode) {
+        switch(row_index + 1) {
+        case 1: row_size = COUNT_OF(symbols_row_1); break;
+        case 2: row_size = COUNT_OF(symbols_row_2); break;
+        case 3: row_size = COUNT_OF(symbols_row_3); break;
+        default: furi_crash();
+        }
+    } else {
+        switch(row_index + 1) {
+        case 1: row_size = COUNT_OF(letters_row_1); break;
+        case 2: row_size = COUNT_OF(letters_row_2); break;
+        case 3: row_size = COUNT_OF(letters_row_3); break;
+        default: furi_crash();
+        }
+    }
+    return row_size;
+}
+
+static const NdefTextInputKey* get_row(const NdefTextInputModel* model, uint8_t row_index) {
+    const NdefTextInputKey* row = NULL;
+    if(model->symbol_mode) {
+        switch(row_index + 1) {
+        case 1: row = symbols_row_1; break;
+        case 2: row = symbols_row_2; break;
+        case 3: row = symbols_row_3; break;
+        default: furi_crash();
+        }
+    } else {
+        switch(row_index + 1) {
+        case 1: row = letters_row_1; break;
+        case 2: row = letters_row_2; break;
+        case 3: row = letters_row_3; break;
+        default: furi_crash();
+        }
+    }
+    return row;
+}
+
+static char get_selected_char(NdefTextInputModel* model) {
+    return get_row(model, model->selected_row)[model->selected_column].text;
+}
+
+static bool char_is_lowercase(char letter) {
+    return letter >= 0x61 && letter <= 0x7A;
+}
+
+static char char_to_uppercase(const char letter) {
+    if(letter == '_') {
+        return 0x20;
+    } else if(islower((int)letter)) {
+        return letter - 0x20;
+    } else {
+        return letter;
+    }
+}
+
+static void ndef_text_input_backspace_cb(NdefTextInputModel* model) {
+    uint8_t text_length = model->clear_default_text ? 1 : strlen(model->text_buffer);
+    if(text_length > 0) {
+        model->text_buffer[text_length - 1] = 0;
+    }
+}
+
+// Render the shift key as a small framed box with a label that flips between
+// modes. Stock text_input draws Enter/Backspace via dedicated icons; we don't
+// have icons for shift, so we paint primitives instead.
+static void draw_shift_key(Canvas* canvas, uint8_t x, uint8_t y, bool selected, bool symbol_mode) {
+    // Key cell: 8 wide × 10 tall (matches the selection highlight box).
+    if(selected) {
+        canvas_set_color(canvas, ColorBlack);
+        canvas_draw_box(canvas, x - 1, y - 8, 9, 10);
+        canvas_set_color(canvas, ColorWhite);
+    } else {
+        canvas_set_color(canvas, ColorBlack);
+        canvas_draw_rframe(canvas, x - 1, y - 8, 9, 10, 1);
+    }
+    // Label: "A" in symbol mode (press to return to letters), "#" in letters mode.
+    canvas_draw_glyph(canvas, x, y, symbol_mode ? 'A' : '#');
+    canvas_set_color(canvas, ColorBlack);
+}
+
+static void ndef_text_input_view_draw_callback(Canvas* canvas, void* _model) {
+    NdefTextInputModel* model = _model;
+    uint8_t text_length = model->text_buffer ? strlen(model->text_buffer) : 0;
+    uint8_t needed_string_width = canvas_width(canvas) - 8;
+    uint8_t start_pos = 4;
+
+    const char* text = model->text_buffer;
+
+    canvas_clear(canvas);
+    canvas_set_color(canvas, ColorBlack);
+
+    canvas_draw_str(canvas, 2, 8, model->header);
+    elements_slightly_rounded_frame(canvas, 1, 12, 126, 15);
+
+    if(canvas_string_width(canvas, text) > needed_string_width) {
+        canvas_draw_str(canvas, start_pos, 22, "...");
+        start_pos += 6;
+        needed_string_width -= 8;
+    }
+
+    while(text != 0 && canvas_string_width(canvas, text) > needed_string_width) {
+        text++;
+    }
+
+    if(model->clear_default_text) {
+        elements_slightly_rounded_box(
+            canvas, start_pos - 1, 14, canvas_string_width(canvas, text) + 2, 10);
+        canvas_set_color(canvas, ColorWhite);
+    } else {
+        canvas_draw_str(canvas, start_pos + canvas_string_width(canvas, text) + 1, 22, "|");
+        canvas_draw_str(canvas, start_pos + canvas_string_width(canvas, text) + 2, 22, "|");
+    }
+    canvas_draw_str(canvas, start_pos, 22, text);
+
+    canvas_set_font(canvas, FontKeyboard);
+
+    for(uint8_t row = 0; row < keyboard_row_count; row++) {
+        const uint8_t column_count = get_row_size(model, row);
+        const NdefTextInputKey* keys = get_row(model, row);
+
+        for(size_t column = 0; column < column_count; column++) {
+            const uint8_t key_x = keyboard_origin_x + keys[column].x;
+            const uint8_t key_y = keyboard_origin_y + keys[column].y;
+            const bool selected = model->selected_row == row && model->selected_column == column;
+
+            if(keys[column].text == ENTER_KEY) {
+                canvas_set_color(canvas, ColorBlack);
+                canvas_draw_icon(
+                    canvas,
+                    key_x,
+                    key_y,
+                    selected ? &I_KeySaveSelected_24x11 : &I_KeySave_24x11);
+            } else if(keys[column].text == BACKSPACE_KEY) {
+                canvas_set_color(canvas, ColorBlack);
+                canvas_draw_icon(
+                    canvas,
+                    key_x,
+                    key_y,
+                    selected ? &I_KeyBackspaceSelected_16x9 : &I_KeyBackspace_16x9);
+            } else if(keys[column].text == SHIFT_KEY) {
+                draw_shift_key(canvas, key_x, key_y, selected, model->symbol_mode);
+            } else {
+                if(selected) {
+                    canvas_set_color(canvas, ColorBlack);
+                    canvas_draw_box(canvas, key_x - 1, key_y - 8, 7, 10);
+                    canvas_set_color(canvas, ColorWhite);
+                } else {
+                    canvas_set_color(canvas, ColorBlack);
+                }
+
+                // Auto-uppercase only applies to lowercase letters at the start
+                // of an empty buffer. Symbols are drawn verbatim.
+                if((model->clear_default_text ||
+                    (text_length == 0 && char_is_lowercase(keys[column].text))) &&
+                   !model->symbol_mode) {
+                    canvas_draw_glyph(
+                        canvas, key_x, key_y, char_to_uppercase(keys[column].text));
+                } else {
+                    canvas_draw_glyph(canvas, key_x, key_y, keys[column].text);
+                }
+            }
+        }
+    }
+
+    if(model->validator_message_visible) {
+        canvas_set_font(canvas, FontSecondary);
+        canvas_set_color(canvas, ColorWhite);
+        canvas_draw_box(canvas, 8, 10, 110, 48);
+        canvas_set_color(canvas, ColorBlack);
+        canvas_draw_icon(canvas, 10, 14, &I_WarningDolphin_45x42);
+        canvas_draw_rframe(canvas, 8, 8, 112, 50, 3);
+        canvas_draw_rframe(canvas, 9, 9, 110, 48, 2);
+        elements_multiline_text(canvas, 62, 20, furi_string_get_cstr(model->validator_text));
+        canvas_set_font(canvas, FontKeyboard);
+    }
+}
+
+static void ndef_text_input_handle_up(NdefTextInput* text_input, NdefTextInputModel* model) {
+    UNUSED(text_input);
+    if(model->selected_row > 0) {
+        model->selected_row--;
+        if(model->selected_column > get_row_size(model, model->selected_row) - 6) {
+            model->selected_column = model->selected_column + 1;
+        }
+    }
+}
+
+static void ndef_text_input_handle_down(NdefTextInput* text_input, NdefTextInputModel* model) {
+    UNUSED(text_input);
+    if(model->selected_row < keyboard_row_count - 1) {
+        model->selected_row++;
+        if(model->selected_column > get_row_size(model, model->selected_row) - 4) {
+            model->selected_column = model->selected_column - 1;
+        }
+    }
+}
+
+static void ndef_text_input_handle_left(NdefTextInput* text_input, NdefTextInputModel* model) {
+    UNUSED(text_input);
+    if(model->selected_column > 0) {
+        model->selected_column--;
+    } else {
+        model->selected_column = get_row_size(model, model->selected_row) - 1;
+    }
+}
+
+static void ndef_text_input_handle_right(NdefTextInput* text_input, NdefTextInputModel* model) {
+    UNUSED(text_input);
+    if(model->selected_column < get_row_size(model, model->selected_row) - 1) {
+        model->selected_column++;
+    } else {
+        model->selected_column = 0;
+    }
+}
+
+static void
+    ndef_text_input_handle_ok(NdefTextInput* text_input, NdefTextInputModel* model, bool shift) {
+    char selected = get_selected_char(model);
+    size_t text_length = strlen(model->text_buffer);
+
+    // Auto-uppercase logic applies only in letter mode.
+    bool toggle_case = !model->symbol_mode && (text_length == 0 || model->clear_default_text);
+    if(shift) toggle_case = !toggle_case;
+    if(toggle_case) {
+        selected = char_to_uppercase(selected);
+    }
+
+    if(selected == ENTER_KEY) {
+        if(model->validator_callback &&
+           (!model->validator_callback(
+               model->text_buffer, model->validator_text, model->validator_callback_context))) {
+            model->validator_message_visible = true;
+            furi_timer_start(text_input->timer, furi_kernel_get_tick_frequency() * 4);
+        } else if(model->callback != 0 && text_length >= model->minimum_length) {
+            model->callback(model->callback_context);
+        }
+    } else if(selected == BACKSPACE_KEY) {
+        ndef_text_input_backspace_cb(model);
+    } else if(selected == SHIFT_KEY) {
+        model->symbol_mode = !model->symbol_mode;
+        // Clamp selection in case the row sizes change in the future. For now
+        // both layouts use identical positions/sizes, so no clamping needed.
+    } else {
+        if(model->clear_default_text) {
+            text_length = 0;
+        }
+        if(text_length < (model->text_buffer_size - 1)) {
+            model->text_buffer[text_length] = selected;
+            model->text_buffer[text_length + 1] = 0;
+        }
+    }
+    model->clear_default_text = false;
+}
+
+static bool ndef_text_input_view_input_callback(InputEvent* event, void* context) {
+    NdefTextInput* text_input = context;
+    furi_assert(text_input);
+
+    bool consumed = false;
+    NdefTextInputModel* model = view_get_model(text_input->view);
+
+    if((!(event->type == InputTypePress) && !(event->type == InputTypeRelease)) &&
+       model->validator_message_visible) {
+        model->validator_message_visible = false;
+        consumed = true;
+    } else if(event->type == InputTypeShort) {
+        consumed = true;
+        switch(event->key) {
+        case InputKeyUp: ndef_text_input_handle_up(text_input, model); break;
+        case InputKeyDown: ndef_text_input_handle_down(text_input, model); break;
+        case InputKeyLeft: ndef_text_input_handle_left(text_input, model); break;
+        case InputKeyRight: ndef_text_input_handle_right(text_input, model); break;
+        case InputKeyOk: ndef_text_input_handle_ok(text_input, model, false); break;
+        default: consumed = false; break;
+        }
+    } else if(event->type == InputTypeLong) {
+        consumed = true;
+        switch(event->key) {
+        case InputKeyUp: ndef_text_input_handle_up(text_input, model); break;
+        case InputKeyDown: ndef_text_input_handle_down(text_input, model); break;
+        case InputKeyLeft: ndef_text_input_handle_left(text_input, model); break;
+        case InputKeyRight: ndef_text_input_handle_right(text_input, model); break;
+        case InputKeyOk: ndef_text_input_handle_ok(text_input, model, true); break;
+        case InputKeyBack: ndef_text_input_backspace_cb(model); break;
+        default: consumed = false; break;
+        }
+    } else if(event->type == InputTypeRepeat) {
+        consumed = true;
+        switch(event->key) {
+        case InputKeyUp: ndef_text_input_handle_up(text_input, model); break;
+        case InputKeyDown: ndef_text_input_handle_down(text_input, model); break;
+        case InputKeyLeft: ndef_text_input_handle_left(text_input, model); break;
+        case InputKeyRight: ndef_text_input_handle_right(text_input, model); break;
+        case InputKeyBack: ndef_text_input_backspace_cb(model); break;
+        default: consumed = false; break;
+        }
+    }
+
+    view_commit_model(text_input->view, consumed);
+    return consumed;
+}
+
+static void ndef_text_input_timer_callback(void* context) {
+    furi_assert(context);
+    NdefTextInput* text_input = context;
+    with_view_model(
+        text_input->view,
+        NdefTextInputModel * model,
+        { model->validator_message_visible = false; },
+        true);
+}
+
+NdefTextInput* ndef_text_input_alloc(void) {
+    NdefTextInput* text_input = malloc(sizeof(NdefTextInput));
+    text_input->view = view_alloc();
+    view_set_context(text_input->view, text_input);
+    view_allocate_model(text_input->view, ViewModelTypeLocking, sizeof(NdefTextInputModel));
+    view_set_draw_callback(text_input->view, ndef_text_input_view_draw_callback);
+    view_set_input_callback(text_input->view, ndef_text_input_view_input_callback);
+
+    text_input->timer =
+        furi_timer_alloc(ndef_text_input_timer_callback, FuriTimerTypeOnce, text_input);
+
+    with_view_model(
+        text_input->view,
+        NdefTextInputModel * model,
+        { model->validator_text = furi_string_alloc(); },
+        false);
+
+    ndef_text_input_reset(text_input);
+    return text_input;
+}
+
+void ndef_text_input_free(NdefTextInput* text_input) {
+    furi_check(text_input);
+    with_view_model(
+        text_input->view,
+        NdefTextInputModel * model,
+        { furi_string_free(model->validator_text); },
+        false);
+    furi_timer_stop(text_input->timer);
+    furi_timer_free(text_input->timer);
+    view_free(text_input->view);
+    free(text_input);
+}
+
+void ndef_text_input_reset(NdefTextInput* text_input) {
+    furi_check(text_input);
+    with_view_model(
+        text_input->view,
+        NdefTextInputModel * model,
+        {
+            model->header = "";
+            model->selected_row = 0;
+            model->selected_column = 0;
+            model->minimum_length = 1;
+            model->clear_default_text = false;
+            model->symbol_mode = false;
+            model->text_buffer = NULL;
+            model->text_buffer_size = 0;
+            model->callback = NULL;
+            model->callback_context = NULL;
+            model->validator_callback = NULL;
+            model->validator_callback_context = NULL;
+            furi_string_reset(model->validator_text);
+            model->validator_message_visible = false;
+        },
+        true);
+}
+
+View* ndef_text_input_get_view(NdefTextInput* text_input) {
+    furi_check(text_input);
+    return text_input->view;
+}
+
+void ndef_text_input_set_result_callback(
+    NdefTextInput* text_input,
+    NdefTextInputCallback callback,
+    void* callback_context,
+    char* text_buffer,
+    size_t text_buffer_size,
+    bool clear_default_text) {
+    furi_check(text_input);
+    with_view_model(
+        text_input->view,
+        NdefTextInputModel * model,
+        {
+            model->callback = callback;
+            model->callback_context = callback_context;
+            model->text_buffer = text_buffer;
+            model->text_buffer_size = text_buffer_size;
+            model->clear_default_text = clear_default_text;
+            if(text_buffer && text_buffer[0] != '\0') {
+                // Focus on Save (Enter) like the stock widget does.
+                model->selected_row = 2;
+                model->selected_column = 8;
+            }
+        },
+        true);
+}
+
+void ndef_text_input_set_minimum_length(NdefTextInput* text_input, size_t minimum_length) {
+    with_view_model(
+        text_input->view,
+        NdefTextInputModel * model,
+        { model->minimum_length = minimum_length; },
+        true);
+}
+
+void ndef_text_input_set_validator(
+    NdefTextInput* text_input,
+    NdefTextInputValidatorCallback callback,
+    void* callback_context) {
+    furi_check(text_input);
+    with_view_model(
+        text_input->view,
+        NdefTextInputModel * model,
+        {
+            model->validator_callback = callback;
+            model->validator_callback_context = callback_context;
+        },
+        true);
+}
+
+NdefTextInputValidatorCallback ndef_text_input_get_validator_callback(NdefTextInput* text_input) {
+    furi_check(text_input);
+    NdefTextInputValidatorCallback validator_callback = NULL;
+    with_view_model(
+        text_input->view,
+        NdefTextInputModel * model,
+        { validator_callback = model->validator_callback; },
+        false);
+    return validator_callback;
+}
+
+void* ndef_text_input_get_validator_callback_context(NdefTextInput* text_input) {
+    furi_check(text_input);
+    void* validator_callback_context = NULL;
+    with_view_model(
+        text_input->view,
+        NdefTextInputModel * model,
+        { validator_callback_context = model->validator_callback_context; },
+        false);
+    return validator_callback_context;
+}
+
+void ndef_text_input_set_header_text(NdefTextInput* text_input, const char* text) {
+    furi_check(text_input);
+    with_view_model(
+        text_input->view, NdefTextInputModel * model, { model->header = text; }, true);
+}

--- a/applications/main/nfc/views/ndef_text_input.h
+++ b/applications/main/nfc/views/ndef_text_input.h
@@ -1,0 +1,54 @@
+/**
+ * @file ndef_text_input.h
+ *
+ * Text input view forked from gui/modules/text_input. Adds a SHIFT key that
+ * toggles a second keyboard layout containing URL/Wi-Fi-friendly punctuation
+ * (`.` `/` `:` `-` `?` `=` `&` `#` `@` `+` `_` `!` `~` `,` `*` `;` `(` `)` `'`
+ * `<` `>` `"` `%` `$` `[` `]`). The stock TextInput on F0 only exposes
+ * `a-z 0-9 _`, which makes URL/SSID entry impossible.
+ *
+ * Public API mirrors text_input.h so existing patterns translate 1:1.
+ */
+#pragma once
+
+#include <gui/view.h>
+#include <gui/modules/validators.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct NdefTextInput NdefTextInput;
+typedef void (*NdefTextInputCallback)(void* context);
+typedef bool (
+    *NdefTextInputValidatorCallback)(const char* text, FuriString* error, void* context);
+
+NdefTextInput* ndef_text_input_alloc(void);
+void ndef_text_input_free(NdefTextInput* text_input);
+void ndef_text_input_reset(NdefTextInput* text_input);
+View* ndef_text_input_get_view(NdefTextInput* text_input);
+
+void ndef_text_input_set_result_callback(
+    NdefTextInput* text_input,
+    NdefTextInputCallback callback,
+    void* callback_context,
+    char* text_buffer,
+    size_t text_buffer_size,
+    bool clear_default_text);
+
+void ndef_text_input_set_minimum_length(NdefTextInput* text_input, size_t minimum_length);
+
+void ndef_text_input_set_validator(
+    NdefTextInput* text_input,
+    NdefTextInputValidatorCallback callback,
+    void* callback_context);
+
+NdefTextInputValidatorCallback ndef_text_input_get_validator_callback(NdefTextInput* text_input);
+
+void* ndef_text_input_get_validator_callback_context(NdefTextInput* text_input);
+
+void ndef_text_input_set_header_text(NdefTextInput* text_input, const char* text);
+
+#ifdef __cplusplus
+}
+#endif

--- a/applications/main/nfc/views/ndef_text_input.h
+++ b/applications/main/nfc/views/ndef_text_input.h
@@ -20,8 +20,7 @@ extern "C" {
 
 typedef struct NdefTextInput NdefTextInput;
 typedef void (*NdefTextInputCallback)(void* context);
-typedef bool (
-    *NdefTextInputValidatorCallback)(const char* text, FuriString* error, void* context);
+typedef bool (*NdefTextInputValidatorCallback)(const char* text, FuriString* error, void* context);
 
 NdefTextInput* ndef_text_input_alloc(void);
 void ndef_text_input_free(NdefTextInput* text_input);


### PR DESCRIPTION
# What's new

Adds a **Write NDEF Tag** entry under the NFC app's *Extra Actions* menu that builds an NDEF message and writes it to a blank NTAG213/215/216 via the existing `MfUltralightPoller` write path.

Supported record types:
- **URL** — URI RTD with prefix-table compression (`http://`, `https://`, …)
- **Email** — `mailto:` URI
- **Phone** — `tel:` URI
- **Text** — UTF-8 text record (lang `en`)
- **Wi-Fi (WPA2)** — WPS Credential record (`application/vnd.wfa.wsc`, WPA2-PSK/AES)

The stock `TextInput` widget only exposes `a-z 0-9 _`, which makes URL/SSID entry impossible. To avoid touching the shared widget, this PR ships a forked `ndef_text_input` view inside the NFC app with a shift key that toggles a symbol keyboard layout (`. / : - ? = & # @ + _ ! ~ , * ; ( ) ' < > " % $ [ ]`). Letters mode, auto-uppercase on empty buffer, and long-press OK case toggle behave identically to the stock widget.

Implementation notes:
- Synthetic `MfUltralightData` has zeroed static + dynamic lock bits and the factory default password so the poller's pre-write checks pass on fresh NTAGs. Pages 0–3 are populated but never written — `mf_ultralight_poller_handler_write_pages` starts at page 4.
- `skip_auth = true` paired with the poller's `TryDefaultPass` state covers fresh NTAGs.
- `CardMismatch` → "Wrong tag type" popup, `CardLocked`/`WriteFail` → "Write failed" popup, `WriteSuccess` → "Successfully written".
- New files live under `applications/main/nfc/{helpers,scenes,views}` and use the existing `nfc.fap` source glob — no `application.fam` change needed.

# Verification

1. `./fbt fap_nfc` — clean build, ~96 KB text on the FAP.
2. `./fbt launch APPSRC=applications/main/nfc` to flash a test device.
3. NFC app → Extra Actions → **Write NDEF Tag** → pick a record type → enter value(s) → pick NTAG variant → present a blank tag.
4. Read the written tag back with the same app or any phone NDEF reader for each record type (URL, Email, Phone, Text, Wi-Fi).
5. Present a different NTAG variant than the one selected → expect "Wrong tag type" popup.
6. Present a password-protected NTAG → expect "Write failed" popup.
7. Custom keyboard: shift key renders single-glyph `#` (letters mode) / `A` (symbols mode); long-press OK still toggles case in letters mode.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix

🤖 Generated with [Claude Code](https://claude.com/claude-code)