### PR TITLE
furi_hal_rfid: LF capture reports every duration short by one interrupt latency

### DIFF
--- a/targets/f7/furi_hal/furi_hal_rfid.c
+++ b/targets/f7/furi_hal/furi_hal_rfid.c
@@ -238,6 +238,12 @@ static void furi_hal_rfid_tim_emulate(void) {
     LL_TIM_GenerateEvent_UPDATE(FURI_HAL_RFID_EMULATE_TIMER);
 }
 
+// counter value latched at the last rising edge, written only by the capture ISR
+static uint32_t furi_hal_rfid_capture_origin = 0;
+
+// Counter free-runs; consecutive captures are differenced. Zeroing it here happened one interrupt
+// latency after the edge, so every reported duration read short by it. uint32_t wraparound is
+// self-correcting. CC3 (falling) must precede CC4 (rising) so a high width uses its own cycle's origin.
 static void furi_hal_capture_dma_isr(void* context) {
     UNUSED(context);
 
@@ -245,15 +251,18 @@ static void furi_hal_capture_dma_isr(void* context) {
     if(LL_TIM_IsActiveFlag_CC3(RFID_CAPTURE_TIM)) {
         LL_TIM_ClearFlag_CC3(RFID_CAPTURE_TIM);
         furi_hal_rfid->read_capture_callback(
-            true, LL_TIM_IC_GetCaptureCH3(RFID_CAPTURE_TIM), furi_hal_rfid->context);
+            true,
+            LL_TIM_IC_GetCaptureCH3(RFID_CAPTURE_TIM) - furi_hal_rfid_capture_origin,
+            furi_hal_rfid->context);
     }
 
     // Channel 4, overall level
     if(LL_TIM_IsActiveFlag_CC4(RFID_CAPTURE_TIM)) {
         LL_TIM_ClearFlag_CC4(RFID_CAPTURE_TIM);
-        LL_TIM_SetCounter(RFID_CAPTURE_TIM, 0);
-        furi_hal_rfid->read_capture_callback(
-            false, LL_TIM_IC_GetCaptureCH4(RFID_CAPTURE_TIM), furi_hal_rfid->context);
+        const uint32_t rise = LL_TIM_IC_GetCaptureCH4(RFID_CAPTURE_TIM);
+        const uint32_t period = rise - furi_hal_rfid_capture_origin;
+        furi_hal_rfid_capture_origin = rise;
+        furi_hal_rfid->read_capture_callback(false, period, furi_hal_rfid->context);
     }
 }
 
@@ -303,6 +312,8 @@ void furi_hal_rfid_tim_read_capture_start(FuriHalRfidReadCaptureCallback callbac
     LL_TIM_CC_EnableChannel(RFID_CAPTURE_TIM, RFID_CAPTURE_IND_CH);
     LL_TIM_CC_EnableChannel(RFID_CAPTURE_TIM, RFID_CAPTURE_DIR_CH);
     LL_TIM_SetCounter(RFID_CAPTURE_TIM, 0);
+    // must precede EnableCounter, and hence any interrupt
+    furi_hal_rfid_capture_origin = 0;
     LL_TIM_EnableCounter(RFID_CAPTURE_TIM);
 
     furi_hal_rfid_comp_start();


### PR DESCRIPTION
# What's new

This fixes a small systematic bias in every LF capture duration. The capture channels latch edge instants in hardware but the counter has no hardware zero, so the origin is written by software inside the capture ISR. That write happens at `edge + L`, where `L` is the interrupt latency, while `CCR4` was latched *at* the edge. Every duration reported to `read_capture_callback` is therefore short by `L`.

`L` is a bias, not noise, as it has the same sign every cycle. Protocol decoders quantise each duration independently and round it away, which is why this has gone unnoticed. A consumer that integrates durations onto an absolute time axis accumulates it linearly. (I am building one such consumer, for which this bug has a measurable impact, but there are none currently shipped that I know of.)

The fix lets the counter free-run and takes the difference between consecutive `CCR4` latches, which is exact and carries no latency. **Reported values keep their existing meaning** (`true` = HIGH width, `false` = rising-to-rising period), so no consumer changes and there is no API change.

One file, +15/−4. The sections below give the mechanism, the measurement, and the alternative I considered.

## What happens

The LF capture uses TIM2 CH4 (rising) and CH3 (falling) input capture, so both edge *instants* are latched by hardware. But the counter has no hardware zero. Slave-mode reset is disabled and the trigger input is `TI2FP2`, which is not the capture channel:

```c
LL_TIM_SetTriggerInput(RFID_CAPTURE_TIM, LL_TIM_TS_TI2FP2);      // :279
LL_TIM_SetSlaveMode(RFID_CAPTURE_TIM, LL_TIM_SLAVEMODE_DISABLED); // :280
```

The origin is instead written by software, inside the capture ISR:

```c
if(LL_TIM_IsActiveFlag_CC4(RFID_CAPTURE_TIM)) {
    LL_TIM_ClearFlag_CC4(RFID_CAPTURE_TIM);
    LL_TIM_SetCounter(RFID_CAPTURE_TIM, 0);   // :254 (runs at edge + L, not at the edge)
    furi_hal_rfid->read_capture_callback(
        false, LL_TIM_IC_GetCaptureCH4(RFID_CAPTURE_TIM), furi_hal_rfid->context);
}
```

`CCR4` was latched *at* the edge, but the counter is zeroed `L` later, where `L` is the interrupt latency. So the value delivered to the callback is `period − L`. Same for `CCR3` (HIGH). The derived LOW (`period − high`) is exact, because `L` cancels.

## Why it is worth fixing even though nothing visibly breaks

**Two classes of consumer see `L` differently:**

- A consumer that **quantises each duration independently** rounds it away. Every protocol decoder in the tree does this, which is why this has gone unnoticed.
- A consumer that **integrates durations onto an absolute time axis** accumulates it linearly.

Measured on my own LF work (a T5577 deep-read that reads 32-bit words at absolute half-bit positions): **`L` = 1.46 µs, spread 0.05 µs across 105 captures.** Drift accumulates as `periods × L`, and a 72-half-bit frame at RF/32 holds 26.1 periods at the corpus mean rising to 31.5 at its densest content, so **~38 µs typical and ~46 µs worst case, against a 64 µs sampling budget.** On device, an independent readout of the same quantity gave **43–47 µs across 36 samples** of mixed-content words, and the per-block model then predicted the deliberately written worst cases to within 1–2 µs (all-zeros 47–51 µs, all-ones 46–49).

**The harm is measurable, but it is margin rather than breakage.**

- At worst-case content the bias spends **~46 µs of a 64 µs budget**, roughly three quarters of it, before the decoder starts.
- I measured where the remaining margin runs out. Injecting further bias into the same captures, my T5577 decoder (not yet released) begins returning **wrong answers that all ten of its independent checks agree on** at about **2 µs more** than the shipped value. Ten observations are not independent when the error is systematic: they all shift together and concur on the same wrong word.
- So the shipped configuration sits about **1 µs of extra interrupt latency from losing most of its reads, and about 2 µs from silent corruption** — in the one direction that has no margin, and interrupt latency is not a controlled quantity.

⚠ **What I am NOT claiming: I have not observed this produce a wrong answer in shipped firmware.** The case is that the margin is nearly all spent, not that something is broken today.

What it did cost me in practice was a day of debugging when an unrelated diagnostic added ~1 µs to the ISR path and a decoder with 16 µs of margin left stopped working entirely. A 4/10 read rate dropped to 0/10 from a change that touched no decoding logic at all, while block reads — which quantise — stayed at 4/10.

## The fix

Stop writing the origin in software, let the counter free-run and take differences between consecutive latches. `CCR4` already holds the exact instant of the rising edge, so the difference is exact and carries no latency.

- `uint32_t` arithmetic makes wraparound self-correcting; at the timer's 1 MHz a 32-bit counter wraps every ~71 minutes against captures measured in hundreds of milliseconds.
- Reported values keep their existing meaning (`true` = HIGH width, `false` = rising-to-rising period), so **no consumer needs changing** and there is no API change.
- CC3 is already handled before CC4, so a HIGH width is measured against the origin of the cycle it belongs to even when both flags are found pending in one entry.

An alternative is to point the trigger input at TI4 and enable slave-mode reset, so the counter is zeroed by silicon. That is less code but changes peripheral configuration; the arithmetic version changes only how the ISR interprets what the hardware already captured. Either is defensible and I implemented the second.

# Verification

## How to verify this yourself

**1. By reading, no hardware needed.** `CCR3`/`CCR4` are latched by the capture hardware at the edge. The only zero was `LL_TIM_SetCounter(RFID_CAPTURE_TIM, 0)` inside the ISR, which necessarily runs after it. That is the whole bug. The patch replaces it with a subtraction.

**2. Confirm it does no harm, using any LF tag.** Read a card on `dev`, note the decode. Apply the patch, read the same card at the same position. The decode is identical. Any protocol works, every decoder in the tree quantises each duration independently, so none should shift.

**3. Measure the latency change directly.** `rfid raw_read ask /ext/x.raw` then `rfid raw_analyze /ext/x.raw` — both existing commands — write the HAL's reported durations to a file and print them back. Same tag, untouched throughout; 40 captures per phase, ~2800 duration pairs each. The harness I used, and the raw duration pairs it produced, are in the [verification branch](https://github.com/mfcarroll/flipperzero-firmware/tree/hal-capture-exact-period-verification/lfrfid_capture_verification) — `--compare` on the archived pairs reproduces the table below with no hardware at all.

⚠ Run the baseline **twice, bracketing the patched build** (baseline → patched → baseline). The same-build repeat is what makes this interpretable: between two measurements of *identical firmware* 25 minutes apart, the reported HIGH width drifted 0.5 µs and the derived LOW drifted 0.6 µs. That is the analogue front end, not the firmware, and it is larger than the effect's own error bar, so a single before/after pair will mislead you. Bracketing cancels it.

| | baseline (2 phases) | patched | shift |
|---|---|---|---|
| reported period | 509.571 | 511.359 | **+1.788 µs** |
| reported HIGH | 273.044 | 274.760 | **+1.716 µs** |
| derived LOW — *control* | 236.023 | 236.110 | **+0.087 µs** |

Both reported durations rise by the same amount, `L`, and that is the whole claim. **The LOW is the control**: `L` cancels in `period − high`, so it must not move, and it does not. The two shifts agree with each other to 0.07 µs, which is that same residual. An independent replication on a later build put the same control at **−0.041 µs** — the opposite sign, which a real effect cannot do, and which is what retires that residual as noise rather than as a small asymmetry between the two channels.

⚠ Each row is the mean of its own dominant value cluster, taken over a slightly different number of pairs (3360 period, 3921 HIGH, 4001 LOW), and LOW is derived per pair before clustering — so the columns do not subtract exactly.

⚠ Two more things if you repeat it. `raw_read` returns a fixed ~71 pairs per capture whatever duration you give it, and the *overall* mean period swings ±1.4 µs depending on where in the tag's bit pattern the capture began, so take the mean of the dominant value **cluster** instead. And `L` is build-specific: ~1.75 µs here, against 1.46 µs measured separately on another tree by a different method. Figures above are from a release build with the HAL file byte-identical to this one.

## What I already ran

Submitting against **`dev`**; the OFW baseline arm below was built from `a55e3939`, which is `dev` at the time of writing. `./fbt format` produces no changes; both `./fbt` and `COMPACT=1 DEBUG=0` build clean.

**Two separate questions**, *does it do what it claims*, and *does it cost anything*:

**1. Does it work?** On the T5577 absolute-time path (my fork, where an integrating consumer exists) the drift readout goes from 43–47 µs to **exactly 0**, and the cross-check headroom from 13–17 µs to the full 64 µs budget. Exactly 0 is the expected result rather than a suspiciously clean one: the tag's data rate divides down from the Flipper's own 125 kHz carrier, and both that carrier and the capture timer derive from the same 64 MHz clock (`Autoreload = SystemCoreClock/freq − 1` = 511 ⇒ exactly 125000).

**2. Does it harm anything?** Because of the low-level nature of the reading, and it being what every other LF decoder rests on, I wanted to be certain that no tag types would be affected, and ran a test suite across each supported tag type on three firmware trees, since a few of the decoders differ, including in ways that could have plausibly been impacted by the correction. Three independently maintained decoder sets is also free evidence for a change this low in the stack, and it answers in advance what I assume is the first question downstream maintainers will ask if this lands — "does it affect the changes we've made to LF decoders that are different to OFW". Here is the LF protocol matrix, before and after, on all three firmware trees.

| tree | build | baseline | with the patch | protocols | result |
|---|---|---|---|---|---|
| **OFW** | debug | `a55e3939` | `57ff3e96` | **24 of 24** | **all identical** |
| Momentum | release | `63c28280` | `2e876de7` | **26 of 26** | **all identical** |
| Unleashed | release, `unlshd-092` | `3c9be0fd` | `c29e5c32` | 6 targeted | **all identical** |

Zero decoders returned a different answer anywhere. Method, per protocol per build: the tag is written by a Proxmark, **verified by the Proxmark in place immediately before the Flipper reads it**, then read up to 10 times at a recorded air gap. Every row is checked for the **right card**, not merely for a recognised protocol name: 19 of 26 against the value I asked the Proxmark to write, 4 against the Proxmark's own reader agreeing with the Flipper, and 3 against a block recipe the Flipper itself produced — encoder and decoder, so a symmetric bug there would be invisible. The auditor in the verification branch re-derives that breakdown from the raw text alone and prints the weaker rows rather than hiding them.

Coverage spans all four demodulator families (ASK/Manchester, FSK, PSK and biphase), clocks from RF/16 to RF/64, and frame lengths from 32 to 224 bits. Cross-check: all 24 protocols shared between OFW and Momentum decode **byte-identically on both trees**, which tests my harness as much as your firmware.

**Unleashed was targeted rather than exhaustive, on a file-level basis:** `furi_hal_rfid.c` and `lfrfid_cli.c` are byte-identical to OFW's, `lfrfid_worker.c` differs only on the write path, and every protocol decoder matches OFW's or Momentum's except `protocol_em4100.c` and `protocol_pac_stanley.c`. So the six rows are its unique read code plus `electra`, which EM4100's lookahead exists to disambiguate.

⚠ **This is a correctness and jitter-immunity fix, not a performance fix.** I am not claiming it makes anything read better. The matrix above used varying attempt counts with early stopping, so all it establishes is that every protocol successfully reads on both builds and decodes identically.

Full per-protocol records - the clone command, Proxmark verification, per-attempt decode, air gap, firmware commit and raw CLI text - and both test harnesses are published on a separate branch, [`hal-capture-exact-period-verification`](https://github.com/mfcarroll/flipperzero-firmware/tree/hal-capture-exact-period-verification/lfrfid_capture_verification). Nothing there is proposed for merge or part of the build.

## What I did not test

- **Native protocol chips.** Every tag is a T5577 configured for the protocol, so the waveforms are conformant but all come from one modulator design. A native EM4100 or HID chip could differ in envelope shape, although not, I think, in a way a constant-latency correction interacts with.
- **Atmel-manufactured T5577 silicon.** I have Silicon Craft and Invengo only.
- **Anything with a password set**, and no `lf t55xx` protected-mode paths.

# Author checklist (Fill this out)

- [X] I've read the [contribution guidelines](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/CONTRIBUTING.md) and my PR follows them.
- [X] I own the code I'm submitting or have code owner's permission (or code license allows redistribution) to submit it.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.

# AI usage disclosure (Fill this out):

- [X] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

Claude Code and Gemini were used extensively in the underlying research work that surfaced this bug, and in authoring the fix. Claude was used for an initial draft of this PR and the accompanying commit message, as well as for building the two test harnesses used for tag read verification and latency measurement. All of the submitted code and PR text have been thoroughly human-reviewed and edited.

# Reviewer checklist (Don't fill this out!)

- [x] PR has description of feature/bug or link to GitHub Project task.
- [x] Description contains actions to verify feature/bugfix.
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix.
