### PR TITLE
bit_lib: don't read past the buffer when the requested bits fit one byte

### DIFF
--- a/lib/bit_lib/bit_lib.c
+++ b/lib/bit_lib/bit_lib.c
@@ -37,8 +37,10 @@ uint8_t bit_lib_get_bits(const uint8_t* data, size_t position, uint8_t length) {
     uint8_t shift = position % 8;
     if(shift == 0) {
         return data[position / 8] >> (8 - length);
+    } else if(shift + length <= 8) {
+        // Requested bits fit in the current byte, don't read the next one
+        return (uint8_t)(data[position / 8] << shift) >> (8 - length);
     } else {
-        // TODO FL-3534: fix read out of bounds
         uint8_t value = (data[position / 8] << (shift));
         value |= data[position / 8 + 1] >> (8 - shift);
         value = value >> (8 - length);


### PR DESCRIPTION
`bit_lib_get_bits()` reads `data[position / 8 + 1]` on every non-byte-aligned call, even when all `length` requested bits sit inside the current byte. When `position / 8` is the last byte of the buffer, that reads one byte past the end.

The next byte only contributes bits that get shifted straight back out, so the return value doesn't change, and an optimizing compiler often drops the load entirely. At `-O0` it stays, and AddressSanitizer flags it as a heap read past the end. The LFRFID protocol decoders call this on tightly packed buffers where the last field can land on the final byte.

`lib/bit_lib` here is an independent copy of the same code in fbtng-corelibs, where this fix already landed. The `TODO FL-3534` comment is still sitting in this tree. Same fix: when `shift + length <= 8`, return the bits from the current byte and leave the next one alone.

I checked it with a small standalone test under AddressSanitizer. The read shows up as a heap-buffer-overflow before the change and is gone after, and the patched branch returns the same value as the original for every in-bounds position and length on a two-byte buffer. Not run on hardware, since it only removes an out-of-bounds read without changing the value returned.
