### PR TITLE
NFC FeliCa: check the poller error before reading the system-code response

### DIFF
--- a/lib/nfc/protocols/felica/felica_poller.c
+++ b/lib/nfc/protocols/felica/felica_poller.c
@@ -129,17 +129,17 @@ NfcCommand felica_poller_state_handler_list_system(FelicaPoller* instance) {
     FelicaListSystemCodeCommandResponse* response_system_code;
     FelicaError error = felica_poller_list_system_code(instance, &response_system_code);
 
-    instance->systems_total = response_system_code->system_count;
-    simple_array_init(instance->data->systems, instance->systems_total);
-    uint8_t* system_codes = response_system_code->system_code;
-
-    for(uint8_t i = 0; i < instance->systems_total; i++) {
-        FelicaSystem* system = simple_array_get(instance->data->systems, i);
-        system->system_code = system_codes[i * 2] << 8 | system_codes[i * 2 + 1];
-        system->system_code_idx = i;
-    }
-
     if(error == FelicaErrorNone) {
+        instance->systems_total = response_system_code->system_count;
+        simple_array_init(instance->data->systems, instance->systems_total);
+        uint8_t* system_codes = response_system_code->system_code;
+
+        for(uint8_t i = 0; i < instance->systems_total; i++) {
+            FelicaSystem* system = simple_array_get(instance->data->systems, i);
+            system->system_code = system_codes[i * 2] << 8 | system_codes[i * 2 + 1];
+            system->system_code_idx = i;
+        }
+
         instance->state = FelicaPollerStateSelectSystemIndex;
     } else if(error != FelicaErrorTimeout) {
         instance->felica_event.type = FelicaPollerEventTypeError;


### PR DESCRIPTION
# What's new

`felica_poller_state_handler_list_system()` reads `response_system_code->system_count` before checking whether `felica_poller_list_system_code()` succeeded. That function only writes the response pointer on the success path. On a timeout, a bad CRC, or a response shorter than 13 bytes it returns an error and leaves the pointer untouched, and since it's an uninitialized stack variable, every error path here dereferences garbage.

This is the default path for any Standard FeliCa card (Suica/Pasmo/Octopus-style), since auth is skipped by default. So a weak read, a card pulled away mid-read, or an emulator that doesn't answer `Request System Code` all crash the reader.

This is the crash in #4314. The write-up there says the same thing: the other side doesn't respond, and the reader shouldn't freeze on it. #4383 helps the no-response case by teaching the listener to answer, but it doesn't touch this function, so a short or malformed reply (or a non-Flipper emulator that still doesn't answer) hits the same dereference.

The fix moves the response handling inside the `error == FelicaErrorNone` branch, which is what every other handler in this file already does (`traverse_standard_system`, `auth_internal`, `auth_external`, `read_standard_blocks` all check the error before touching the response).

# Verification

Traced `felica_poller_list_system_code()` and confirmed it returns on the frame-exchange error and the short-response check without ever assigning `*response_ptr`, while the caller dereferenced it unconditionally. Compiled the two functions standalone against a stubbed transport and confirmed the out-parameter is left at its sentinel value on the error path, and that MemorySanitizer flags the caller's dereference as use-of-uninitialized-value. `clang-format` is clean.

I don't have hardware to flash, so I haven't run it on-device. To confirm there: reproduce #4314 (one Flipper reading another emulating a blank/partial FeliCa Standard save), or make `Request System Code` time out (weak signal, pull the card early), and check the reader reports a normal read failure instead of freezing. A normal Standard FeliCa read should behave exactly as before.

# Author checklist (Fill this out)

- [x] I've read the contribution guidelines and my PR follows them.
- [x] I own the code I'm submitting or have code owner's permission (or code license allows redistribution) to submit it.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).

I used an AI assistant to help trace the `felica_poller.c` / `felica_poller_i.c` call path and to build a small standalone reproduction (outside this repo) that compiles the real `felica_poller_list_system_code` body against a stubbed transport, to confirm the out-parameter is left untouched on the error path and that MemorySanitizer catches the dereference. The fix itself is a hand-written reorder that matches the error-checking pattern the other handlers in this file already use.
