### PR TITLE
LFRFID: fix the Pyramid trailing Wiegand parity bit

### DIFF
--- a/lib/lfrfid/protocols/protocol_pyramid.c
+++ b/lib/lfrfid/protocols/protocol_pyramid.c
@@ -124,10 +124,10 @@ bool protocol_pyramid_decoder_feed(ProtocolPyramid* protocol, bool level, uint32
     return result;
 }
 
-bool protocol_pyramid_get_parity(const uint8_t* bits, uint8_t type, int length) {
+bool protocol_pyramid_get_parity(const uint8_t* bits, size_t position, uint8_t type, int length) {
     int x;
     for(x = 0; length > 0; --length)
-        x += bit_lib_get_bit(bits, length - 1);
+        x += bit_lib_get_bit(bits, position + length - 1);
     x %= 2;
     return x ^ type;
 }
@@ -138,12 +138,12 @@ void protocol_pyramid_add_wiegand_parity(
     uint8_t* source,
     uint8_t length) {
     bit_lib_set_bit(
-        target, target_position, protocol_pyramid_get_parity(source, 0 /* even */, length / 2));
+        target, target_position, protocol_pyramid_get_parity(source, 0, 0 /* even */, length / 2));
     bit_lib_copy_bits(target, target_position + 1, length, source, 0);
     bit_lib_set_bit(
         target,
         target_position + length + 1,
-        protocol_pyramid_get_parity(source + length / 2, 1 /* odd */, length / 2));
+        protocol_pyramid_get_parity(source, length / 2, 1 /* odd */, length / 2));
 }
 
 static void protocol_pyramid_encode(ProtocolPyramid* protocol) {


### PR DESCRIPTION
# What's new

`protocol_pyramid_add_wiegand_parity()` computes the trailing odd-parity bit like this:

```c
protocol_pyramid_get_parity(source + length / 2, 1 /* odd */, length / 2)
```

`length` is a bit count (24 at the only call site), so `source + length / 2` moves the pointer 12 **bytes**. `wiegand[]` in `protocol_pyramid_encode()` is 3 bytes. It should be reading bits 12..23 of that same buffer.

So the parity bit we put on the air comes from whatever stack memory sits past `wiegand[]` rather than from the card number. It's also an out-of-bounds read on every `encoder_start()` and `write_data()`.

It looks like a leftover from the Proxmark3 port, where `source` is one bit per byte and the arithmetic lines up.

The fix gives `get_parity()` an explicit start position instead of doing pointer arithmetic with a bit count. The even-parity call reads bits 0..11 exactly as before.

# Verification

I pulled both versions of `get_parity` out with `bit_lib_get_bit` and compared the emitted bit against what a 26-bit Wiegand reader expects (odd parity over data bits 12..23), sweeping facility codes and card numbers:

```
combinations checked: 70304
  before: wrong trailing parity 34632 (49.3%)
  after:  wrong trailing parity 0     (0.0%)
```

The giveaway is that on `dev` the bit changes when I modify bytes *outside* `wiegand[]` and leave the card number alone:

```
same card, only neighbouring bytes changed: buggy parity 1 -> 0
```

Under ASan the original reads past the `wiegand` frame object from `protocol_pyramid_encoder_start()`.

I have not tested this on hardware — I don't have a Pyramid credential or a reader to try it against. The check that matters on a bench: write a saved Pyramid card to a T5577 before and after this change and present it to a real reader. Roughly half of card numbers should go from rejected to accepted. Reading a written card back with a second Flipper won't show a difference, since our decoder doesn't validate Wiegand parity.

`clang-format` is clean. Both functions are local to this file (neither is in `protocol_pyramid.h`), so nothing else calls them.

# Author checklist (Fill this out)

- [x] I've read the [contribution guidelines](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/CONTRIBUTING.md) and my PR follows them.
- [x] I own the code I'm submitting or have code owner's permission (or code license allows redistribution) to submit it.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

I used an AI assistant to help audit the LFRFID encoders and to build the host-side harness that produced the numbers above. The change itself is four lines: a `size_t position` parameter on `protocol_pyramid_get_parity()`, `position + length - 1` in its loop, and the two call sites updated to pass `0` and `length / 2`. I read the Wiegand format and the surrounding code myself to confirm the trailing bit is odd parity over data bits 12..23, checked that neither function is exported in the header, and verified the result independently before opening this. The hardware caveat above is real and stated deliberately — I could only prove this on the host.
