### PR TITLE
Fix typo in BT HAL source

### DIFF
--- a/targets/f7/furi_hal/furi_hal_bt.c
+++ b/targets/f7/furi_hal/furi_hal_bt.c
@@ -15,7 +15,7 @@
 
 #include <furi_hal_version.h>
 #include <furi_hal_power.h>
-#include <furi_hal_bus.c>
+#include <furi_hal_bus.h>
 #include <services/battery_service.h>
 #include <furi.h>
 


### PR DESCRIPTION
# What's new
`furi_hal_bt.c` included `furi_hal_bus.c` instead of `furi_hal_bus.h` by mistake. This used to lead to "duplicate definition" linker errors if specific circumstances are met.

# Verification 
- Rename the `furi_hal_bt.c` file in such a way that it comes _after_ `furi_hal_bus.c` alphabetically (e.g. `furi_hal_deadbeef.c`)
- Verify that linking doesn't fail, but does on dev.

# Author checklist (Fill this out)

- [x] I've read the [contribution guidelines](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/CONTRIBUTING.md) and my PR follows them.
- [x] I own the code I'm submitting or have code owner's permission (or code license allows redistribution) to submit it.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

# Reviewer checklist (Don't fill this out!)

- [x] PR has description of feature/bug or link to GitHub Project task.
- [x] Description contains actions to verify feature/bugfix.
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix.