### PR TITLE
LFRFID: NUL-terminate the PAC/Stanley card id before parsing it

### DIFF
--- a/lib/lfrfid/protocols/protocol_pac_stanley.c
+++ b/lib/lfrfid/protocols/protocol_pac_stanley.c
@@ -44,7 +44,8 @@ uint8_t* protocol_pac_stanley_get_data(ProtocolPACStanley* protocol) {
 }
 
 static void protocol_pac_stanley_decode(ProtocolPACStanley* protocol) {
-    uint8_t asciiCardId[8];
+    // hex_chars_to_uint8() reads until a terminator, so leave room for one
+    uint8_t asciiCardId[9] = {0};
     for(size_t idx = 0; idx < 8; idx++) {
         uint8_t byte = bit_lib_reverse_8_fast(bit_lib_get_bits(
             protocol->encoded_data,


### PR DESCRIPTION
# What's new

`protocol_pac_stanley_decode()` fills an 8-byte `asciiCardId[]` and passes it to `hex_chars_to_uint8()`:

```c
uint8_t asciiCardId[8];
...
hex_chars_to_uint8((char*)asciiCardId, protocol->data);
```

`hex_chars_to_uint8()` takes no length. It loops `while(*value_str && value_str[1])`, one byte written per hex pair, and stops only at a terminator — which `asciiCardId` doesn't have.

So the loop condition itself reads `asciiCardId[8]` and `[9]` past the end of the array on every successful decode. If those two stack bytes happen to be ASCII hex digits, it keeps going and writes past `protocol->data` as well, which is 4 bytes (`PAC_STANLEY_DECODED_DATA_SIZE`).

This is reachable from reading a real tag, and from `write_data()` at the bottom of the file, which calls `decode()` unconditionally.

Making the buffer 9 bytes and zeroing it fixes both ends: the loop still fills `[0..7]`, index 8 stays 0, so the parse stops after exactly 4 bytes.

# Verification

Compiled `protocol_pac_stanley.c` on a PC against a small stub `furi.h` and drove it through the write path under AddressSanitizer:

```
ERROR: AddressSanitizer: stack-buffer-overflow
READ of size 1 at ... thread T0
    #0 hex_chars_to_uint8 lib/toolbox/hex.c:40
    #1 protocol_pac_stanley_decode protocol_pac_stanley.c
    [32, 40) 'asciiCardId' <== Memory access at offset 40 overflows this variable
```

Pointing the same helper at a 4-byte destination shows the write side too (`heap-buffer-overflow`, `0 bytes after 4-byte region`). After the change the run is clean and the value survives the round trip — `CIN: 12345678` renders, and `protocol->data` reads back `12 34 56 78`.

Not tested on hardware; I don't have a PAC/Stanley tag. On a bench the check is: read a real tag, note the CIN, then emulate or write it to a T5577 and confirm the CIN is the same.

I left `hex_chars_to_uint8()`'s signature alone on purpose. Its other two callers are already guarded — `manifest.c` checks the field is exactly 32 chars, and `felica.c` passes a NUL-terminated `FuriString` — so widening the helper's contract would make this a much bigger diff than the bug needs.

`clang-format` is clean.

# Author checklist (Fill this out)

- [x] I've read the [contribution guidelines](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/CONTRIBUTING.md) and my PR follows them.
- [x] I own the code I'm submitting or have code owner's permission (or code license allows redistribution) to submit it.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

I used an AI assistant to help audit the LFRFID decoders and to build the host-side test that produced the ASan output above. The change is one line — `uint8_t asciiCardId[9] = {0};` in place of `uint8_t asciiCardId[8];` — plus a comment saying why. I read `hex_chars_to_uint8()` and the other two call sites myself to confirm the helper really is unbounded and that 4 bytes is the intended output length, and checked the fix on the host before opening this.
