### PR TITLE
NFC: fix iso1569 emulation dropping Read Multiple Blocks for tags >64 blocks

### DIFF
--- a/lib/nfc/protocols/iso15693_3/iso15693_3_listener_i.h
+++ b/lib/nfc/protocols/iso15693_3/iso15693_3_listener_i.h
@@ -18,9 +18,9 @@ extern "C" {
 // There is also READ_MULTI_BLOCKS which has no explicit limit on requested block count
 // and ISO 15693-3 also does not specify a maximum overall response length, so this command could
 // theoretically result in a 8195 byte response (1 byte flags + 32 byte block * 256 blocks + 2 byte crc);
-// for practicality we use a sufficient buffer for a full GET_BLOCKS_SECURITY and
+// for practicality we use a sufficient buffer for a full 256-block, 4-byte-block read and
 // limit READ_MULTI_BLOCKS to how many blocks we can fit into that buffer size.
-#define ISO15693_3_LISTENER_BUFFER_SIZE (259U)
+#define ISO15693_3_LISTENER_BUFFER_SIZE (1U + 256U * 4U + 2U) // flags + 256*4-byte blocks + CRC
 
 typedef enum {
     Iso15693_3ListenerStateReady,

--- a/lib/signal_reader/parsers/iso15693/iso15693_parser.c
+++ b/lib/signal_reader/parsers/iso15693/iso15693_parser.c
@@ -192,6 +192,10 @@ static Iso15693ParserCommand iso15693_parser_parse_1_out_of_4(Iso15693Parser* in
                 instance->next_byte_part++;
                 if(instance->next_byte_part == 4) {
                     instance->next_byte_part = 0;
+                    // Overlong frame (noise): drop it instead of overflowing parsed_frame
+                    if(bit_buffer_get_size_bytes(instance->parsed_frame) >=
+                       bit_buffer_get_capacity_bytes(instance->parsed_frame))
+                        return Iso15693ParserCommandFail;
                     bit_buffer_append_byte(instance->parsed_frame, instance->next_byte);
                     instance->next_byte = 0;
                 }
@@ -239,6 +243,10 @@ static Iso15693ParserCommand iso15693_parser_parse_1_out_of_256(Iso15693Parser* 
             if(instance->bitstream_buff[i] != 0x00) {
                 for(size_t j = 0; j < 8; j++) {
                     if(FURI_BIT(instance->bitstream_buff[i], j) == 1) {
+                        // Overlong frame (noise): drop it instead of overflowing parsed_frame
+                        if(bit_buffer_get_size_bytes(instance->parsed_frame) >=
+                           bit_buffer_get_capacity_bytes(instance->parsed_frame))
+                            return Iso15693ParserCommandFail;
                         bit_buffer_append_byte(
                             instance->parsed_frame, instance->next_byte_part * 4 + j / 2);
                     }


### PR DESCRIPTION
# What's new

While working on getting a LEGO smart brick to work with the Flipper Zero, I discovered that ISO 15693 tag emulation failed even though the tag could be read and saved correctly.

-  After inspecting, I found that it reads the entire tag in a single `READ_MULTI_BLOCKS` command (66 blocks). The ISO 15693 listener, however, builds `READ_MULTI_BLOCKS` responses into a fixed 259-byte buffer. When the requested response exceeds this size, no response is sent at all.
- As a result, readers requesting more than 64 four-byte blocks receive no response and repeatedly retry the command, making the emulated tag appear dead/unresponsive.
- This affects any emulated ISO 15693 tag read with more than 64 (four-byte) blocks
  in a single command.

This PR fixes the issue by increasing the response buffer to support the full ISO 15693 size. By sizing the buffer for a full 256-block, 4-byte-block read.

The new value `1U + 256U * 4U + 2U` (= 1027 bytes) is:
  - `1`   - response flags byte
  - `256` - max block count (ISO 15693 addresses blocks with 1 byte, 0–255)
  - `4`   - bytes per block (common block size)
  - `2`   - 2-byte CRC checksum (ISO 13239 CRC-16) 

While testing this, I ran into a furi_check failed crash during emulation. It's a older bug in iso15693_parser.c, which this PR also fixes.

*The problem:* as the parser decodes an incoming frame, it keeps adding each byte to a 1024-byte buffer (parsed_frame) without ever checking if the buffer is full. If it decodes more than 1024 bytes before seeing an end-of-frame, bit_buffer_append_byte hits its furi_check and the Flipper crashes.

# Verification 

  - Read and save an ISO 15693 tag with >64 blocks.
  - Emulate the saved tag to a reader that reads the whole tag in one addressed
    READ_MULTI_BLOCKS.
    - **Before**: reader loops Inventory -> READ_MULTI_BLOCKS(start=0, count=66) forever, tag is never accepted.
    - **After**: the read is answered and the tag is accepted. (LEGO smart brick makes correct sound and color)
  - Verified with the (66-block) LEGO smart brick NFC tags.
  - Related: #4334 (merged) added the ISO 15693-3 buffer sizing and `READ_MULTI_BLOCKS` handling that this PR resizes.

# Author checklist (Fill this out)

- [x] I've read the [contribution guidelines](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/CONTRIBUTING.md) and my PR follows them.
- [x] I own the code I'm submitting or have code owner's permission (or code license allows redistribution) to submit it.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

- Code is not changed by ai, but research about mine NFC tag's payload is done by AI.

# Reviewer checklist (Don't fill this out!)

- [x] PR has description of feature/bug or link to GitHub Project task.
- [x] Description contains actions to verify feature/bugfix.
- [x] I've built this code, uploaded it to the device and verified feature/bugfix.