### PR TITLE
Fix broken docs links

### DIFF
--- a/applications/services/cli/cli_main_shell.c
+++ b/applications/services/cli/cli_main_shell.c
@@ -23,7 +23,7 @@ void cli_main_motd(void* context) {
            "| _| | |__  | | |  _/|  _/| _| |   /  | (__ | |__  | |\r\n"
            "|_|  |____||___||_|  |_|  |___||_|_\\   \\___||____||___|\r\n"
            "\r\n" ANSI_FG_BR_WHITE "Welcome to Flipper Zero Command Line Interface!\r\n"
-           "Read the manual: https://docs.flipper.net/development/cli\r\n"
+           "Read the manual: https://docs.flipper.net/zero/development/cli\r\n"
            "Run `help` or `?` to list available commands\r\n"
            "\r\n" ANSI_RESET);
 

--- a/applications/system/js_app/packages/fz-sdk/gpio/index.d.ts
+++ b/applications/system/js_app/packages/fz-sdk/gpio/index.d.ts
@@ -111,7 +111,7 @@ export interface Pin {
 
 /**
  * Returns an object that can be used to manage a GPIO pin. For the list of
- * available pins, see https://docs.flipper.net/gpio-and-modules#miFsS
+ * available pins, see https://docs.flipper.net/zero/gpio-and-modules#miFsS
  * @param pin Pin name (e.g. `"PC3"`) or number (e.g. `7`)
  * @version Added in JS SDK 0.1
  */

--- a/documentation/devboard/Get started with the Dev Board.md
+++ b/documentation/devboard/Get started with the Dev Board.md
@@ -15,7 +15,7 @@ Since the main purpose of the Developer board is to debug applications on Flippe
 > [!note]
 > Debug Mode needs to be re-enabled after each update of Flipper Zero's firmware.
 
-Debug Mode allows you to debug your apps for Flipper Zero, as well as access debugging options in apps via the user interface and CLI. To learn more about Flipper Zero CLI, visit [Command-line interface in Flipper Docs](https://docs.flipper.net/development/cli).
+Debug Mode allows you to debug your apps for Flipper Zero, as well as access debugging options in apps via the user interface and CLI. To learn more about Flipper Zero CLI, visit [Command-line interface in Flipper Docs](https://docs.flipper.net/zero/development/cli).
 
 \image html https://cdn.flipperzero.one/Flipper_Zero_Command_Line_Interface_CDN.jpg width=700
 

--- a/documentation/doxygen/index.dox
+++ b/documentation/doxygen/index.dox
@@ -6,7 +6,7 @@
 
 This documentation is intended for developers interested in modifying the Flipper Zero firmware, creating Apps and JavaScript programs, or working on external hardware modules for the device.
 
-If you are looking for the user manual, please visit the [User Documentation](https://docs.flipper.net/) instead.
+If you are looking for the user manual, please visit the [User Documentation](https://docs.flipper.net/zero/) instead.
 
 The documentation is divided into several sections. All of them are accessible from the sidebar on the left:
 

--- a/documentation/js/js_your_first_js_app.md
+++ b/documentation/js/js_your_first_js_app.md
@@ -69,7 +69,7 @@ The command-line interface (CLI) is a text-based interface that lets you control
 To run the script via CLI:
 
 1. Connect your Flipper Zero to your PC via USB.
-2. Access the CLI using one of the [recommended methods](https://docs.flipper.net/development/cli#HfXTy).
+2. Access the CLI using one of the [recommended methods](https://docs.flipper.net/zero/development/cli#HfXTy).
 3. Enter the `js path` command, replacing `path` with the path to the script file on your Flipper Zero:
 
 \code{.sh}

--- a/lib/toolbox/cli/shell/cli_shell.c
+++ b/lib/toolbox/cli/shell/cli_shell.c
@@ -125,7 +125,7 @@ void cli_command_help(PipeSide* pipe, FuriString* args, void* context) {
         printf(
             ANSI_RESET
             "\r\nIf you added a new external command and can't see it above, run `reload_ext_cmds`");
-    printf(ANSI_RESET "\r\nFind out more: https://docs.flipper.net/development/cli");
+    printf(ANSI_RESET "\r\nFind out more: https://docs.flipper.net/zero/development/cli");
 
     cli_registry_unlock(registry);
 }


### PR DESCRIPTION
# What's new

- Fixing docs links broken by the split to https://docs.flipper.net/zero/ and https://docs.flipper.net/one. 
Resolves #4382

# Verification 

- Try following the new links

# Author checklist (Fill this out)

- [x] I've read the [contribution guidelines](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/CONTRIBUTING.md) and my PR follows them.
- [x] I own the code I'm submitting or have code owner's permission (or code license allows redistribution) to submit it.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

# Reviewer checklist (Don't fill this out!)

- [x] PR has description of feature/bug or link to GitHub Project task.
- [x] Description contains actions to verify feature/bugfix.
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix.