### PR TITLE
Fix User Documentation link in index.dox

### DIFF
--- a/documentation/doxygen/index.dox
+++ b/documentation/doxygen/index.dox
@@ -6,7 +6,7 @@
 
 This documentation is intended for developers interested in modifying the Flipper Zero firmware, creating Apps and JavaScript programs, or working on external hardware modules for the device.
 
-If you are looking for the user manual, please visit the [User Documentation](https://docs.flipper.net/zero/) instead.
+If you are looking for the user manual, please visit the [User Documentation](https://docs.flipper.net/zero) instead.
 
 The documentation is divided into several sections. All of them are accessible from the sidebar on the left:
 


### PR DESCRIPTION
# What's new

- Updated the link to the User Documentation by removing the trailing slash, which was pointing to an incorrectly rendered page

# Verification 

- See link https://docs.flipper.net/zero (vs wrong link: https://docs.flipper.net/zero/)

# Author checklist (Fill this out)

- [x] I've read the [contribution guidelines](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/CONTRIBUTING.md) and my PR follows them.
- [x] I own the code I'm submitting or have code owner's permission (or code license allows redistribution) to submit it.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.

# AI usage disclosure (Fill this out):

- [-] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [-] Fully AI generated (explain what all the generated code does in moderate detail).

- [ Describe here how AI was used in this PR if it was used ]

# Reviewer checklist (Don't fill this out!)

- [x] PR has description of feature/bug or link to GitHub Project task.
- [x] Description contains actions to verify feature/bugfix.
- [x] I've built this code, uploaded it to the device and verified feature/bugfix.