### PR TITLE
js_event_loop: reject a zero or negative timer interval

### DIFF
--- a/applications/system/js_app/modules/js_event_loop/js_event_loop.c
+++ b/applications/system/js_app/modules/js_event_loop/js_event_loop.c
@@ -263,6 +263,11 @@ static void js_event_loop_timer(struct mjs* mjs) {
     int32_t interval;
     JS_VALUE_PARSE_ARGS_OR_RETURN(mjs, &js_loop_timer_args, &mode, &interval);
 
+    if(interval <= 0) {
+        mjs_prepend_errorf(mjs, MJS_BAD_ARGS_ERROR, "timer interval must be a positive number");
+        return;
+    }
+
     JsEventLoop* module = JS_GET_CONTEXT(mjs);
 
     // make timer contract


### PR DESCRIPTION
`eventLoop.timer(mode, interval)` passes `interval` straight to `furi_ms_to_ticks()` with no check. A periodic timer with interval `0` then divides by zero in `furi_event_loop_process_expired_timers()` (`elapsed_time / timer->interval`), and since a zero-interval timer counts as expired on every pass, this one-liner pins the thread running the loop:

```js
let eventLoop = require("event_loop");
eventLoop.timer("periodic", 0);
eventLoop.run();
```

Any `.js` app can hit it. This rejects `interval <= 0` at the binding with a normal script error, the same way the other js_app modules report bad arguments. The `<= 0` also catches negative values, which would otherwise wrap to a huge interval through the `(uint32_t)` cast.

Traced the parse-to-divide path in the source; the divide and the always-expired check live in `furi/core/event_loop_timer.c`. Not run on hardware.
