### PR TITLE
Add method for changing variable item label

### DIFF
--- a/applications/services/gui/modules/variable_item_list.c
+++ b/applications/services/gui/modules/variable_item_list.c
@@ -394,7 +394,7 @@ void variable_item_list_set_enter_callback(
         false);
 }
 
-void variable_item_set_label(VariableItem* item, const char* label) {
+void variable_item_set_item_label(VariableItem* item, const char* label) {
     furi_check(item);
     furi_check(label);
     item->label = label;

--- a/applications/services/gui/modules/variable_item_list.c
+++ b/applications/services/gui/modules/variable_item_list.c
@@ -394,6 +394,12 @@ void variable_item_list_set_enter_callback(
         false);
 }
 
+void variable_item_set_label(VariableItem* item, const char* label) {
+    furi_check(item);
+    furi_check(label);
+    item->label = label;
+}
+
 void variable_item_set_current_value_index(VariableItem* item, uint8_t current_value_index) {
     furi_check(item);
     item->current_value_index = current_value_index;

--- a/applications/services/gui/modules/variable_item_list.h
+++ b/applications/services/gui/modules/variable_item_list.h
@@ -79,7 +79,7 @@ uint8_t variable_item_list_get_selected_item_index(VariableItemList* variable_it
  * @param      item        VariableItem* instance
  * @param      label       The label text
  */
-void variable_item_set_label(VariableItem* item, const char* label);
+void variable_item_set_item_label(VariableItem* item, const char* label);
 
 /** Set item current selected index
  *

--- a/applications/services/gui/modules/variable_item_list.h
+++ b/applications/services/gui/modules/variable_item_list.h
@@ -74,6 +74,13 @@ void variable_item_list_set_selected_item(VariableItemList* variable_item_list, 
 
 uint8_t variable_item_list_get_selected_item_index(VariableItemList* variable_item_list);
 
+/** Set item label
+ *
+ * @param      item        VariableItem* instance
+ * @param      label       The label text
+ */
+void variable_item_set_label(VariableItem* item, const char* label);
+
 /** Set item current selected index
  *
  * @param      item                 VariableItem* instance

--- a/targets/f18/api_symbols.csv
+++ b/targets/f18/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,88.0,,
+Version,+,88.1,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
 Header,+,applications/services/cli/cli.h,,
@@ -2833,6 +2833,7 @@ Function,+,variable_item_list_set_enter_callback,void,"VariableItemList*, Variab
 Function,+,variable_item_list_set_selected_item,void,"VariableItemList*, uint8_t"
 Function,+,variable_item_set_current_value_index,void,"VariableItem*, uint8_t"
 Function,+,variable_item_set_current_value_text,void,"VariableItem*, const char*"
+Function,+,variable_item_set_item_label,void,"VariableItem*, const char*"
 Function,+,variable_item_set_values_count,void,"VariableItem*, uint8_t"
 Function,+,varint_int32_length,size_t,int32_t
 Function,+,varint_int32_pack,size_t,"int32_t, uint8_t*"

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,88.0,,
+Version,+,88.1,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
@@ -3733,7 +3733,7 @@ Function,+,variable_item_list_set_enter_callback,void,"VariableItemList*, Variab
 Function,+,variable_item_list_set_selected_item,void,"VariableItemList*, uint8_t"
 Function,+,variable_item_set_current_value_index,void,"VariableItem*, uint8_t"
 Function,+,variable_item_set_current_value_text,void,"VariableItem*, const char*"
-Function,+,variable_item_set_label,void,"VariableItem*, const char*"
+Function,+,variable_item_set_item_label,void,"VariableItem*, const char*"
 Function,+,variable_item_set_values_count,void,"VariableItem*, uint8_t"
 Function,+,varint_int32_length,size_t,int32_t
 Function,+,varint_int32_pack,size_t,"int32_t, uint8_t*"

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -3733,6 +3733,7 @@ Function,+,variable_item_list_set_enter_callback,void,"VariableItemList*, Variab
 Function,+,variable_item_list_set_selected_item,void,"VariableItemList*, uint8_t"
 Function,+,variable_item_set_current_value_index,void,"VariableItem*, uint8_t"
 Function,+,variable_item_set_current_value_text,void,"VariableItem*, const char*"
+Function,+,variable_item_set_label,void,"VariableItem*, const char*"
 Function,+,variable_item_set_values_count,void,"VariableItem*, uint8_t"
 Function,+,varint_int32_length,size_t,int32_t
 Function,+,varint_int32_pack,size_t,"int32_t, uint8_t*"


### PR DESCRIPTION
# What's new

- A new method has been added which writes to a `variable_item`'s `label` field. This works the same way as the other methods on `variable_item` (ie; it does not lock the `variable_item_list`'s model).
- Without this, there is no way of changing the label -- the most likely way to generate a mutatable `char*` would be via `FuriString`, however the pointer that this returns is invalidated by any writes, as per the m-lib documentation.

# Verification 

- Use this method when using the variable item list. After the change to the label is made, it'll be shown the next time that the view is redrawn.

# Author checklist (Fill this out)

- [x] I've read the [contribution guidelines](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/CONTRIBUTING.md) and my PR follows them.
- [x] I own the code I'm submitting or have code owner's permission (or code license allows redistribution) to submit it.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

- [ Describe here how AI was used in this PR if it was used ]

# Reviewer checklist (Don't fill this out!)

- [x] PR has description of feature/bug or link to GitHub Project task.
- [x] Description contains actions to verify feature/bugfix.
- [x] I've built this code, uploaded it to the device and verified feature/bugfix.
