### PR TITLE
Infrared: initialize timings_cnt on decoder alloc and fix its bounds check

### DIFF
--- a/lib/infrared/encoder_decoder/common/infrared_common_decoder.c
+++ b/lib/infrared/encoder_decoder/common/infrared_common_decoder.c
@@ -231,7 +231,7 @@ InfraredMessage*
 
     decoder->timings[decoder->timings_cnt] = duration;
     decoder->timings_cnt++;
-    furi_check(decoder->timings_cnt <= sizeof(decoder->timings));
+    furi_check(decoder->timings_cnt <= COUNT_OF(decoder->timings));
 
     while(1) {
         switch(decoder->state) {
@@ -288,6 +288,7 @@ void* infrared_common_decoder_alloc(const InfraredCommonProtocolSpec* protocol) 
     InfraredCommonDecoder* decoder = malloc(alloc_size);
     decoder->protocol = protocol;
     decoder->level = true;
+    decoder->timings_cnt = 0;
     return decoder;
 }
 


### PR DESCRIPTION
# What's new

Two small issues around `timings_cnt` in the common IR decoder.

`infrared_common_decoder_alloc()` sets `protocol` and `level` but leaves `timings_cnt` uninitialized. Every caller goes through `infrared_alloc_decoder()`, which allocs then immediately resets. For RC5 (the one protocol with `preamble_mark == 0`), the reset path reads `timings_cnt` and passes it to `consume_samples()` as a length, and the reset function only zeroes `timings_cnt` a couple of lines later, after `reset_state()` has already used it. If the uninitialized value happens to be nonzero, `consume_samples()` shifts the 6-element `timings[]` array using that length, reading and writing past the end.

Separately, the defensive check in `infrared_common_decode()` is `furi_check(decoder->timings_cnt <= sizeof(decoder->timings))`. `timings_cnt` is an element count but `sizeof(decoder->timings)` is 24 (six `uint32_t`), so the check doesn't trip until 24 instead of 6. Should be `COUNT_OF`, which the file already uses elsewhere.

Both come down to `timings_cnt` not being trustworthy: initialize it at alloc so the first reset sees 0, and compare against the element count in the bounds check.

# Verification

Traced the alloc → reset call path and confirmed `timings_cnt` is read in `reset_state()` before `reset()` zeroes it, and that RC5's `preamble_mark` is 0 so it takes that branch. Compiled `infrared_common_decoder.c` standalone against a spec mirroring RC5 and called it the way `infrared_alloc_decoder()` does; before the change AddressSanitizer catches an out-of-bounds access in `consume_samples()` from the uninitialized count, and it's clean after. `clang-format` is clean, and `COUNT_OF` is already included/used in this file.

Being upfront on severity: how often the uninitialized read actually bites depends on what byte the heap left in that slot, which I can't observe without flashing. On a reused/dirty heap block it's nonzero and fires; on a fresh-zeroed one it doesn't. The fix is correct either way, and the `sizeof`/`COUNT_OF` check is simply wrong regardless. On device this only touches allocation-time init and a bounds constant, so IR read/learn/send for NEC/RC5/RC6/Samsung/etc. should behave exactly as before.

# Author checklist (Fill this out)

- [x] I've read the contribution guidelines and my PR follows them.
- [x] I own the code I'm submitting or have code owner's permission (or code license allows redistribution) to submit it.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).

I used an AI assistant to compile `infrared_common_decoder.c` standalone (outside this repo) with a synthetic RC5-like spec and confirm that `timings_cnt` is uninitialized after alloc and that ASan catches the resulting out-of-bounds access when reset runs the same way `infrared_alloc_decoder()` calls it. The two-line fix is hand-written.
