### PR TITLE
Fix typo in SLIX-L unlock menu ("TommyBox" → "TonieBox")

### DIFF
--- a/applications/main/nfc/scenes/nfc_scene_slix_unlock_menu.c
+++ b/applications/main/nfc/scenes/nfc_scene_slix_unlock_menu.c
@@ -25,7 +25,7 @@ void nfc_scene_slix_unlock_menu_on_enter(void* context) {
         instance);
     submenu_add_item(
         submenu,
-        "Auth As TommyBox",
+        "Auth As TonieBox",
         SubmenuIndexSlixUnlockMenuTonieBox,
         nfc_scene_slix_unlock_menu_submenu_callback,
         instance);


### PR DESCRIPTION
# What's new

- Fixes a typo in the NFC SLIX-L unlock menu: the menu item read "Auth As TommyBox" but should be "Auth As TonieBox", matching the adjacent enum (SubmenuIndexSlixUnlockMenuTonieBox) and unlock method (SlixUnlockMethodTonieBox). Closes #4359.

# Verification

- On a Flipper Zero running this build, go to NFC → Extra Actions → Unlock SLIX-L. The menu item now reads "Auth As TonieBox". No functional change — label text only.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix