### PR TITLE
GUI: add canvas_buffer to public api

### DIFF
--- a/applications/services/gui/canvas.c
+++ b/applications/services/gui/canvas.c
@@ -1,4 +1,5 @@
 #include "canvas_i.h"
+#include "canvas.h"
 #include "icon_animation_i.h"
 
 #include <furi.h>

--- a/applications/services/gui/canvas.h
+++ b/applications/services/gui/canvas.h
@@ -84,6 +84,22 @@ typedef enum {
 /** Canvas anonymous structure */
 typedef struct Canvas Canvas;
 
+/** Get canvas buffer.
+ *
+ * @param      canvas  Canvas instance
+ *
+ * @return     pointer to buffer
+ */
+uint8_t* canvas_get_buffer(Canvas* canvas);
+
+/** Get canvas buffer size.
+ *
+ * @param      canvas  Canvas instance
+ *
+ * @return     size of canvas in bytes
+ */
+size_t canvas_get_buffer_size(const Canvas* canvas);
+
 /** Reset canvas drawing tools configuration
  *
  * @param      canvas  Canvas instance

--- a/applications/services/gui/canvas_i.h
+++ b/applications/services/gui/canvas_i.h
@@ -61,22 +61,6 @@ Canvas* canvas_init(void);
  */
 void canvas_free(Canvas* canvas);
 
-/** Get canvas buffer.
- *
- * @param      canvas  Canvas instance
- *
- * @return     pointer to buffer
- */
-uint8_t* canvas_get_buffer(Canvas* canvas);
-
-/** Get canvas buffer size.
- *
- * @param      canvas  Canvas instance
- *
- * @return     size of canvas in bytes
- */
-size_t canvas_get_buffer_size(const Canvas* canvas);
-
 /** Set drawing region relative to real screen buffer
  *
  * @param      canvas    Canvas instance

--- a/targets/f18/api_symbols.csv
+++ b/targets/f18/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,v,87.3,,
+Version,+,87.3,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
 Header,+,applications/services/cli/cli.h,,

--- a/targets/f18/api_symbols.csv
+++ b/targets/f18/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,87.2,,
+Version,v,87.3,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
 Header,+,applications/services/cli/cli.h,,
@@ -767,6 +767,8 @@ Function,+,canvas_draw_str_aligned,void,"Canvas*, int32_t, int32_t, Align, Align
 Function,+,canvas_draw_triangle,void,"Canvas*, int32_t, int32_t, size_t, size_t, CanvasDirection"
 Function,+,canvas_draw_xbm,void,"Canvas*, int32_t, int32_t, size_t, size_t, const uint8_t*"
 Function,+,canvas_draw_xbm_ex,void,"Canvas*, int32_t, int32_t, size_t, size_t, IconRotation, const uint8_t*"
+Function,+,canvas_get_buffer,uint8_t*,Canvas*
+Function,+,canvas_get_buffer_size,size_t,const Canvas*
 Function,+,canvas_get_font_params,const CanvasFontParameters*,"const Canvas*, Font"
 Function,+,canvas_glyph_width,size_t,"Canvas*, uint16_t"
 Function,+,canvas_height,size_t,const Canvas*

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,87.2,,
+Version,+,87.3,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
@@ -850,6 +850,8 @@ Function,+,canvas_draw_str_aligned,void,"Canvas*, int32_t, int32_t, Align, Align
 Function,+,canvas_draw_triangle,void,"Canvas*, int32_t, int32_t, size_t, size_t, CanvasDirection"
 Function,+,canvas_draw_xbm,void,"Canvas*, int32_t, int32_t, size_t, size_t, const uint8_t*"
 Function,+,canvas_draw_xbm_ex,void,"Canvas*, int32_t, int32_t, size_t, size_t, IconRotation, const uint8_t*"
+Function,+,canvas_get_buffer,uint8_t*,Canvas*
+Function,+,canvas_get_buffer_size,size_t,const Canvas*
 Function,+,canvas_get_font_params,const CanvasFontParameters*,"const Canvas*, Font"
 Function,+,canvas_glyph_width,size_t,"Canvas*, uint16_t"
 Function,+,canvas_height,size_t,const Canvas*


### PR DESCRIPTION
# What's new

Moved the canvas_get_buffer and canvas_get_buffer_size declarations from the internal canvas_i.h header to the public canvas.h, and registered them in the firmware API symbols.

This gives external applications direct access to the display framebuffer for more convenient and efficient rendering, and fixes a critical bug in my games that required low-level buffer access.

# Verification 

Moved the canvas_get_buffer and canvas_get_buffer_size declarations from the internal canvas_i.h header to the public canvas.h, and registered them in the firmware API symbols.

# Author checklist (Fill this out)

- [X] I've read the [contribution guidelines](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/CONTRIBUTING.md) and my PR follows them.
- [X] I own the code I'm submitting or have code owner's permission (or code license allows redistribution) to submit it.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

Not used

# Reviewer checklist (Don't fill this out!)

- [x] PR has description of feature/bug or link to GitHub Project task.
- [x] Description contains actions to verify feature/bugfix.
- [x] I've built this code, uploaded it to the device and verified feature/bugfix.