### PR TITLE
NFC DESFire: Fix crash when reading card with a zero-key application

### DIFF
--- a/lib/nfc/protocols/mf_desfire/mf_desfire.c
+++ b/lib/nfc/protocols/mf_desfire/mf_desfire.c
@@ -2,6 +2,8 @@
 
 #include <furi.h>
 
+#define TAG "MfDesfire"
+
 #define MF_DESFIRE_PROTOCOL_NAME "Mifare DESFire"
 
 #define MF_DESFIRE_HW_MINOR_TYPE          (0x00)
@@ -135,7 +137,13 @@ bool mf_desfire_load(MfDesfireData* data, FlipperFormat* ff, uint32_t version) {
             break;
 
         const uint32_t master_key_version_count = data->master_key_settings.max_keys;
-        simple_array_init(data->master_key_versions, master_key_version_count);
+        // A card may report zero keys, in which case nothing was saved and the
+        // array stays empty - same as the per-application path does on load
+        if(master_key_version_count) {
+            simple_array_init(data->master_key_versions, master_key_version_count);
+        } else {
+            FURI_LOG_W(TAG, "PICC reports zero master keys, key versions skipped");
+        }
 
         uint32_t i;
         for(i = 0; i < master_key_version_count; ++i) {

--- a/lib/nfc/protocols/mf_desfire/mf_desfire_poller_i.c
+++ b/lib/nfc/protocols/mf_desfire/mf_desfire_poller_i.c
@@ -188,6 +188,9 @@ MfDesfireError mf_desfire_poller_read_key_versions(
 
     if(count > 0) {
         simple_array_init(data, count);
+    } else {
+        // Legitimate: max_keys comes straight off the card and may be zero
+        FURI_LOG_W(TAG, "Application reports zero keys, key versions skipped");
     }
 
     MfDesfireError error = MfDesfireErrorNone;

--- a/lib/nfc/protocols/mf_desfire/mf_desfire_poller_i.c
+++ b/lib/nfc/protocols/mf_desfire/mf_desfire_poller_i.c
@@ -185,9 +185,10 @@ MfDesfireError mf_desfire_poller_read_key_versions(
     SimpleArray* data,
     uint32_t count) {
     furi_check(instance);
-    furi_check(count > 0);
 
-    simple_array_init(data, count);
+    if(count > 0) {
+        simple_array_init(data, count);
+    }
 
     MfDesfireError error = MfDesfireErrorNone;
 


### PR DESCRIPTION
# What's new

Fixes #3835.

`mf_desfire_poller_read_key_versions()` starts with `furi_check(count > 0)`, so reading any DESFire card containing an application whose key settings report zero keys crashes the whole firmware instead of completing the read.

The removed `furi_check()` is the one in the backtrace in https://github.com/flipperdevices/flipperzero-firmware/issues/3835#issuecomment-2287460035 .

The zero-key case is legitimate per the card, and the poller already treats the analogous cases as valid: `mf_desfire_poller_read_application_ids()` and `mf_desfire_poller_read_file_ids()` in the same file both skip `simple_array_init()` when their count is zero rather than crashing.

`simple_array_init()` itself requires count > 0, so this PR replaces the `furi_check()` with the same guard the sibling functions use. The key-version loop then runs zero times and the function returns `MfDesfireErrorNone`, so the application is reported with an empty key version list and the rest of the card parses normally.

Skipping init is safe: the allocator zero-fills, so an uninitialized `SimpleArray` has `data == NULL` / `count == 0`, which `simple_array_free()` handles as an empty array. Making `simple_array` accept count == 0 directly would be the deeper fix, but that changes a toolbox invariant with call sites across every NFC protocol, so this PR deliberately follows the existing local pattern instead.

# Verification 

Tested on a real Disney DESFire Card similar to the one in https://github.com/flipperdevices/flipperzero-firmware/issues/3835#issuecomment-2283004787 / https://github.com/flipperdevices/flipperzero-firmware/issues/3835#issuecomment-2287460035 . My card is EV3 but the applications look the same.

<details><summary>Proxmark3 dump of my card</summary>
<p>

```
[usb] pm3 --> hf 14a info

[=] ---------- ISO14443-A Information ----------
[+]  UID: 04 xx xx xx xx xx xx   ( double )
[+] ATQA: 03 44
[+]  SAK: 20 [1]
[+]       NXP Semiconductors Germany
[+] Possible types:
[+]    MIFARE DESFire EV3 
[=] -------------------------- ATS ----------------------------------
[+] ATS: 06 75 77 81 02 80 [ 02 F0 ]
[=]      06...............  TL    length is 6 bytes
[=]      ...75............  T0    TA1 is present, TB1 is present, TC1 is present, FSCI is 5 (FSC = 64)
[=]      ......77.........  TA1   different divisors are supported, DR: [2, 4, 8], DS: [2, 4, 8]
[=]      .........81......  TB1   SFGI = 1 (SFGT = 8192/fc), FWI = 8 (FWT = 1048576/fc)
[=]      ............02...  TC1   NAD is NOT supported, CID is supported

[=] -------------------- Historical bytes ---------------------------
[+] 80  (compact TLV data object)

[?] Hint: Try `hf mfdes info`

[usb] pm3 --> hf mfdes info

[=] ---------------------------------- Tag Information ----------------------------------
[+]               UID: 04 xx xx xx xx xx xx
[+]      Batch number: 21 20 71 30 30 
[+]   Production date: week 83 / 2025
[+]      Product type: MIFARE DESFire native IC (physical card)

[=] --- Hardware Information
[=]    raw: 04010133001605
[=]      Vendor Id: NXP Semiconductors Germany
[=]           Type: 0x01 ( DESFire )
[=]        Subtype: 0x01
[=]        Version: 33.0 ( DESFire EV3 )
[=]   Storage size: 0x16 ( 2048 bytes )
[=]       Protocol: 0x05 ( ISO 14443-2, 14443-3 )

[=] --- Software Information
[=]    raw: 04010103001605
[=]      Vendor Id: NXP Semiconductors Germany
[=]           Type: 0x01 ( DESFire )
[=]        Subtype: 0x01
[=]        Version: 3.0
[=]   Storage size: 0x16 ( 2048 bytes )
[=]       Protocol: 0x05 ( ISO 14443-3, 14443-4 )

[=] --------------------------------- Card capabilities ---------------------------------
[=]     3.0 - DESFire Ev3, Originality check, proximity check, badass EAL6

[=] --- Tag Signature
[=]  IC signature public key name: DESFire EV3
[=] IC signature public key value: 041DB46C145D0A36539C6544BD6D9B0A
[=]                              : A62FF91EC48CBC6ABAE36E0089A46F0D
[=]                              : 08C8A715EA40A63313B92E90DDC17302
[=]                              : 30E0458A33276FB743
[=]     Elliptic curve parameters: secp224r1
[=]              TAG IC Signature: [...]
[+]        Signature verification: successful

[+] --- AID list ( 3 found )
[+] F70090,   
[+] 78E127, Disney MagicBand [Disney]
[+] 4C4344,   

[+] ------------------------------------ PICC level -------------------------------------
[+] # applications....... 3
[+]
[+] PICC level auth commands
[+]    Auth.............. NO
[+]    Auth ISO.......... NO
[+]    Auth AES.......... YES
[+]    Auth Ev2.......... YES
[+]    Auth ISO Native... YES
[+]    Auth LRP.......... NO
[+] PICC level rights
[+] [1...] CMK Configuration changeable               : YES
[+] [.0..] CMK required for create/delete             : YES
[+] [..1.] CMK required for AID list / GetKeySettings : NO
[+] [...1] CMK is changeable                          : YES
[+]
[+] Key type... AES
[+] Key cnt.... 1
[+] PICC key 0 version: 254 (0xfe)

[=] --- Free memory
[+]    Available free memory on card... 1856 bytes

[=] Standalone DESFire
[usb] pm3 --> 

[usb] pm3 --> hf mfdes lsapp --no-auth
[=] It may take up to 15 seconds. Processing...

[+] ------------------------------------ PICC level -------------------------------------
[+] # applications....... 3
[+]
[+] PICC level auth commands
[+]    Auth.............. NO
[+]    Auth ISO.......... NO
[+]    Auth AES.......... YES
[+]    Auth Ev2.......... YES
[+]    Auth ISO Native... YES
[+]    Auth LRP.......... NO
[+] PICC level rights
[+] [1...] CMK Configuration changeable               : YES
[+] [.0..] CMK required for create/delete             : YES
[+] [..1.] CMK required for AID list / GetKeySettings : NO
[+] [...1] CMK is changeable                          : YES
[+]
[+] Key type... AES
[+] Key cnt.... 1
[+] PICC key 0 version: 254 (0xfe)

[+] --------------------------------- Applications list ---------------------------------
[+] Application ID....... 0xF70090
[+]    ISO id............ 0x0000
[+]    DF name...........  ( 00000000000000000000000000000000 )
[+]   AID mapped to MIFARE Classic AID (MAD): 7009
[+]    MAD AID Cluster  0x70..... Hotel
[=]    MAD AID Function 0x7009...  Access control data for electronic locks [Timelox AB]
[+] Auth commands
[+]    Auth.............. NO
[+]    Auth ISO.......... NO
[+]    Auth AES.......... YES
[+]    Auth Ev2.......... YES
[+]    Auth ISO Native... YES
[+]    Auth LRP.......... NO
[+]
[+] Application level rights
[+]  - AMK authentication is necessary to change any key (default)
[+] [1...] AMK Configuration changeable               : YES
[+] [.0..] AMK required for create/delete             : YES
[+] [..1.] AMK required for FID list / GetKeySettings : NO
[+] [...1] AMK is changeable                          : YES
[+]
[+] Key type... AES
[+] Key cnt.... 3
[+] Key versions [0..2]  00, 00, 00

[+] Application ID....... 0x78E127
[+]    ISO id............ 0x0000
[+]    DF name...........  ( 00000000000000000000000000000000 )
[=]   DF AID Function... 78E127  : Disney MagicBand [Disney]
[+] Auth commands
[+]    Auth.............. NO
[+]    Auth ISO.......... NO
[+]    Auth AES.......... YES
[+]    Auth Ev2.......... YES
[+]    Auth ISO Native... YES
[+]    Auth LRP.......... NO
[+]
[+] Application level rights
[+]  - AMK authentication is necessary to change any key (default)
[+] [1...] AMK Configuration changeable               : YES
[+] [.0..] AMK required for create/delete             : YES
[+] [..1.] AMK required for FID list / GetKeySettings : NO
[+] [...1] AMK is changeable                          : YES
[+]
[+] Key type... AES
[+] Key cnt.... 2
[+] Key versions [0..1]  01, 01

[+] Application ID....... 0x4C4344
[+]    ISO id............ 0x0000
[+]    DF name...........  ( 00000000000000000000000000000000 )
[=]   DF AID Function... 4C4344  : (unknown)
[+] Auth commands
[+]    Auth.............. NO
[+]    Auth ISO.......... NO
[+]    Auth AES.......... NO
[+]    Auth Ev2.......... NO
[+]    Auth ISO Native... YES
[+]    Auth LRP.......... NO
[+]
[usb] pm3 --> 
```

</p>
</details>

On current `dev`:
  NFC -> Read -> the read crashes with `furi_check` in `mf_desfire_poller_read_key_versions()` (the crash in #3835).

With this fix, built and flashed to the same Flipper Zero:
   The same card reads successfully. The zero-key application shows `Max Keys: 00` and everything looks normal.

The card's other two applications have 2–3 AES keys and continue to parse correctly on the same read, so the normal keyed path is still working normally.

`./fbt format` is clean.

# Author checklist (Fill this out)

- [x] I've read the [contribution guidelines](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/CONTRIBUTING.md) and my PR follows them.
- [x] I own the code I'm submitting or have code owner's permission (or code license allows redistribution) to submit it.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
     (No comment was necessary.)

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

Debugging and code fix were entirely human. AI performed initial code review and sanity check and helped write this description.

# Reviewer checklist (Don't fill this out!)

- [x] PR has description of feature/bug or link to GitHub Project task.
- [x] Description contains actions to verify feature/bugfix.
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix.
