### PR TITLE
Fix condition for cleaning up dict attack resources

### DIFF
--- a/lib/nfc/protocols/mf_classic/mf_classic_poller.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller.c
@@ -67,7 +67,8 @@ void mf_classic_poller_free(MfClassicPoller* instance) {
 
     // Clean up dict attack resources when the poller was in dict attack mode.
     if(instance->mode == MfClassicPollerModeDictAttackStandard ||
-       instance->mode == MfClassicPollerModeDictAttackEnhanced) {
+       instance->mode == MfClassicPollerModeDictAttackEnhanced ||
+       instance->mode == MfClassicPollerModeDictAttackCUID) {
         MfClassicPollerDictAttackContext* dict_attack_ctx = &instance->mode_ctx.dict_attack_ctx;
 
         // Free the dictionaries


### PR DESCRIPTION
# What's new

- Add missing MfClassicPollerModeDictAttackCUID

# Author checklist (Fill this out)

- [X] I've read the [contribution guidelines](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/CONTRIBUTING.md) and my PR follows them.
- [X] I own the code I'm submitting or have code owner's permission (or code license allows redistribution) to submit it.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

- [ Describe here how AI was used in this PR if it was used ]

# Reviewer checklist (Don't fill this out!)

- [x] PR has description of feature/bug or link to GitHub Project task.
- [x] Description contains actions to verify feature/bugfix.
- [x] I've built this code, uploaded it to the device and verified feature/bugfix.