### PR TITLE
Allow for checking if an id is in use before adding to view dispatcher

### DIFF
--- a/applications/services/gui/view.h
+++ b/applications/services/gui/view.h
@@ -110,6 +110,8 @@ void view_tie_icon_animation(View* view, IconAnimation* icon_animation);
 
 /** Set View Draw callback
  *
+ * @warning callback will be invoked on the GUI thread
+ *
  * @param      view      View instance
  * @param      callback  draw callback
  */

--- a/applications/services/gui/view_dispatcher.c
+++ b/applications/services/gui/view_dispatcher.c
@@ -140,6 +140,11 @@ void view_dispatcher_stop(ViewDispatcher* view_dispatcher) {
     furi_event_loop_stop(view_dispatcher->event_loop);
 }
 
+bool view_dispatcher_check_id(ViewDispatcher* view_dispatcher, uint32_t view_id) {
+    furi_check(view_dispatcher);
+    return ViewDict_get(view_dispatcher->views, view_id) == NULL;
+}
+
 void view_dispatcher_add_view(ViewDispatcher* view_dispatcher, uint32_t view_id, View* view) {
     furi_check(view_dispatcher);
     furi_check(view);

--- a/applications/services/gui/view_dispatcher.h
+++ b/applications/services/gui/view_dispatcher.h
@@ -97,6 +97,8 @@ void view_dispatcher_set_custom_event_callback(
 
 /** Set navigation event handler
  *
+ * @note this will be called on the thread that invoked view_dispatcher_run
+ *
  * Called on Input Short Back Event, if it is not consumed by view
  *
  * @param      view_dispatcher  ViewDispatcher instance

--- a/applications/services/gui/view_dispatcher.h
+++ b/applications/services/gui/view_dispatcher.h
@@ -161,6 +161,14 @@ void view_dispatcher_run(ViewDispatcher* view_dispatcher);
  */
 void view_dispatcher_stop(ViewDispatcher* view_dispatcher);
 
+/** Check if a view exists at id.
+ *
+ * @param      view_id          View id to check
+ *
+ * @return     True if a view has been added with id, false if not.
+ */
+bool view_dispatcher_check_id(ViewDispatcher* view_dispatcher, uint32_t view_id);
+
 /** Add view to ViewDispatcher
  *
  * @param      view_dispatcher  ViewDispatcher instance

--- a/applications/services/gui/view_i.h
+++ b/applications/services/gui/view_i.h
@@ -37,16 +37,20 @@ void view_icon_animation_callback(IconAnimation* instance, void* context);
 /** Unlock model */
 void view_unlock_model(View* view);
 
-/** Draw Callback for View dispatcher */
+/** Invokes the \a draw_callback, draw into the given canvas.
+ *
+ * @param     view     View instance
+ * @param     canvas   the canvas to draw into
+ */
 void view_draw(View* view, Canvas* canvas);
 
-/** Input Callback for View dispatcher */
+/** Input Callback for View dispatcher or View Holder */
 bool view_input(View* view, InputEvent* event);
 
-/** Custom Callback for View dispatcher */
+/** Custom Callback for View dispatcher and View Holder */
 bool view_custom(View* view, uint32_t event);
 
-/** Previous Callback for View dispatcher */
+/** Previous Callback for View dispatcher and View Holder */
 uint32_t view_previous(View* view);
 
 /** Enter Callback for View dispatcher */

--- a/applications/services/gui/view_port.h
+++ b/applications/services/gui/view_port.h
@@ -102,7 +102,7 @@ void view_port_input_callback_set(
 
 /** Emit update signal to GUI system.
  *
- * Rendering will happen later after GUI system process signal.
+ * Rendering will happen later, after the GUI system (gui_srv) has processed the signal.
  *
  * @param      view_port  ViewPort instance
  */

--- a/targets/f18/api_symbols.csv
+++ b/targets/f18/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,88.1,,
+Version,+,88.2,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
 Header,+,applications/services/cli/cli.h,,
@@ -2868,6 +2868,7 @@ Function,+,view_dispatcher_add_view,void,"ViewDispatcher*, uint32_t, View*"
 Function,+,view_dispatcher_alloc,ViewDispatcher*,
 Function,+,view_dispatcher_alloc_ex,ViewDispatcher*,FuriEventLoop*
 Function,+,view_dispatcher_attach_to_gui,void,"ViewDispatcher*, Gui*, ViewDispatcherType"
+Function,+,view_dispatcher_check_id,_Bool,"ViewDispatcher*, uint32_t"
 Function,+,view_dispatcher_enable_queue,void,ViewDispatcher*
 Function,+,view_dispatcher_free,void,ViewDispatcher*
 Function,+,view_dispatcher_get_event_loop,FuriEventLoop*,ViewDispatcher*

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,88.1,,
+Version,+,88.2,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -3767,6 +3767,7 @@ Function,+,view_dispatcher_add_view,void,"ViewDispatcher*, uint32_t, View*"
 Function,+,view_dispatcher_alloc,ViewDispatcher*,
 Function,+,view_dispatcher_alloc_ex,ViewDispatcher*,FuriEventLoop*
 Function,+,view_dispatcher_attach_to_gui,void,"ViewDispatcher*, Gui*, ViewDispatcherType"
+Function,+,view_dispatcher_check_id,_Bool,"ViewDispatcher*, uint32_t"
 Function,+,view_dispatcher_enable_queue,void,ViewDispatcher*
 Function,+,view_dispatcher_free,void,ViewDispatcher*
 Function,+,view_dispatcher_get_event_loop,FuriEventLoop*,ViewDispatcher*


### PR DESCRIPTION
- **Include documentation about caller thread context**
- **Add method for checking if view dispatcher id is already in use**

# What's new

- A new method has been added that checks the `view_dispatcher`'s dictionary to see if an id is already in use. This is useful as, without this, attempting to add an item with an id that is already in use, or remove an item at an id that isn't in use, results in a crash.

# Verification 

- [ Describe how to verify changes ]

# Author checklist (Fill this out)

- [x] I've read the [contribution guidelines](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/CONTRIBUTING.md) and my PR follows them.
- [x] I own the code I'm submitting or have code owner's permission (or code license allows redistribution) to submit it.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

- [ Describe here how AI was used in this PR if it was used ]

# Reviewer checklist (Don't fill this out!)

- [x] PR has description of feature/bug or link to GitHub Project task.
- [x] Description contains actions to verify feature/bugfix.
- [x] I've built this code, uploaded it to the device and verified feature/bugfix.
