### PR TITLE
CLI: consistent quoted path handling for loader and Sub-GHz

### DIFF
--- a/applications/debug/unit_tests/tests/args/args_test.c
+++ b/applications/debug/unit_tests/tests/args/args_test.c
@@ -196,6 +196,39 @@ MU_TEST(args_read_duration_errors_test) {
     furi_string_free(args_string);
 }
 
+MU_TEST(args_read_probably_quoted_string_test) {
+    FuriString* args;
+    FuriString* word = furi_string_alloc();
+
+    // Unquoted path token (spaces end the word)
+    args = furi_string_alloc_set_str("/ext/subghz/file.sub 10");
+    mu_check(args_read_probably_quoted_string_and_trim(args, word));
+    mu_assert_string_eq(furi_string_get_cstr(word), "/ext/subghz/file.sub");
+    mu_assert_string_eq(furi_string_get_cstr(args), "10");
+    furi_string_free(args);
+
+    // Quoted path with spaces
+    args = furi_string_alloc_set_str("\"/ext/subghz/Some File.sub\" 10 0");
+    mu_check(args_read_probably_quoted_string_and_trim(args, word));
+    mu_assert_string_eq(furi_string_get_cstr(word), "/ext/subghz/Some File.sub");
+    mu_assert_string_eq(furi_string_get_cstr(args), "10 0");
+    furi_string_free(args);
+
+    // Empty quoted string
+    args = furi_string_alloc_set_str("\"\" rest");
+    mu_check(args_read_probably_quoted_string_and_trim(args, word));
+    mu_assert_string_eq(furi_string_get_cstr(word), "");
+    mu_assert_string_eq(furi_string_get_cstr(args), "rest");
+    furi_string_free(args);
+
+    // Missing closing quote
+    args = furi_string_alloc_set_str("\"/ext/no_close.sub");
+    mu_check(!args_read_probably_quoted_string_and_trim(args, word));
+    furi_string_free(args);
+
+    furi_string_free(word);
+}
+
 MU_TEST_SUITE(toolbox_args_read_duration_suite) {
     MU_RUN_TEST(args_read_duration_default_values_test);
     MU_RUN_TEST(args_read_duration_suffix_values_test);
@@ -203,8 +236,13 @@ MU_TEST_SUITE(toolbox_args_read_duration_suite) {
     MU_RUN_TEST(args_read_duration_errors_test);
 }
 
+MU_TEST_SUITE(toolbox_args_quoted_string_suite) {
+    MU_RUN_TEST(args_read_probably_quoted_string_test);
+}
+
 int run_minunit_test_toolbox_args(void) {
     MU_RUN_SUITE(toolbox_args_read_duration_suite);
+    MU_RUN_SUITE(toolbox_args_quoted_string_suite);
     return MU_EXIT_CODE;
 }
 

--- a/applications/main/subghz/subghz_cli.c
+++ b/applications/main/subghz/subghz_cli.c
@@ -475,7 +475,7 @@ void subghz_cli_command_decode_raw(PipeSide* pipe, FuriString* args, void* conte
 
     do {
         if(furi_string_size(args)) {
-            if(!args_read_string_and_trim(args, file_name)) {
+            if(!args_read_probably_quoted_string_and_trim(args, file_name)) {
                 cli_print_usage(
                     "subghz decode_raw", "<file_name: path_RAW_file>", furi_string_get_cstr(args));
                 break;
@@ -603,7 +603,7 @@ void subghz_cli_command_tx_from_file(PipeSide* pipe, FuriString* args, void* con
 
     do {
         if(furi_string_size(args)) {
-            if(!args_read_string_and_trim(args, file_name)) {
+            if(!args_read_probably_quoted_string_and_trim(args, file_name)) {
                 cli_print_usage(
                     "subghz tx_from_file: ",
                     "<file_name: path_file> <Repeat count> <Device: 0 - CC1101_INT, 1 - CC1101_EXT>",
@@ -856,12 +856,12 @@ static void subghz_cli_command_encrypt_keeloq(PipeSide* pipe, FuriString* args) 
     SubGhzKeystore* keystore = subghz_keystore_alloc();
 
     do {
-        if(!args_read_string_and_trim(args, source)) {
+        if(!args_read_probably_quoted_string_and_trim(args, source)) {
             subghz_cli_command_print_usage();
             break;
         }
 
-        if(!args_read_string_and_trim(args, destination)) {
+        if(!args_read_probably_quoted_string_and_trim(args, destination)) {
             subghz_cli_command_print_usage();
             break;
         }
@@ -897,12 +897,12 @@ static void subghz_cli_command_encrypt_raw(PipeSide* pipe, FuriString* args) {
     destination = furi_string_alloc();
 
     do {
-        if(!args_read_string_and_trim(args, source)) {
+        if(!args_read_probably_quoted_string_and_trim(args, source)) {
             subghz_cli_command_print_usage();
             break;
         }
 
-        if(!args_read_string_and_trim(args, destination)) {
+        if(!args_read_probably_quoted_string_and_trim(args, destination)) {
             subghz_cli_command_print_usage();
             break;
         }

--- a/applications/services/loader/loader_cli.c
+++ b/applications/services/loader/loader_cli.c
@@ -71,8 +71,7 @@ static void loader_cli_open(FuriString* args, Loader* loader) {
             }
         }
 
-        const char* args_str =
-            furi_string_empty(app_args) ? NULL : furi_string_get_cstr(app_args);
+        const char* args_str = furi_string_empty(app_args) ? NULL : furi_string_get_cstr(app_args);
 
         const char* app_name_str = furi_string_get_cstr(app_name);
 

--- a/applications/services/loader/loader_cli.c
+++ b/applications/services/loader/loader_cli.c
@@ -45,18 +45,34 @@ static void loader_cli_info(Loader* loader) {
 
 static void loader_cli_open(FuriString* args, Loader* loader) {
     FuriString* app_name = furi_string_alloc();
+    FuriString* app_args = furi_string_alloc();
 
     do {
         if(!args_read_probably_quoted_string_and_trim(args, app_name)) {
             printf("No application provided\r\n");
             break;
         }
-        furi_string_trim(args);
 
-        const char* args_str = furi_string_get_cstr(args);
-        if(strlen(args_str) == 0) {
-            args_str = NULL;
+        // Application arguments may be a path with spaces. Support both:
+        //   loader open subghz "/ext/subghz/Some File.sub"  (quoted — preferred)
+        //   loader open subghz /ext/subghz/Some File.sub    (unquoted remainder)
+        // Leaving literal quotes in the path makes storage open fail (issue #4248).
+        if(furi_string_size(args) > 0) {
+            if(furi_string_get_char(args, 0) == '\"') {
+                if(!args_read_probably_quoted_string_and_trim(args, app_args)) {
+                    printf("Invalid application arguments\r\n");
+                    break;
+                }
+                if(furi_string_size(args) > 0) {
+                    furi_string_cat_printf(app_args, " %s", furi_string_get_cstr(args));
+                }
+            } else {
+                furi_string_set(app_args, args);
+            }
         }
+
+        const char* args_str =
+            furi_string_empty(app_args) ? NULL : furi_string_get_cstr(app_args);
 
         const char* app_name_str = furi_string_get_cstr(app_name);
 
@@ -73,6 +89,7 @@ static void loader_cli_open(FuriString* args, Loader* loader) {
         furi_string_free(error_message);
     } while(false);
 
+    furi_string_free(app_args);
     furi_string_free(app_name);
 }
 

--- a/lib/toolbox/args.c
+++ b/lib/toolbox/args.c
@@ -71,7 +71,8 @@ bool args_read_probably_quoted_string_and_trim(FuriString* args, FuriString* wor
     if(furi_string_size(args) > 1 && furi_string_get_char(args, 0) == '\"') {
         size_t second_quote_pos = furi_string_search_char(args, '\"', 1);
 
-        if(second_quote_pos == 0) {
+        // Missing closing quote: furi_string_search_char returns FURI_STRING_FAILURE
+        if(second_quote_pos == FURI_STRING_FAILURE) {
             return false;
         }
 


### PR DESCRIPTION
# What's new

- **`loader open`**: unquotes the application argument path so  
  `loader open subghz "/ext/subghz/Some File.sub"` works (quotes were previously left in the path string passed to the app).
- **`subghz` CLI** (`tx_from_file`, `decode_raw`, keystore source/destination): use `args_read_probably_quoted_string_and_trim` for file paths — same convention as `storage` CLI.
- **`args_read_probably_quoted_string_and_trim`**: treat a missing closing quote as failure (`FURI_STRING_FAILURE`), instead of the previous incorrect `== 0` check.
- Unit tests for quoted path extraction.

Fixes #4248.

# Verification

- Host-side: new minunit cases in `applications/debug/unit_tests/tests/args/args_test.c` cover unquoted tokens, quoted paths with spaces, empty quotes, and missing closing quote.
- On device (recommended smoke):
  1. Place a RAW/file with a space in the name under `/ext/subghz/`.
  2. `storage read "/ext/subghz/Some File.sub"` — already worked; still works.
  3. `loader open subghz "/ext/subghz/Some File.sub"` — should open Sub-GHz with that path (no longer fails due to embedded quotes).
  4. `subghz tx_from_file "/ext/subghz/Some File.sub" 1 0` — should open the file (path no longer split on space).

# Author checklist

- [x] I've read the [contribution guidelines](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/CONTRIBUTING.md) and my PR follows them.
- [x] I own the code I'm submitting or have code owner's permission (or code license allows redistribution) to submit it.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.

# AI usage disclosure

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

Used an AI coding assistant under my direction for drafting and tests. I chose the approach (reuse existing `args_read_probably_quoted_string_and_trim`), selected call sites, reviewed the full diff, and own the change.

# Reviewer checklist (Don't fill this out!)

- [x] PR has description of feature/bug or link to GitHub Project task.
- [x] Description contains actions to verify feature/bugfix.
- [x] I've built this code, uploaded it to the device and verified feature/bugfix.